### PR TITLE
chore: Remove default webpack target

### DIFF
--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="0.10.5"></a>
+
 ## [0.10.5](https://github.com/wireapp/wire-web-packages/tree/master/packages/api-client/compare/@wireapp/api-client@0.10.4...@wireapp/api-client@0.10.5) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/api-client
 

--- a/packages/api-client/webpack.browser.js
+++ b/packages/api-client/webpack.browser.js
@@ -39,5 +39,4 @@ module.exports = {
     path: `${__dirname}/dist`,
   },
   plugins: [new webpack.BannerPlugin(`${pkg.name} v${pkg.version}`)],
-  target: 'web',
 };

--- a/packages/bazinga64/CHANGELOG.md
+++ b/packages/bazinga64/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="5.1.11"></a>
+
 ## [5.1.11](https://github.com/wireapp/wire-web-packages/tree/master/packages/bazinga64/compare/bazinga64@5.1.10...bazinga64@5.1.11) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package bazinga64
 

--- a/packages/cbor/CHANGELOG.md
+++ b/packages/cbor/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="3.0.32"></a>
+
 ## [3.0.32](https://github.com/wireapp/wire-web-packages/tree/master/packages/cbor/compare/@wireapp/cbor@3.0.31...@wireapp/cbor@3.0.32) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/cbor
 

--- a/packages/cli-client/CHANGELOG.md
+++ b/packages/cli-client/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="1.3.117"></a>
+
 ## [1.3.117](https://github.com/wireapp/wire-web-packages/tree/master/packages/cli-client/compare/@wireapp/cli-client@1.3.116...@wireapp/cli-client@1.3.117) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/cli-client
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.8.8"></a>
+
 ## [2.8.8](https://github.com/wireapp/wire-web-packages/tree/master/packages/core/compare/@wireapp/core@2.8.7...@wireapp/core@2.8.8) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/core
 

--- a/packages/cryptobox/CHANGELOG.md
+++ b/packages/cryptobox/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="8.3.58"></a>
+
 ## [8.3.58](https://github.com/wireapp/wire-web-packages/tree/master/packages/cryptobox/compare/@wireapp/cryptobox@8.3.57...@wireapp/cryptobox@8.3.58) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/cryptobox
 

--- a/packages/cryptobox/webpack.config.js
+++ b/packages/cryptobox/webpack.config.js
@@ -49,5 +49,4 @@ module.exports = {
     path: `${__dirname}/dist`,
   },
   plugins: [new webpack.BannerPlugin(`${pkg.name} v${pkg.version}`)],
-  target: 'web',
 };

--- a/packages/lru-cache/CHANGELOG.md
+++ b/packages/lru-cache/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="2.1.11"></a>
+
 ## [2.1.11](https://github.com/wireapp/wire-web-packages/tree/master/packages/lru-cache/compare/@wireapp/lru-cache@2.1.10...@wireapp/lru-cache@2.1.11) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/lru-cache
 

--- a/packages/priority-queue/CHANGELOG.md
+++ b/packages/priority-queue/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="0.1.30"></a>
+
 ## [0.1.30](https://github.com/wireapp/wire-web-packages/tree/master/packages/priority-queue/compare/@wireapp/priority-queue@0.1.29...@wireapp/priority-queue@0.1.30) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/priority-queue
 

--- a/packages/proteus/CHANGELOG.md
+++ b/packages/proteus/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="7.1.44"></a>
+
 ## [7.1.44](https://github.com/wireapp/wire-web-packages/tree/master/packages/proteus/compare/@wireapp/proteus@7.1.43...@wireapp/proteus@7.1.44) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/proteus
 

--- a/packages/react-ui-kit/CHANGELOG.md
+++ b/packages/react-ui-kit/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="1.1.25"></a>
+
 ## [1.1.25](https://github.com/wireapp/wire-web-packages/tree/master/packages/react-ui-kit/compare/@wireapp/react-ui-kit@1.1.24...@wireapp/react-ui-kit@1.1.25) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/react-ui-kit
 

--- a/packages/store-engine/CHANGELOG.md
+++ b/packages/store-engine/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="0.11.15"></a>
+
 ## [0.11.15](https://github.com/wireapp/wire-web-packages/tree/master/packages/store-engine/compare/@wireapp/store-engine@0.11.14...@wireapp/store-engine@0.11.15) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/store-engine
 

--- a/packages/travis-bot/CHANGELOG.md
+++ b/packages/travis-bot/CHANGELOG.md
@@ -1,13 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 <a name="0.1.128"></a>
+
 ## [0.1.128](https://github.com/wireapp/wire-web-packages/tree/master/packages/travis-bot/compare/@wireapp/travis-bot@0.1.127...@wireapp/travis-bot@0.1.128) (2018-05-22)
-
-
-
 
 **Note:** Version bump only for package @wireapp/travis-bot
 


### PR DESCRIPTION
According to the [docs](https://webpack.js.org/configuration/target/) `web` is the default value for `target`.