### PR TITLE
fix(core): Don't send external message for ping

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -118,11 +118,7 @@ export default class ConversationService {
       messageId,
     });
 
-    const preKeyBundles = await this.getPreKeyBundles(conversationId);
-    const plainTextBuffer: Buffer = this.protocolBuffers.GenericMessage.encode(ping).finish();
-    const payload: EncryptedAsset = await AssetCryptography.encryptAsset(plainTextBuffer);
-
-    await this.sendExternalGenericMessage(this.clientID, conversationId, payload, <UserPreKeyBundleMap>preKeyBundles);
+    await this.sendGenericMessage(this.clientID, conversationId, ping);
     return messageId;
   }
 


### PR DESCRIPTION
We don't need to upload an asset for sending a ping.