### PR TITLE
refactor(core): Return userId in PayloadBundle

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -153,7 +153,7 @@ export default class ConversationService {
         asset: imageAsset,
         image,
       },
-      from: this.clientID,
+      from: this.apiClient.context!.userId,
       id: messageId,
       state: PayloadBundleState.OUTGOING_UNSENT,
       type: GenericMessageType.ASSET,
@@ -166,7 +166,7 @@ export default class ConversationService {
   ): Promise<PayloadBundleOutgoingUnsent> {
     return {
       content: message,
-      from: this.clientID,
+      from: this.apiClient.context!.userId,
       id: messageId,
       state: PayloadBundleState.OUTGOING_UNSENT,
       type: GenericMessageType.TEXT,
@@ -199,7 +199,7 @@ export default class ConversationService {
 
     return {
       conversation: conversationId,
-      from: this.clientID,
+      from: this.apiClient.context!.userId,
       id: messageId,
       state: PayloadBundleState.OUTGOING_SENT,
       type: GenericMessageType.CONFIRMATION,
@@ -266,7 +266,7 @@ export default class ConversationService {
 
     return {
       conversation: conversationId,
-      from: this.clientID,
+      from: this.apiClient.context!.userId,
       id: messageId,
       state: PayloadBundleState.OUTGOING_SENT,
       type: GenericMessageType.KNOCK,
@@ -285,7 +285,7 @@ export default class ConversationService {
 
     return {
       conversation: conversationId,
-      from: this.clientID,
+      from: this.apiClient.context!.userId,
       id: messageId,
       state: PayloadBundleState.OUTGOING_SENT,
       type: GenericMessageType.CLIENT_ACTION,


### PR DESCRIPTION
Since we don't send the `from` field anywhere and use it only locally, we can return the content as the other side would receive it (which is the user ID in the `from` field).