### PR TITLE
fix(travis-bot): Only read conversation ID if it is provided

### DIFF
--- a/packages/travis-bot/src/main/cli.ts
+++ b/packages/travis-bot/src/main/cli.ts
@@ -112,7 +112,9 @@ switch (process.argv[SECOND_ARGUMENT]) {
     process.exit(0);
   }
   default: {
-    process.env.WIRE_WEBAPP_BOT_CONVERSATION_IDS = process.argv[SECOND_ARGUMENT];
+    if (process.argv[SECOND_ARGUMENT]) {
+      process.env.WIRE_WEBAPP_BOT_CONVERSATION_IDS = process.argv[SECOND_ARGUMENT];
+    }
   }
 }
 


### PR DESCRIPTION
... otherwise the bot would always send `undefined` as conversation ID if it was provided as environment variable and not as CLI argument.