### PR TITLE
fix(core): Add Article for old iOS devices (WEBFOUND-42)

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -44,6 +44,7 @@ import {
 } from '../conversation/root';
 
 import {
+  Article,
   Asset,
   Cleared,
   ClientAction,
@@ -644,6 +645,13 @@ class ConversationService {
 
         linkPreviewMessage.image = assetMessage;
       }
+
+      linkPreviewMessage.article = Article.create({
+        image: linkPreviewMessage.image,
+        permanentUrl: linkPreviewMessage.permanentUrl,
+        summary: linkPreviewMessage.summary,
+        title: linkPreviewMessage.title,
+      });
 
       builtLinkPreviews.push(linkPreviewMessage);
     }


### PR DESCRIPTION
iOS currently only renders link previews which have the [deprecated](https://github.com/wireapp/generic-message-proto/blob/master/proto/messages.proto#L65) `Article` set.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
