### PR TITLE
refactor(changelog-bot): Use libraries instead of self implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "git add"
     ],
     "*.ts": [
-      "tslint -c tslint.json --fix",
+      "tslint --config tslint.json --project tsconfig.json --fix",
       "git add"
     ],
     "*.{json,md,scss}": [

--- a/packages/changelog-bot/README.md
+++ b/packages/changelog-bot/README.md
@@ -25,24 +25,17 @@ yarn global add @wireapp/changelog-bot
 
 ### Usage
 
-- [cli.ts](./src/main/cli.ts)
-
-### Execution
+Just ask for `--help` to get informed on how to use this bot:
 
 **Bash**
 
 ```bash
-#!/bin/bash
-
-export WIRE_WEBAPP_BOT_EMAIL="<email>"
-export WIRE_WEBAPP_BOT_PASSWORD="<password>"
-
-wire-changelog-bot "<conversation id>,<conversation id>"
+wire-changelog-bot --help
 ```
 
 **Node**
 
 ```bash
 yarn dist
-node dist/cli.js "<conversation id>,<conversation id>"
+node dist/cli.js --help
 ```

--- a/packages/changelog-bot/package.json
+++ b/packages/changelog-bot/package.json
@@ -6,6 +6,8 @@
     "@types/generate-changelog": "1.7.0",
     "@types/node": "10.3.1",
     "@wireapp/core": "2.9.2",
+    "chalk": "2.4.1",
+    "commander": "2.15.1",
     "generate-changelog": "1.7.1"
   },
   "description": "A changelog notification bot.",

--- a/packages/changelog-bot/src/main/cli.ts
+++ b/packages/changelog-bot/src/main/cli.ts
@@ -31,12 +31,14 @@ const logger = logdown('@wireapp/changelog-bot/cli', {
   markdown: false,
 });
 
+logger.state.isEnabled = true;
+
 program
   .version(version)
   .description(description)
+  .option('-c, --conversations <conversationId,...>', 'The conversation IDs to write in')
   .option('-e, --email <address>', 'Your email address')
   .option('-p, --password <password>', 'Your password')
-  .option('-c, --conversations <conversationId,...>', 'The conversation IDs to write in')
   .parse(process.argv);
 
 const TRAVIS_ENV_VARS = ['TRAVIS_COMMIT_RANGE', 'TRAVIS_EVENT_TYPE', 'TRAVIS_REPO_SLUG'];
@@ -47,13 +49,13 @@ const parameters = {
   WIRE_CHANGELOG_BOT_PASSWORD: program.password || process.env.WIRE_CHANGELOG_BOT_PASSWORD,
 };
 
-logger.info(chalk`{bold wire-changelog-bot v${version}}\n`);
+logger.info(chalk`{bold wire-changelog-bot v${version}}`);
 
 TRAVIS_ENV_VARS.forEach(envVar => {
   if (!process.env[envVar]) {
     logger.error(
-      chalk`{bold ('Error:')} Travis environment variable "${envVar}" is not set.\n` +
-        'Read more: https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables'
+      chalk`{bold Error:} Travis environment variable "${envVar}" is not set.` +
+        '\nRead more: https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables'
     );
     process.exit(1);
   }

--- a/packages/changelog-bot/src/main/start.ts
+++ b/packages/changelog-bot/src/main/start.ts
@@ -1,0 +1,28 @@
+import {LoginData} from '@wireapp/api-client/dist/commonjs/auth/';
+import {ChangelogBot, MessageData} from './index';
+
+export async function start(parameters: {[index: string]: string}): Promise<ChangelogBot> {
+  const {WIRE_CHANGELOG_BOT_CONVERSATION_IDS, WIRE_CHANGELOG_BOT_EMAIL, WIRE_CHANGELOG_BOT_PASSWORD} = parameters;
+  const {TRAVIS_COMMIT_RANGE, TRAVIS_REPO_SLUG} = process.env;
+
+  const loginData: LoginData = {
+    email: WIRE_CHANGELOG_BOT_EMAIL,
+    password: WIRE_CHANGELOG_BOT_PASSWORD,
+    persist: false,
+  };
+
+  const changelog = await ChangelogBot.generateChangelog(String(TRAVIS_REPO_SLUG), String(TRAVIS_COMMIT_RANGE));
+
+  const messageData: MessageData = {
+    content: changelog,
+  };
+
+  if (WIRE_CHANGELOG_BOT_CONVERSATION_IDS) {
+    messageData.conversationIds = WIRE_CHANGELOG_BOT_CONVERSATION_IDS.replace(' ', '').split(',');
+  }
+
+  const bot = new ChangelogBot(loginData, messageData);
+  await bot.start();
+
+  return bot;
+}

--- a/packages/changelog-bot/src/main/start.ts
+++ b/packages/changelog-bot/src/main/start.ts
@@ -1,3 +1,22 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
 import {LoginData} from '@wireapp/api-client/dist/commonjs/auth/';
 import {ChangelogBot, MessageData} from './index';
 

--- a/packages/cli-client/README.md
+++ b/packages/cli-client/README.md
@@ -35,5 +35,5 @@ wire-cli -e "$WIRE_LOGIN_EMAIL" -p "$WIRE_LOGIN_PASSWORD" -c "$WIRE_CONVERSATION
 #### Node.js
 
 ```bash
-tsc && node dist/commonjs/index.js -e "yourname@email.com" -p "secret"
+tsc && node dist/commonjs/index.js -e "yourname@email.com" -p "secret" -c "594f0908-b9b7-40f9-a06a-45612145e64e"
 ```

--- a/packages/cli-client/src/main/index.ts
+++ b/packages/cli-client/src/main/index.ts
@@ -1,5 +1,24 @@
 #!/usr/bin/env node
 
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
 const fs = require('fs-extra');
 const program = require('commander');
 const {Account} = require('@wireapp/core');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1926,6 +1926,14 @@ chalk@0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
+chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1935,14 +1943,6 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 change-emitter@^0.1.2:
   version "0.1.6"


### PR DESCRIPTION
**Changes:**

- Replaced custom `setBold` function with `chalk` library
- Replaced `console.log` statements with `logdown`
- Activated logdown statements by default
- Replaced manual parsing of `process.argv` with `commander` library
- Removed usage section from `README.md` because `commander` offers auto-generated [help](https://github.com/tj/commander.js/)
- Outsourced `start` function into a separate file (because it was already 50 lines long)
- Implemented feature to setup bot with environment variables **AND** parameters (that's new!)