### PR TITLE
fix(lru-cache): remove parameters for getAll

### DIFF
--- a/packages/lru-cache/src/main/LRUCache.ts
+++ b/packages/lru-cache/src/main/LRUCache.ts
@@ -63,7 +63,7 @@ class LRUCache<T> {
     return undefined;
   }
 
-  public getAll(key: string): {[id: string]: T}[] {
+  public getAll(): {[id: string]: T}[] {
     return Object.keys(this.map).map(id => {
       const node = this.map[id];
       return {

--- a/packages/lru-cache/src/main/LRUCache.ts
+++ b/packages/lru-cache/src/main/LRUCache.ts
@@ -63,7 +63,7 @@ class LRUCache<T> {
     return undefined;
   }
 
-  public getAll(): {[id: string]: T}[] {
+  public getAll(): Array<{[id: string]: T}> {
     return Object.keys(this.map).map(id => {
       const node = this.map[id];
       return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8972,10 +8972,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
-
 typescript@2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"


### PR DESCRIPTION
A function which returns all data, doesn't need parameters.