### PR TITLE
chore(api-client): Wording for cookie expiration log

### DIFF
--- a/packages/api-client/src/main/shims/node/cookie.ts
+++ b/packages/api-client/src/main/shims/node/cookie.ts
@@ -76,7 +76,7 @@ export const retrieveCookie = async (response: AxiosResponse, engine: CRUDEngine
     for (const cookie of cookies) {
       await setInternalCookie(new Cookie(cookie.value, cookie.expires), engine);
       logger.info(
-        `Saved internal cookie. It will expire in "${cookie.expires}" seconds.`,
+        `Saved internal cookie. It will expire on "${cookie.expires}".`,
         ObfuscationUtil.obfuscateCookie(cookie)
       );
     }


### PR DESCRIPTION
**Before**
```
Saved internal cookie. It will expire in "Wed Nov 14 2018 09:59:30 GMT+0100 (Central European Standard Time)" seconds.
```

**After**
```
Saved internal cookie. It will expire on "Wed Nov 14 2018 09:59:30 GMT+0100 (Central European Standard Time)".
```

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
