### PR TITLE
fix(store-engine): Use Dexie from window namespace to avoid errors with npm's "setimmediate" package

### DIFF
--- a/packages/store-engine/webpack.config.js
+++ b/packages/store-engine/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     [projectName]: `${__dirname}/${pkg.main}`,
   },
   externals: {
+    dexie: 'Dexie',
     'fs-extra': '{}',
   },
   node: {


### PR DESCRIPTION
…th npm's "setimmediate" package