### PR TITLE
refactor: Use lerna.json over npm scripts

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,9 +6,12 @@
       "message": "[skip ci] chore: Publish %s"
     }
   },
+  "exact": true,
   "ignoreChanges": ["**/demo/**"],
+  "loglevel": "verbose",
   "npmClient": "yarn",
   "npmClientArgs": ["--exact"],
   "useWorkspaces": true,
-  "version": "independent"
+  "version": "independent",
+  "yes": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -8,6 +8,7 @@
   },
   "exact": true,
   "ignoreChanges": ["**/demo/**"],
+  "lerna": "2.11.0",
   "loglevel": "verbose",
   "npmClient": "yarn",
   "npmClientArgs": ["--exact"],

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,12 @@
 {
-  "lerna": "2.5.1",
+  "command": {
+    "publish": {
+      "allowBranch": "master",
+      "conventionalCommits": true,
+      "message": "[skip ci] chore: Publish %s"
+    }
+  },
+  "ignoreChanges": ["**/demo/**"],
   "npmClient": "yarn",
   "npmClientArgs": ["--exact"],
   "useWorkspaces": true,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:ts": "tslint --config tslint.json --project tsconfig.json \"**/*.ts\"",
     "precommit": "lint-staged",
     "prettier": "prettier \"**/*.{json,md,scss,yml}\"",
-    "release": "lerna publish -m \"[skip ci] chore: Publish\" --conventional-commits --loglevel=verbose --exact --allow-branch=master --registry=https://registry.npmjs.org/ --yes",
+    "release": "lerna publish --loglevel=verbose --exact --registry=https://registry.npmjs.org/ --yes",
     "test": "yarn && yarn lint:js && yarn lint:ts && yarn lint:other && node bin/testUpdated.js",
     "test:all": "yarn && yarn dist && yarn lint && lerna run test"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:ts": "tslint --config tslint.json --project tsconfig.json \"**/*.ts\"",
     "precommit": "lint-staged",
     "prettier": "prettier \"**/*.{json,md,scss,yml}\"",
-    "release": "lerna publish --loglevel=verbose --exact --registry=https://registry.npmjs.org/ --yes",
+    "release": "lerna publish",
     "test": "yarn && yarn lint:js && yarn lint:ts && yarn lint:other && node bin/testUpdated.js",
     "test:all": "yarn && yarn dist && yarn lint && lerna run test"
   },


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- ~~[ ] My code is covered by tests~~
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes

## Note

The npm registry is already defined in our `.npmrc` file and lerna will automatically resolve it from there. :)
