### PR TITLE
fix(store-engine): Make init() options optional

### DIFF
--- a/packages/store-engine/src/main/engine/FileEngine.ts
+++ b/packages/store-engine/src/main/engine/FileEngine.ts
@@ -26,7 +26,7 @@ export default class FileEngine implements CRUDEngine {
     }
   }
 
-  public async init(storeName = '', options: {fileExtension: string}): Promise<any> {
+  public async init(storeName = '', options?: {fileExtension: string}): Promise<any> {
     await this.isSupported();
 
     FileEngine.enforcePathRestrictions(this.baseDirectory, storeName);


### PR DESCRIPTION
The options in `init()` should be optional because
* [`storeName` is optional](https://github.com/wireapp/wire-web-packages/pull/1191/files#diff-333c4b7db5b6087797f2608a9df38dc5L29)
* [the options are merged with the default options](https://github.com/wireapp/wire-web-packages/pull/1191/files#diff-333c4b7db5b6087797f2608a9df38dc5L35)

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
