### PR TITLE
chore: Remove optional lerna property

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -8,7 +8,6 @@
   },
   "exact": true,
   "ignoreChanges": ["**/demo/**"],
-  "lerna": "2.11.0",
   "loglevel": "verbose",
   "npmClient": "yarn",
   "npmClientArgs": ["--exact"],


### PR DESCRIPTION
With Lerna v3 the "lerna" property is optional: https://github.com/lerna/lerna/issues/1546#issuecomment-411095945

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
