### PR TITLE
chore: Revert TypeScript check for unused parameters

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmitOnError": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "removeComments": true,
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
We need to revert this rule because it forces us to change things like this:

```ts
const binaryString = escapedString.replace(/%([0-9A-F]{2})/g, (match, position) => {
  const code = parseInt(`0x${position}`, 16);
  return String.fromCharCode(code);
});
```

into:

```ts
const binaryString = escapedString.replace(/%([0-9A-F]{2})/g, (_, position) => {
  const code = parseInt(`0x${position}`, 16);
  return String.fromCharCode(code);
});
```