### PR TITLE
fix(core): Pass empty content in decodeEvent when message text is empty

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -249,7 +249,7 @@ class Account extends EventEmitter {
           this.service.cryptography.decrypt(sessionId, ciphertext).then((decryptedMessage: Uint8Array) => {
             const genericMessage = this.protocolBuffers.GenericMessage.decode(decryptedMessage);
             resolve({
-              content: genericMessage.text.content,
+              content: genericMessage.text && genericMessage.text.content,
               id: genericMessage.messageId,
               type: genericMessage.content,
             });


### PR DESCRIPTION
While this is fixing a short time issue we should clarify where we want to handle, save and map the different OTR message types.