### PR TITLE
fix(react-ui-kit): Set initial loading progress to undefined

### DIFF
--- a/packages/react-ui-kit/src/Misc/Loading.tsx
+++ b/packages/react-ui-kit/src/Misc/Loading.tsx
@@ -30,14 +30,14 @@ interface LoadingComponentProps {
 
 function LoadingComponent({
   className,
-  progress = null,
+  progress = undefined,
   size,
 }: LoadingComponentProps & React.HTMLAttributes<SVGElement>) {
   const additionalProps: {
     strokeDashoffset?: string;
   } = {};
 
-  if (progress !== null) {
+  if (typeof progress !== 'undefined') {
     additionalProps.strokeDashoffset = `${pathLength - pathLength * progress}`;
   }
   return (
@@ -75,7 +75,7 @@ interface LoadingProps {
 
 const Loading = styled<LoadingProps & React.HTMLAttributes<SVGElement>>(LoadingComponent)`
   ${props =>
-    props.progress === null &&
+    typeof props.progress === 'undefined' &&
     css`
       circle:nth-of-type(2) {
         transform-origin: 50% 50%;
@@ -87,7 +87,7 @@ const Loading = styled<LoadingProps & React.HTMLAttributes<SVGElement>>(LoadingC
 `;
 
 Loading.defaultProps = {
-  progress: null,
+  progress: undefined,
   size: 43,
 };
 

--- a/packages/react-ui-kit/src/Misc/Loading.tsx
+++ b/packages/react-ui-kit/src/Misc/Loading.tsx
@@ -37,7 +37,7 @@ function LoadingComponent({
     strokeDashoffset?: string;
   } = {};
 
-  if (typeof progress !== 'undefined') {
+  if (progress) {
     additionalProps.strokeDashoffset = `${pathLength - pathLength * progress}`;
   }
   return (
@@ -75,7 +75,7 @@ interface LoadingProps {
 
 const Loading = styled<LoadingProps & React.HTMLAttributes<SVGElement>>(LoadingComponent)`
   ${props =>
-    typeof props.progress === 'undefined' &&
+    !props.progress &&
     css`
       circle:nth-of-type(2) {
         transform-origin: 50% 50%;


### PR DESCRIPTION
## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes

The `props` for the `<Loading />` component have been defined as follows:

```js
interface LoadingComponentProps {
  progress?: number;
  size: number;
}
```

The declaration of `progress?: number;` is the same as `progress: number | undefined;` which is different from `progress: number | null;`. So we have been always expecting a `number` or `undefined` value for the `progress` property but our code was checking against `null` which is wrong in that case.
