### PR TITLE
fix(cryptobox): Add missing dependency

### DIFF
--- a/packages/cryptobox/package.json
+++ b/packages/cryptobox/package.json
@@ -6,6 +6,7 @@
     "@wireapp/priority-queue": "0.1.57",
     "@wireapp/proteus": "7.2.9",
     "@wireapp/store-engine": "0.11.42",
+    "bazinga64": "5.2.11",
     "dexie": "2.0.4",
     "fs-extra": "6.0.1"
   },

--- a/packages/cryptobox/package.json
+++ b/packages/cryptobox/package.json
@@ -8,7 +8,8 @@
     "@wireapp/store-engine": "0.11.42",
     "bazinga64": "5.2.11",
     "dexie": "2.0.4",
-    "fs-extra": "6.0.1"
+    "fs-extra": "6.0.1",
+    "logdown": "3.2.3"
   },
   "description": "High-level API with persistent storage for Proteus.",
   "devDependencies": {
@@ -30,7 +31,6 @@
     "karma-jasmine": "1.1.2",
     "karma-jasmine-diff-reporter": "1.2.0",
     "karma-sourcemap-loader": "0.3.7",
-    "logdown": "3.2.3",
     "pure-uuid": "1.5.3",
     "rimraf": "2.6.2",
     "run-sequence": "2.2.1",


### PR DESCRIPTION
When installing `@wireapp/cryptobox` from npm, `bazinga64` is not installed since none of the sub-dependencies have it as dependency but it is required in [`src/main/Cryptobox.ts`](https://github.com/wireapp/wire-web-packages/blob/8b522bd2e0917438f4aa54d0872654a89700de95/packages/cryptobox/src/main/Cryptobox.ts#L24).