### PR TITLE
fix(api-client): Return complete error

### DIFF
--- a/packages/api-client/src/main/http/HttpClient.ts
+++ b/packages/api-client/src/main/http/HttpClient.ts
@@ -88,14 +88,8 @@ class HttpClient {
     }
 
     return axios.request(config).catch((error: AxiosError) => {
-      if (error.response) {
-        if (error.response.status === 401) {
-          return this.refreshAccessToken().then(() => this._sendRequest(config, tokenAsParam));
-        }
-
-        if (error.response.data) {
-          return Promise.reject(error.response.data);
-        }
+      if (error.response && error.response.status === 401) {
+        return this.refreshAccessToken().then(() => this._sendRequest(config, tokenAsParam));
       }
 
       return Promise.reject(error);


### PR DESCRIPTION
This partly reverts commit [`c3212e2`](https://github.com/wireapp/wire-web-packages/commit/c3212e2567148b48839099c82a785096e1db5bfe#diff-95d5338bd6a14015ed940d49cdf48d16) which introduced a bug in sending messages by not returning the whole error so the `core` couldn't check for missing prekeys.