### PR TITLE
fix(api-client): Increase maximum content length

### DIFF
--- a/packages/api-client/src/main/http/HttpClient.ts
+++ b/packages/api-client/src/main/http/HttpClient.ts
@@ -103,7 +103,10 @@ class HttpClient extends EventEmitter {
     }
 
     return axios
-      .request(config)
+      .request({
+        ...config,
+        maxContentLength: 104857600, // 100 Megabytes
+      })
       .then((response: AxiosResponse) => {
         this.updateConnectionState(ConnectionState.CONNECTED);
         return response;


### PR DESCRIPTION
With a default filesize limit of 10mb we can't upload large assets.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
