### PR TITLE
chore: no-unused-variable is deprecated in TSLint

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noEmitOnError": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "removeComments": true,
     "sourceMap": true,
     "strict": true,

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,6 @@
     "no-return-await": true,
     "no-sparse-arrays": true,
     "no-this-assignment": true,
-    "no-unused-variable": true,
     "object-literal-sort-keys": true,
     "ordered-imports": true,
     "prefer-conditional-expression": true,


### PR DESCRIPTION
See https://github.com/palantir/tslint/issues/1481.