### PR TITLE
refactor(core): Reduce amount of return types for "handleEvent"

### DIFF
--- a/packages/core/src/main/Account.test.node.js
+++ b/packages/core/src/main/Account.test.node.js
@@ -150,7 +150,7 @@ describe('Account', () => {
     });
   });
 
-  fdescribe('"handleEvent"', () => {
+  describe('"handleEvent"', () => {
     it('maps unencrypted events', async done => {
       const account = new Account();
 
@@ -197,6 +197,26 @@ describe('Account', () => {
       expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
       expect(incomingEvent.timestamp).toBe(new Date(memberJoin.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MEMBER_JOIN);
+
+      const conversationRename = {
+        conversation: 'ed5e4cd5-85ab-4d9e-be59-4e1c0324a9d4',
+        data: {
+          name: 'Tiny Timed Messages',
+        },
+        from: '39b7f597-dfd1-4dff-86f5-fe1b79cb70a0',
+        time: '2018-08-01T12:01:21.629Z',
+        type: 'conversation.rename',
+      };
+
+      incomingEvent = await account.handleEvent(conversationRename);
+
+      expect(incomingEvent.conversation).toBe(conversationRename.conversation);
+      expect(incomingEvent.from).toBe(conversationRename.from);
+      expect(typeof incomingEvent.id).toBe('string');
+      expect(incomingEvent.messageTimer).toBe(0);
+      expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
+      expect(incomingEvent.timestamp).toBe(new Date(conversationRename.time).getTime());
+      expect(incomingEvent.type).toBe(CONVERSATION_EVENT.RENAME);
 
       done();
     });

--- a/packages/core/src/main/Account.test.node.js
+++ b/packages/core/src/main/Account.test.node.js
@@ -165,6 +165,7 @@ describe('Account', () => {
       const account = new Account();
       const incomingEvent = account.mapConversationEvent(event);
 
+      expect(incomingEvent.content).toBe(event.data);
       expect(incomingEvent.conversation).toBe(event.conversation);
       expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
@@ -192,6 +193,7 @@ describe('Account', () => {
       const account = new Account();
       const incomingEvent = account.mapConversationEvent(event);
 
+      expect(incomingEvent.content).toBe(event.data);
       expect(incomingEvent.conversation).toBe(event.conversation);
       expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
@@ -215,6 +217,7 @@ describe('Account', () => {
       const account = new Account();
       const incomingEvent = account.mapConversationEvent(event);
 
+      expect(incomingEvent.content).toBe(event.data);
       expect(incomingEvent.conversation).toBe(event.conversation);
       expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
@@ -236,6 +239,7 @@ describe('Account', () => {
       const account = new Account();
       const incomingEvent = account.mapConversationEvent(event);
 
+      expect(incomingEvent.content).toBe(event.data);
       expect(incomingEvent.conversation).toBe(event.conversation);
       expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');

--- a/packages/core/src/main/Account.test.node.js
+++ b/packages/core/src/main/Account.test.node.js
@@ -218,6 +218,24 @@ describe('Account', () => {
       expect(incomingEvent.timestamp).toBe(new Date(conversationRename.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.RENAME);
 
+      const isTyping = {
+        conversation: '508f14b9-ef4c-405d-bba9-5c4300cc1cbf',
+        data: {status: 'started'},
+        from: '16d71f22-0f7b-425e-b4b3-5e288700ac1f',
+        time: '2018-08-01T12:10:42.422Z',
+        type: 'conversation.typing',
+      };
+
+      incomingEvent = await account.handleEvent(isTyping);
+
+      expect(incomingEvent.conversation).toBe(isTyping.conversation);
+      expect(incomingEvent.from).toBe(isTyping.from);
+      expect(typeof incomingEvent.id).toBe('string');
+      expect(incomingEvent.messageTimer).toBe(0);
+      expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
+      expect(incomingEvent.timestamp).toBe(new Date(isTyping.time).getTime());
+      expect(incomingEvent.type).toBe(CONVERSATION_EVENT.TYPING);
+
       done();
     });
   });

--- a/packages/core/src/main/Account.test.node.js
+++ b/packages/core/src/main/Account.test.node.js
@@ -150,8 +150,10 @@ describe('Account', () => {
     });
   });
 
-  describe('"handleEvent"', () => {
+  fdescribe('"handleEvent"', () => {
     it('maps unencrypted events', async done => {
+      const account = new Account();
+
       const messageTimerUpdate = {
         conversation: 'ed5e4cd5-85ab-4d9e-be59-4e1c0324a9d4',
         data: {
@@ -162,8 +164,7 @@ describe('Account', () => {
         type: 'conversation.message-timer-update',
       };
 
-      const account = new Account();
-      const incomingEvent = await account.handleEvent(messageTimerUpdate);
+      let incomingEvent = await account.handleEvent(messageTimerUpdate);
 
       expect(incomingEvent.conversation).toBe(messageTimerUpdate.conversation);
       expect(incomingEvent.from).toBe(messageTimerUpdate.from);
@@ -172,6 +173,30 @@ describe('Account', () => {
       expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
       expect(incomingEvent.timestamp).toBe(new Date(messageTimerUpdate.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MESSAGE_TIMER_UPDATE);
+
+      const memberJoin = {
+        conversation: '87591650-8676-430f-985f-dec8583f58cb',
+        data: {
+          user_ids: [
+            'e023c681-7e51-43dd-a5d8-0f821e70a9c0',
+            'b8a09877-7b73-4636-a664-95b2bda193b0',
+            '5b068afd-1ef2-4860-9fbb-9c3c70a22f97',
+          ],
+        },
+        from: '39b7f597-dfd1-4dff-86f5-fe1b79cb70a0',
+        time: '2018-07-12T09:43:34.442Z',
+        type: 'conversation.member-join',
+      };
+
+      incomingEvent = await account.handleEvent(memberJoin);
+
+      expect(incomingEvent.conversation).toBe(memberJoin.conversation);
+      expect(incomingEvent.from).toBe(memberJoin.from);
+      expect(typeof incomingEvent.id).toBe('string');
+      expect(incomingEvent.messageTimer).toBe(0);
+      expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
+      expect(incomingEvent.timestamp).toBe(new Date(memberJoin.time).getTime());
+      expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MEMBER_JOIN);
 
       done();
     });

--- a/packages/core/src/main/Account.test.node.js
+++ b/packages/core/src/main/Account.test.node.js
@@ -150,10 +150,8 @@ describe('Account', () => {
     });
   });
 
-  describe('"handleEvent"', () => {
-    it('maps unencrypted events', async done => {
-      const account = new Account();
-
+  describe('"mapConversationEvent"', () => {
+    it('maps "conversation.message-timer-update" events', async done => {
       const messageTimerUpdate = {
         conversation: 'ed5e4cd5-85ab-4d9e-be59-4e1c0324a9d4',
         data: {
@@ -164,7 +162,8 @@ describe('Account', () => {
         type: 'conversation.message-timer-update',
       };
 
-      let incomingEvent = await account.handleEvent(messageTimerUpdate);
+      const account = new Account();
+      const incomingEvent = await account.mapConversationEvent(messageTimerUpdate);
 
       expect(incomingEvent.conversation).toBe(messageTimerUpdate.conversation);
       expect(incomingEvent.from).toBe(messageTimerUpdate.from);
@@ -174,6 +173,10 @@ describe('Account', () => {
       expect(incomingEvent.timestamp).toBe(new Date(messageTimerUpdate.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MESSAGE_TIMER_UPDATE);
 
+      done();
+    });
+
+    it('maps "conversation.member-join" events', async done => {
       const memberJoin = {
         conversation: '87591650-8676-430f-985f-dec8583f58cb',
         data: {
@@ -188,7 +191,8 @@ describe('Account', () => {
         type: 'conversation.member-join',
       };
 
-      incomingEvent = await account.handleEvent(memberJoin);
+      const account = new Account();
+      const incomingEvent = await account.mapConversationEvent(memberJoin);
 
       expect(incomingEvent.conversation).toBe(memberJoin.conversation);
       expect(incomingEvent.from).toBe(memberJoin.from);
@@ -198,6 +202,10 @@ describe('Account', () => {
       expect(incomingEvent.timestamp).toBe(new Date(memberJoin.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MEMBER_JOIN);
 
+      done();
+    });
+
+    it('maps "conversation.rename" events', async done => {
       const conversationRename = {
         conversation: 'ed5e4cd5-85ab-4d9e-be59-4e1c0324a9d4',
         data: {
@@ -208,7 +216,8 @@ describe('Account', () => {
         type: 'conversation.rename',
       };
 
-      incomingEvent = await account.handleEvent(conversationRename);
+      const account = new Account();
+      const incomingEvent = await account.mapConversationEvent(conversationRename);
 
       expect(incomingEvent.conversation).toBe(conversationRename.conversation);
       expect(incomingEvent.from).toBe(conversationRename.from);
@@ -218,6 +227,10 @@ describe('Account', () => {
       expect(incomingEvent.timestamp).toBe(new Date(conversationRename.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.RENAME);
 
+      done();
+    });
+
+    it('maps "conversation.typing" events', async done => {
       const isTyping = {
         conversation: '508f14b9-ef4c-405d-bba9-5c4300cc1cbf',
         data: {status: 'started'},
@@ -226,7 +239,8 @@ describe('Account', () => {
         type: 'conversation.typing',
       };
 
-      incomingEvent = await account.handleEvent(isTyping);
+      const account = new Account();
+      const incomingEvent = await account.mapConversationEvent(isTyping);
 
       expect(incomingEvent.conversation).toBe(isTyping.conversation);
       expect(incomingEvent.from).toBe(isTyping.from);

--- a/packages/core/src/main/Account.test.node.js
+++ b/packages/core/src/main/Account.test.node.js
@@ -25,7 +25,7 @@ const {AuthAPI} = require('@wireapp/api-client/dist/commonjs/auth/');
 const {BackendErrorLabel, StatusCode} = require('@wireapp/api-client/dist/commonjs/http/');
 const {ClientAPI, ClientType} = require('@wireapp/api-client/dist/commonjs/client/');
 const {Config} = require('@wireapp/api-client/dist/commonjs/Config');
-const {CONVERSATION_EVENT} = require('@wireapp/api-client/dist/commonjs/event');
+const {CONVERSATION_EVENT, USER_EVENT} = require('@wireapp/api-client/dist/commonjs/event');
 const {ConversationAPI} = require('@wireapp/api-client/dist/commonjs/conversation/');
 const {GenericMessage, Text} = require('@wireapp/protocol-messaging');
 const {MemoryEngine} = require('@wireapp/store-engine');
@@ -151,8 +151,8 @@ describe('Account', () => {
   });
 
   describe('"mapConversationEvent"', () => {
-    it('maps "conversation.message-timer-update" events', async done => {
-      const messageTimerUpdate = {
+    it('maps "conversation.message-timer-update" events', () => {
+      const event = {
         conversation: 'ed5e4cd5-85ab-4d9e-be59-4e1c0324a9d4',
         data: {
           message_timer: 2419200000,
@@ -163,21 +163,19 @@ describe('Account', () => {
       };
 
       const account = new Account();
-      const incomingEvent = await account.mapConversationEvent(messageTimerUpdate);
+      const incomingEvent = account.mapConversationEvent(event);
 
-      expect(incomingEvent.conversation).toBe(messageTimerUpdate.conversation);
-      expect(incomingEvent.from).toBe(messageTimerUpdate.from);
+      expect(incomingEvent.conversation).toBe(event.conversation);
+      expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
       expect(incomingEvent.messageTimer).toBe(0);
       expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
-      expect(incomingEvent.timestamp).toBe(new Date(messageTimerUpdate.time).getTime());
+      expect(incomingEvent.timestamp).toBe(new Date(event.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MESSAGE_TIMER_UPDATE);
-
-      done();
     });
 
-    it('maps "conversation.member-join" events', async done => {
-      const memberJoin = {
+    it('maps "conversation.member-join" events', () => {
+      const event = {
         conversation: '87591650-8676-430f-985f-dec8583f58cb',
         data: {
           user_ids: [
@@ -192,21 +190,19 @@ describe('Account', () => {
       };
 
       const account = new Account();
-      const incomingEvent = await account.mapConversationEvent(memberJoin);
+      const incomingEvent = account.mapConversationEvent(event);
 
-      expect(incomingEvent.conversation).toBe(memberJoin.conversation);
-      expect(incomingEvent.from).toBe(memberJoin.from);
+      expect(incomingEvent.conversation).toBe(event.conversation);
+      expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
       expect(incomingEvent.messageTimer).toBe(0);
       expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
-      expect(incomingEvent.timestamp).toBe(new Date(memberJoin.time).getTime());
+      expect(incomingEvent.timestamp).toBe(new Date(event.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.MEMBER_JOIN);
-
-      done();
     });
 
-    it('maps "conversation.rename" events', async done => {
-      const conversationRename = {
+    it('maps "conversation.rename" events', () => {
+      const event = {
         conversation: 'ed5e4cd5-85ab-4d9e-be59-4e1c0324a9d4',
         data: {
           name: 'Tiny Timed Messages',
@@ -217,21 +213,19 @@ describe('Account', () => {
       };
 
       const account = new Account();
-      const incomingEvent = await account.mapConversationEvent(conversationRename);
+      const incomingEvent = account.mapConversationEvent(event);
 
-      expect(incomingEvent.conversation).toBe(conversationRename.conversation);
-      expect(incomingEvent.from).toBe(conversationRename.from);
+      expect(incomingEvent.conversation).toBe(event.conversation);
+      expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
       expect(incomingEvent.messageTimer).toBe(0);
       expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
-      expect(incomingEvent.timestamp).toBe(new Date(conversationRename.time).getTime());
+      expect(incomingEvent.timestamp).toBe(new Date(event.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.RENAME);
-
-      done();
     });
 
-    it('maps "conversation.typing" events', async done => {
-      const isTyping = {
+    it('maps "conversation.typing" events', () => {
+      const event = {
         conversation: '508f14b9-ef4c-405d-bba9-5c4300cc1cbf',
         data: {status: 'started'},
         from: '16d71f22-0f7b-425e-b4b3-5e288700ac1f',
@@ -240,17 +234,43 @@ describe('Account', () => {
       };
 
       const account = new Account();
-      const incomingEvent = await account.mapConversationEvent(isTyping);
+      const incomingEvent = account.mapConversationEvent(event);
 
-      expect(incomingEvent.conversation).toBe(isTyping.conversation);
-      expect(incomingEvent.from).toBe(isTyping.from);
+      expect(incomingEvent.conversation).toBe(event.conversation);
+      expect(incomingEvent.from).toBe(event.from);
       expect(typeof incomingEvent.id).toBe('string');
       expect(incomingEvent.messageTimer).toBe(0);
       expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
-      expect(incomingEvent.timestamp).toBe(new Date(isTyping.time).getTime());
+      expect(incomingEvent.timestamp).toBe(new Date(event.time).getTime());
       expect(incomingEvent.type).toBe(CONVERSATION_EVENT.TYPING);
+    });
+  });
 
-      done();
+  describe('"mapUserEvent"', () => {
+    it('maps "user.connection" events', () => {
+      const event = {
+        connection: {
+          conversation: '19dbbc18-5e22-41dc-acce-0d9d983c1a60',
+          from: '39b7f597-dfd1-4dff-86f5-fe1b79cb70a0',
+          last_update: '2018-07-06T09:38:52.286Z',
+          message: ' ',
+          status: 'sent',
+          to: 'e023c681-7e51-43dd-a5d8-0f821e70a9c0',
+        },
+        type: 'user.connection',
+      };
+
+      const account = new Account();
+      const incomingEvent = account.mapUserEvent(event);
+
+      expect(incomingEvent.content).toBe(event.connection);
+      expect(incomingEvent.conversation).toBe(event.connection.conversation);
+      expect(incomingEvent.from).toBe(event.connection.from);
+      expect(typeof incomingEvent.id).toBe('string');
+      expect(incomingEvent.messageTimer).toBe(0);
+      expect(incomingEvent.state).toBe(PayloadBundleState.INCOMING);
+      expect(incomingEvent.timestamp).toBe(new Date(event.connection.last_update).getTime());
+      expect(incomingEvent.type).toBe(USER_EVENT.CONNECTION);
     });
   });
 

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -371,6 +371,18 @@ class Account extends EventEmitter {
     }
   }
 
+  private mapConversationEvent(event: ConversationEvent): PayloadBundleIncoming {
+    return {
+      conversation: event.conversation,
+      from: event.from,
+      id: ConversationService.createId(),
+      messageTimer: 0,
+      state: PayloadBundleState.INCOMING,
+      timestamp: new Date(event.time).getTime(),
+      type: event.type,
+    };
+  }
+
   private async handleEvent(event: IncomingEvent): Promise<PayloadBundleIncoming | IncomingEvent | void> {
     this.logger.log('handleEvent', event.type);
     const ENCRYPTED_EVENTS = [CONVERSATION_EVENT.OTR_MESSAGE_ADD];
@@ -387,7 +399,7 @@ class Account extends EventEmitter {
     } else if (META_EVENTS.includes(event.type as CONVERSATION_EVENT)) {
       const {conversation, from} = event as ConversationEvent;
       const metaEvent = {...event, from, conversation};
-      return metaEvent as ConversationEvent;
+      return this.mapConversationEvent(metaEvent as ConversationEvent);
     } else if (USER_EVENTS.includes(event.type as USER_EVENT)) {
       return event as UserEvent;
     }

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -374,6 +374,7 @@ class Account extends EventEmitter {
 
   private mapConversationEvent(event: ConversationEvent): PayloadBundleIncoming {
     return {
+      content: event.data,
       conversation: event.conversation,
       from: event.from,
       id: ConversationService.createId(),

--- a/packages/core/src/main/conversation/PayloadBundle.ts
+++ b/packages/core/src/main/conversation/PayloadBundle.ts
@@ -19,6 +19,7 @@
 
 import {ClientActionType, GenericMessageType} from '../conversation/root';
 
+import {CONVERSATION_EVENT} from '@wireapp/api-client/dist/commonjs/event';
 import {
   AssetContent,
   ClientActionContent,
@@ -67,7 +68,7 @@ interface PayloadBundle {
   id: string;
   state: PayloadBundleState;
   timestamp: number;
-  type: GenericMessageType;
+  type: GenericMessageType | CONVERSATION_EVENT;
 }
 
 export {PayloadBundle, PayloadBundleIncoming, PayloadBundleOutgoing, PayloadBundleOutgoingUnsent, PayloadBundleState};

--- a/packages/core/src/main/conversation/PayloadBundle.ts
+++ b/packages/core/src/main/conversation/PayloadBundle.ts
@@ -19,7 +19,8 @@
 
 import {ClientActionType, GenericMessageType} from '../conversation/root';
 
-import {CONVERSATION_EVENT} from '@wireapp/api-client/dist/commonjs/event';
+import {Connection} from '@wireapp/api-client/dist/commonjs/connection';
+import {CONVERSATION_EVENT, USER_EVENT} from '@wireapp/api-client/dist/commonjs/event';
 import {
   AssetContent,
   ClientActionContent,
@@ -57,6 +58,7 @@ interface PayloadBundle {
     | ClientActionContent
     | ClientActionType
     | ConfirmationContent
+    | Connection
     | DeletedContent
     | EditedTextContent
     | HiddenContent
@@ -68,7 +70,7 @@ interface PayloadBundle {
   id: string;
   state: PayloadBundleState;
   timestamp: number;
-  type: GenericMessageType | CONVERSATION_EVENT;
+  type: GenericMessageType | CONVERSATION_EVENT | USER_EVENT;
 }
 
 export {PayloadBundle, PayloadBundleIncoming, PayloadBundleOutgoing, PayloadBundleOutgoingUnsent, PayloadBundleState};


### PR DESCRIPTION
To make our API a bit neater, this PR turns the following signature:

```ts
private async handleEvent(event: IncomingEvent): Promise<PayloadBundleIncoming | IncomingEvent | void>
```

Into:

```ts
private async handleEvent(event: IncomingEvent): Promise<PayloadBundleIncoming | void>
```