### PR TITLE
fix(core): Linkpreview title, expose Asset API (WEBFOUND-34)

### DIFF
--- a/packages/core/src/demo/echo.js
+++ b/packages/core/src/demo/echo.js
@@ -93,7 +93,7 @@ const messageIdCache = {};
     const {content, id: messageId} = data;
     let textPayload;
 
-    const linkPreviews = [];
+    const newLinkPreviews = [];
 
     if (content.linkPreviews) {
       for (const linkPreview of content.linkPreviews) {
@@ -112,17 +112,12 @@ const messageIdCache = {};
           };
         }
 
-        const newLinkPreview = await account.service.conversation.createLinkPreview(
-          linkPreview.url,
-          linkPreview.urlOffset,
-          linkPreviewImage,
-          linkPreview.permanentUrl,
-          linkPreview.summary,
-          linkPreview.title,
-          linkPreview.tweet
-        );
+        const newLinkPreview = await account.service.conversation.createLinkPreview({
+          ...linkPreview,
+          image: linkPreviewImage,
+        });
 
-        linkPreviews.push(newLinkPreview);
+        newLinkPreviews.push(newLinkPreview);
       }
 
       await handleIncomingMessage(data);
@@ -130,7 +125,7 @@ const messageIdCache = {};
       const messageIdOriginal = messageIdCache[messageId];
 
       if (messageIdOriginal) {
-        textPayload = account.service.conversation.createText(content.text, linkPreviews, messageIdOriginal);
+        textPayload = account.service.conversation.createText(content.text, newLinkPreviews, messageIdOriginal);
       } else {
         logger.warn(`Link preview for message ID "${messageId} was received before the original message."`);
         return;

--- a/packages/core/src/demo/echo.js
+++ b/packages/core/src/demo/echo.js
@@ -95,8 +95,8 @@ const messageIdCache = {};
 
     const linkPreviews = [];
 
-    if (content.linkPreview) {
-      for (const linkPreview of content.linkPreview) {
+    if (content.linkPreviews) {
+      for (const linkPreview of content.linkPreviews) {
         const originalLinkPreviewImage =
           linkPreview.article && linkPreview.article.image ? linkPreview.article.image : linkPreview.image;
         let linkPreviewImage;

--- a/packages/core/src/demo/echo.js
+++ b/packages/core/src/demo/echo.js
@@ -97,10 +97,11 @@ const messageIdCache = {};
 
     if (content.linkPreview) {
       for (const linkPreview of content.linkPreview) {
+        const originalLinkPreviewImage =
+          linkPreview.article && linkPreview.article.image ? linkPreview.article.image : linkPreview.image;
         let linkPreviewImage;
 
-        if (linkPreview.article && linkPreview.article.image) {
-          const originalLinkPreviewImage = linkPreview.article.image;
+        if (originalLinkPreviewImage) {
           const imageBuffer = await account.service.conversation.getAsset(originalLinkPreviewImage.uploaded);
 
           linkPreviewImage = {

--- a/packages/core/src/demo/echo.js
+++ b/packages/core/src/demo/echo.js
@@ -115,8 +115,8 @@ const messageIdCache = {};
         const newLinkPreview = await account.service.conversation.createLinkPreview(
           linkPreview.url,
           linkPreview.urlOffset,
-          linkPreview.permanentUrl,
           linkPreviewImage,
+          linkPreview.permanentUrl,
           linkPreview.summary,
           linkPreview.title,
           linkPreview.tweet

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -73,6 +73,7 @@ class Account extends EventEmitter {
 
   private readonly apiClient: APIClient;
   public service?: {
+    asset: AssetService;
     client: ClientService;
     conversation: ConversationService;
     connection: ConnectionService;
@@ -98,6 +99,7 @@ class Account extends EventEmitter {
     const selfService = new SelfService(this.apiClient);
 
     this.service = {
+      asset: assetService,
       client: clientService,
       connection: connectionService,
       conversation: conversationService,

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -273,7 +273,11 @@ class Account extends EventEmitter {
       case GenericMessageType.TEXT: {
         const {content: text, linkPreview} = genericMessage[GenericMessageType.TEXT];
 
-        const content: TextContent = {text, linkPreview};
+        const content: TextContent = {text};
+
+        if (linkPreview.length) {
+          content.linkPreview = linkPreview;
+        }
 
         return {
           content,

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -276,7 +276,7 @@ class Account extends EventEmitter {
         const content: TextContent = {text};
 
         if (linkPreview.length) {
-          content.linkPreview = linkPreview;
+          content.linkPreviews = linkPreview;
         }
 
         return {

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -326,7 +326,7 @@ class Account extends EventEmitter {
       }
       case GenericMessageType.EDITED: {
         const {
-          text: {content: editedText},
+          text: {content: editedText, linkPreview: editedLinkPreview},
           replacingMessageId,
         } = genericMessage[GenericMessageType.EDITED];
 
@@ -334,6 +334,10 @@ class Account extends EventEmitter {
           originalMessageId: replacingMessageId,
           text: editedText,
         };
+
+        if (editedLinkPreview.length) {
+          content.linkPreviews = editedLinkPreview;
+        }
 
         return {
           content,

--- a/packages/core/src/main/conversation/ConversationService.test.node.js
+++ b/packages/core/src/main/conversation/ConversationService.test.node.js
@@ -195,15 +195,14 @@ describe('ConversationService', () => {
       };
       const urlOffset = 0;
 
-      const linkPreview = await account.service.conversation.createLinkPreview(
-        url,
-        urlOffset,
-        undefined,
+      const linkPreview = await account.service.conversation.createLinkPreview({
         permanentUrl,
         summary,
         title,
-        tweet
-      );
+        tweet,
+        url,
+        urlOffset,
+      });
       const textMessage = account.service.conversation.createText(text, [linkPreview]);
 
       expect(textMessage.content.text).toEqual(text);
@@ -258,7 +257,7 @@ describe('ConversationService', () => {
       const text = url;
       const urlOffset = 0;
 
-      const linkPreview = await account.service.conversation.createLinkPreview(url, urlOffset, image);
+      const linkPreview = await account.service.conversation.createLinkPreview({image, url, urlOffset});
       const textMessage = account.service.conversation.createText(text, [linkPreview]);
 
       expect(account.service.asset.uploadImageAsset).toHaveBeenCalledTimes(1);
@@ -268,7 +267,6 @@ describe('ConversationService', () => {
 
       expect(textMessage.content.linkPreviews[0]).toEqual(
         jasmine.objectContaining({
-          image,
           url,
           urlOffset,
         })

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -725,12 +725,17 @@ class ConversationService {
     newLinkPreview?: LinkPreviewContent[],
     messageId: string = ConversationService.createId()
   ): PayloadBundleOutgoingUnsent {
+    const content: EditedTextContent = {
+      originalMessageId,
+      text: newMessageText,
+    };
+
+    if (newLinkPreview) {
+      content.linkPreview = newLinkPreview;
+    }
+
     return {
-      content: {
-        linkPreview: newLinkPreview,
-        originalMessageId,
-        text: newMessageText,
-      },
+      content,
       from: this.apiClient.context!.userId,
       id: messageId,
       state: PayloadBundleState.OUTGOING_UNSENT,

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -823,7 +823,7 @@ class ConversationService {
   public async createLinkPreview(
     url: string,
     urlOffset: number,
-    permanentUrl: string,
+    permanentUrl?: string,
     image?: ImageContent,
     summary?: string,
     title?: string,
@@ -886,7 +886,11 @@ class ConversationService {
     linkPreviews?: LinkPreviewUploadedContent[],
     messageId: string = ConversationService.createId()
   ): PayloadBundleOutgoingUnsent {
-    const content: TextContent = {text, linkPreviews};
+    const content: TextContent = {text};
+
+    if (linkPreviews) {
+      content.linkPreviews = linkPreviews;
+    }
 
     return {
       content,

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -43,7 +43,6 @@ import {
 } from '../conversation/root';
 
 import {
-  Article,
   Asset,
   Cleared,
   ClientAction,
@@ -600,6 +599,7 @@ class ConversationService {
         const linkPreviewMessage = LinkPreview.create({
           permanentUrl: linkPreview.permanentUrl,
           summary: linkPreview.summary,
+          title: linkPreview.title,
           url: linkPreview.url,
           urlOffset: linkPreview.urlOffset,
         });
@@ -622,7 +622,6 @@ class ConversationService {
           const original = Asset.Original.create({
             [GenericMessageType.IMAGE]: imageMetadata,
             mimeType: encryptedAsset.image.type,
-            name: null,
             size: encryptedAsset.image.data.length,
           });
 
@@ -638,14 +637,7 @@ class ConversationService {
             uploaded: remoteData,
           });
 
-          assetMessage.status = AssetTransferState.UPLOADED;
-
-          linkPreviewMessage.article = Article.create({
-            image: assetMessage,
-            permanentUrl: linkPreview.permanentUrl,
-            summary: linkPreview.summary,
-            title: linkPreview.title,
-          });
+          linkPreviewMessage.image = assetMessage;
         }
 
         textMessage.linkPreview.push(linkPreviewMessage);

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -823,8 +823,8 @@ class ConversationService {
   public async createLinkPreview(
     url: string,
     urlOffset: number,
-    permanentUrl?: string,
     image?: ImageContent,
+    permanentUrl?: string,
     summary?: string,
     title?: string,
     tweet?: TweetContent

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -70,7 +70,7 @@ import {
   FileMetaDataContent,
   ImageAssetContent,
   ImageContent,
-  LinkPreviewContent,
+  LinkPreviewUploadedContent,
   LocationContent,
   ReactionContent,
   RemoteData,
@@ -594,8 +594,8 @@ class ConversationService {
       content: payloadBundleContent.text,
     });
 
-    if (payloadBundleContent.linkPreview) {
-      for (const linkPreview of payloadBundleContent.linkPreview) {
+    if (payloadBundleContent.linkPreviews) {
+      for (const linkPreview of payloadBundleContent.linkPreviews) {
         const linkPreviewMessage = LinkPreview.create({
           permanentUrl: linkPreview.permanentUrl,
           summary: linkPreview.summary,
@@ -611,8 +611,8 @@ class ConversationService {
           });
         }
 
-        if (linkPreview.image) {
-          const encryptedAsset = linkPreview.image;
+        if (linkPreview.imageUploaded) {
+          const encryptedAsset = linkPreview.imageUploaded;
 
           const imageMetadata = Asset.ImageMetaData.create({
             height: encryptedAsset.image.height,
@@ -722,7 +722,7 @@ class ConversationService {
   public createEditedText(
     newMessageText: string,
     originalMessageId: string,
-    newLinkPreview?: LinkPreviewContent[],
+    newLinkPreviews?: LinkPreviewUploadedContent[],
     messageId: string = ConversationService.createId()
   ): PayloadBundleOutgoingUnsent {
     const content: EditedTextContent = {
@@ -730,8 +730,8 @@ class ConversationService {
       text: newMessageText,
     };
 
-    if (newLinkPreview) {
-      content.linkPreview = newLinkPreview;
+    if (newLinkPreviews) {
+      content.linkPreviews = newLinkPreviews;
     }
 
     return {
@@ -828,8 +828,9 @@ class ConversationService {
     summary?: string,
     title?: string,
     tweet?: TweetContent
-  ): Promise<LinkPreviewContent> {
-    const linkPreview: LinkPreviewContent = {
+  ): Promise<LinkPreviewUploadedContent> {
+    const linkPreview: LinkPreviewUploadedContent = {
+      image,
       permanentUrl,
       summary,
       title,
@@ -840,7 +841,7 @@ class ConversationService {
 
     if (image) {
       const imageAsset = await this.assetService.uploadImageAsset(image);
-      linkPreview.image = {
+      linkPreview.imageUploaded = {
         asset: imageAsset,
         image,
       };
@@ -882,10 +883,10 @@ class ConversationService {
 
   public createText(
     text: string,
-    linkPreview?: LinkPreviewContent[],
+    linkPreviews?: LinkPreviewUploadedContent[],
     messageId: string = ConversationService.createId()
   ): PayloadBundleOutgoingUnsent {
-    const content: TextContent = {text, linkPreview};
+    const content: TextContent = {text, linkPreviews};
 
     return {
       content,

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -70,12 +70,12 @@ import {
   FileMetaDataContent,
   ImageAssetContent,
   ImageContent,
+  LinkPreviewContent,
   LinkPreviewUploadedContent,
   LocationContent,
   ReactionContent,
   RemoteData,
   TextContent,
-  TweetContent,
 } from '../conversation/content/';
 
 import * as AssetCryptography from '../cryptography/AssetCryptography.node';
@@ -820,34 +820,25 @@ class ConversationService {
     };
   }
 
-  public async createLinkPreview(
-    url: string,
-    urlOffset: number,
-    image?: ImageContent,
-    permanentUrl?: string,
-    summary?: string,
-    title?: string,
-    tweet?: TweetContent
-  ): Promise<LinkPreviewUploadedContent> {
-    const linkPreview: LinkPreviewUploadedContent = {
-      image,
-      permanentUrl,
-      summary,
-      title,
-      tweet,
-      url,
-      urlOffset,
+  public async createLinkPreview(linkPreview: LinkPreviewContent): Promise<LinkPreviewUploadedContent> {
+    const linkPreviewUploaded: LinkPreviewUploadedContent = {
+      ...linkPreview,
     };
 
-    if (image) {
-      const imageAsset = await this.assetService.uploadImageAsset(image);
-      linkPreview.imageUploaded = {
+    const linkPreviewImage = linkPreview.image;
+
+    if (linkPreviewImage) {
+      const imageAsset = await this.assetService.uploadImageAsset(linkPreviewImage);
+
+      delete linkPreviewUploaded.image;
+
+      linkPreviewUploaded.imageUploaded = {
         asset: imageAsset,
-        image,
+        image: linkPreviewImage,
       };
     }
 
-    return linkPreview;
+    return linkPreviewUploaded;
   }
 
   public createLocation(

--- a/packages/core/src/main/conversation/content/ConversationContent.ts
+++ b/packages/core/src/main/conversation/content/ConversationContent.ts
@@ -13,6 +13,7 @@ import {
   ImageAssetContent,
   ImageContent,
   LinkPreviewContent,
+  LinkPreviewUploadedContent,
   LocationContent,
   ReactionContent,
   TextContent,
@@ -33,6 +34,7 @@ type ConversationContent =
   | ImageAssetContent
   | ImageContent
   | LinkPreviewContent
+  | LinkPreviewUploadedContent
   | LocationContent
   | ReactionContent
   | TextContent;

--- a/packages/core/src/main/conversation/content/EditedTextContent.ts
+++ b/packages/core/src/main/conversation/content/EditedTextContent.ts
@@ -17,12 +17,12 @@
  *
  */
 
-import {LinkPreviewContent} from '../content/';
+import {LinkPreviewUploadedContent} from '../content/';
 
 interface EditedTextContent {
   originalMessageId: string;
   text: string;
-  linkPreview?: LinkPreviewContent[];
+  linkPreviews?: LinkPreviewUploadedContent[];
 }
 
 export {EditedTextContent};

--- a/packages/core/src/main/conversation/content/EditedTextContent.ts
+++ b/packages/core/src/main/conversation/content/EditedTextContent.ts
@@ -22,7 +22,7 @@ import {LinkPreviewContent} from '../content/';
 interface EditedTextContent {
   originalMessageId: string;
   text: string;
-  linkPreview?: LinkPreviewContent;
+  linkPreview?: LinkPreviewContent[];
 }
 
 export {EditedTextContent};

--- a/packages/core/src/main/conversation/content/LinkPreviewContent.ts
+++ b/packages/core/src/main/conversation/content/LinkPreviewContent.ts
@@ -17,10 +17,10 @@
  *
  */
 
-import {ImageAssetContent, TweetContent} from '../content/';
+import {ImageAssetContent, ImageContent, TweetContent} from '../content/';
 
 interface LinkPreviewContent {
-  image?: ImageAssetContent;
+  image?: ImageContent;
   permanentUrl: string;
   summary?: string;
   title?: string;
@@ -29,4 +29,8 @@ interface LinkPreviewContent {
   urlOffset: number;
 }
 
-export {LinkPreviewContent};
+interface LinkPreviewUploadedContent extends LinkPreviewContent {
+  imageUploaded?: ImageAssetContent;
+}
+
+export {LinkPreviewContent, LinkPreviewUploadedContent};

--- a/packages/core/src/main/conversation/content/LinkPreviewContent.ts
+++ b/packages/core/src/main/conversation/content/LinkPreviewContent.ts
@@ -21,7 +21,7 @@ import {ImageAssetContent, ImageContent, TweetContent} from '../content/';
 
 interface LinkPreviewContent {
   image?: ImageContent;
-  permanentUrl: string;
+  permanentUrl?: string;
   summary?: string;
   title?: string;
   tweet?: TweetContent;

--- a/packages/core/src/main/conversation/content/TextContent.ts
+++ b/packages/core/src/main/conversation/content/TextContent.ts
@@ -17,11 +17,11 @@
  *
  */
 
-import {LinkPreviewContent} from '../content';
+import {LinkPreviewUploadedContent} from '../content';
 
 interface TextContent {
   text: string;
-  linkPreview?: LinkPreviewContent[];
+  linkPreviews?: LinkPreviewUploadedContent[];
 }
 
 export {TextContent};


### PR DESCRIPTION
This PR will

* add a new type `LinkPreviewUploadedContent` to differentiate between link previews with uploaded image assets and without.
* let `createLinkPreview()` accept an object instead of 8 parameters.
* remove `Article` since it's deprecated.
* rename `linkPreview` in a PayloadBundle to `linkPreviews` since it's an array.
* expose the Asset API.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
