### PR TITLE
fix(react-ui-kit): Add types for styled-components

### DIFF
--- a/packages/react-ui-kit/package.json
+++ b/packages/react-ui-kit/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@types/color": "3.0.0",
+    "@types/styled-components": "4.0.2",
     "bazinga64": "5.3.18",
     "color": "3.1.0",
     "react": "16.6.0",
@@ -18,7 +19,6 @@
     "@babel/preset-react": "7.0.0",
     "@babel/preset-typescript": "7.1.0",
     "@types/recompose": "0.27.0",
-    "@types/styled-components": "4.0.2",
     "babel-loader": "8.0.4",
     "react-helmet": "5.2.0",
     "react-hot-loader": "4.3.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9746,13 +9746,6 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-schedule@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
-  integrity sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==
-  dependencies:
-    object-assign "^4.1.1"
-
 scheduler@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.10.0.tgz#7988de90fe7edccc774ea175a783e69c40c521e1"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes

The `styled-components` are a listed under `dependencies`, so its types should also be listed under `dependencies` because it serves as library. We use the same approach already for the `color` dependency.
