### PR TITLE
refactor(lru-cache): Implement iterator and getAll returns object (BREAKING)

### DIFF
--- a/packages/lru-cache/src/demo/demo.html
+++ b/packages/lru-cache/src/demo/demo.html
@@ -15,7 +15,7 @@
       cache.set('3', 'Tomato');
       cache.delete('2');
       document.write(cache.size()); // "2"
-      document.write(JSON.stringify(cache.getAll())); // [{"1": "Apple"}, {"2": "Orange"}, {"3": "Tomato"}]
+      document.write(JSON.stringify(cache.getAll())); // {"1": "Apple", "2": "Orange", "3": "Tomato"}
     </script>
   </body>
 </html>

--- a/packages/lru-cache/src/main/LRUCache.ts
+++ b/packages/lru-cache/src/main/LRUCache.ts
@@ -192,6 +192,22 @@ class LRUCache<T> {
 
     return `${string} (oldest)`;
   }
+
+  public [Symbol.iterator]() {
+    let node = this.head;
+    return {
+      next: () => {
+        if (node) {
+          const obj = {done: false, value: node.value};
+          node = node.next;
+          return obj;
+        } else {
+          node = this.head;
+          return {done: true};
+        }
+      },
+    };
+  }
 }
 
 export {LRUCache};

--- a/packages/lru-cache/src/main/LRUCache.ts
+++ b/packages/lru-cache/src/main/LRUCache.ts
@@ -69,13 +69,12 @@ class LRUCache<T> {
     return undefined;
   }
 
-  public getAll(): {[id: string]: T}[] {
-    return Object.keys(this.map).map(id => {
+  public getAll(): {[id: string]: T} {
+    return Object.keys(this.map).reduce((accumulator: {[id: string]: T}, id) => {
       const node = this.map[id];
-      return {
-        [id]: node.value,
-      };
-    });
+      accumulator[id] = node.value;
+      return accumulator;
+    }, {});
   }
 
   public keys(): string[] {
@@ -198,7 +197,7 @@ class LRUCache<T> {
     return {
       next: () => {
         if (node) {
-          const obj = {done: false, value: node.value};
+          const obj = {done: false, value: [node.key, node.value]};
           node = node.next;
           return obj;
         } else {

--- a/packages/lru-cache/test/specs/LRUCacheSpec.js
+++ b/packages/lru-cache/test/specs/LRUCacheSpec.js
@@ -102,6 +102,19 @@ describe('LRUCache', () => {
     });
   });
 
+  describe('"iterator"', () => {
+    it('iterates over the nodes', () => {
+      const cache = new LRUCache(4);
+      cache.set('1', 'Apple');
+      cache.set('2', 'Orange');
+      cache.set('3', 'Tomato');
+      cache.set('4', 'Plum');
+      for (const value of cache) {
+        expect(value).toBeDefined();
+      }
+    });
+  });
+
   describe('"keys"', () => {
     it('lists all keys of the cache starting with the latest item in the cache', () => {
       const cache = new LRUCache(3);

--- a/packages/lru-cache/test/specs/LRUCacheSpec.js
+++ b/packages/lru-cache/test/specs/LRUCacheSpec.js
@@ -98,17 +98,32 @@ describe('LRUCache', () => {
       const cache = new LRUCache(4);
       cache.set('1', 'Apple');
       cache.set('2', 'Orange');
-      expect(cache.getAll()).toEqual([{'1': 'Apple'}, {'2': 'Orange'}]);
+      expect(cache.getAll()).toEqual({'1': 'Apple', '2': 'Orange'});
     });
-  });
 
-  describe('"iterator"', () => {
-    it('iterates over the nodes', () => {
+    it('iterates over the keys', () => {
       const cache = new LRUCache(4);
       cache.set('1', 'Apple');
       cache.set('2', 'Orange');
       cache.set('3', 'Tomato');
       cache.set('4', 'Plum');
+
+      const nodes = cache.getAll();
+
+      for (const key in nodes) {
+        expect(key).toBeDefined();
+      }
+    });
+  });
+
+  describe('"iterator"', () => {
+    it('iterates over the values', () => {
+      const cache = new LRUCache(4);
+      cache.set('1', 'Apple');
+      cache.set('2', 'Orange');
+      cache.set('3', 'Tomato');
+      cache.set('4', 'Plum');
+
       for (const value of cache) {
         expect(value).toBeDefined();
       }


### PR DESCRIPTION
Given we have a message cache like:
```ts
const messageCache = new LRUCache();
messageCache.add(...);
```

Instead of using:
```ts
const messages = messageCache.getAll();
for (const messageObject of messages) {
  const objectId = Object.keys(message)[0];
  const message = messageObject[objectId];
  // do something with the message
}
```

we can now iterate over the messages:
```ts
for (const message of messageCache) {
  // do something with the message
}
```

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
