### PR TITLE
fix(changelog-bot): Prevent empty changelogs from being posted

### DIFF
--- a/packages/changelog-bot/src/main/ChangelogBot.ts
+++ b/packages/changelog-bot/src/main/ChangelogBot.ts
@@ -78,11 +78,7 @@ class ChangelogBot {
     }
   }
 
-  static async generateChangelog(
-    repoSlug: string,
-    previousGitTag: string,
-    maximumChars?: number
-  ): Promise<string | undefined> {
+  static async generateChangelog(repoSlug: string, previousGitTag: string, maximumChars?: number): Promise<string> {
     const headlines = new RegExp('^#+ (.*)$', 'gm');
     const listItems = new RegExp('^\\* (.*) \\(\\[.*$', 'gm');
     const githubIssueLinks = new RegExp('\\[[^\\]]+\\]\\((https:[^)]+)\\)', 'gm');
@@ -95,7 +91,9 @@ class ChangelogBot {
     });
 
     if (!changelog.match(listItems)) {
-      return undefined;
+      const excludedTypes = ChangelogBot.SETUP.EXCLUDED_COMMIT_TYPES.join(', ');
+      const errorMessage = `Could not generate a meaningful changelog from the commit types given (excluded ${excludedTypes})`;
+      throw new Error(errorMessage);
     }
 
     let styledChangelog = changelog

--- a/packages/changelog-bot/src/main/ChangelogBot.ts
+++ b/packages/changelog-bot/src/main/ChangelogBot.ts
@@ -92,7 +92,7 @@ class ChangelogBot {
 
     if (!changelog.match(listItems)) {
       const excludedTypes = ChangelogBot.SETUP.EXCLUDED_COMMIT_TYPES.join(', ');
-      const errorMessage = `Could not generate a meaningful changelog from the commit types given (excluded ${excludedTypes})`;
+      const errorMessage = `Could not generate a meaningful changelog from the commit types given (excluded ${excludedTypes}).`;
       throw new Error(errorMessage);
     }
 

--- a/packages/changelog-bot/src/main/Start.ts
+++ b/packages/changelog-bot/src/main/Start.ts
@@ -52,10 +52,6 @@ export async function start(parameters: Parameters): Promise<void> {
 
   if (!message) {
     message = await ChangelogBot.generateChangelog(travisRepoSlug, travisCommitRange);
-    if (!message) {
-      const excluded = ChangelogBot.SETUP.EXCLUDED_COMMIT_TYPES.join(', ');
-      throw new Error(`Could not generate a meaningful changelog from the commit types given (excluded ${excluded}).`);
-    }
   }
 
   const messageData: ChangelogData = {

--- a/packages/changelog-bot/src/main/Start.ts
+++ b/packages/changelog-bot/src/main/Start.ts
@@ -52,6 +52,13 @@ export async function start(parameters: Parameters): Promise<void> {
 
   if (!message) {
     message = await ChangelogBot.generateChangelog(travisRepoSlug, travisCommitRange);
+    if (!message) {
+      throw new Error(
+        `Could not generate a meaningful changelog from the commit types given (excluded ${ChangelogBot.SETUP.EXCLUDED_COMMIT_TYPES.join(
+          ', '
+        )}).`
+      );
+    }
   }
 
   const messageData: ChangelogData = {

--- a/packages/changelog-bot/src/main/Start.ts
+++ b/packages/changelog-bot/src/main/Start.ts
@@ -53,11 +53,8 @@ export async function start(parameters: Parameters): Promise<void> {
   if (!message) {
     message = await ChangelogBot.generateChangelog(travisRepoSlug, travisCommitRange);
     if (!message) {
-      throw new Error(
-        `Could not generate a meaningful changelog from the commit types given (excluded ${ChangelogBot.SETUP.EXCLUDED_COMMIT_TYPES.join(
-          ', '
-        )}).`
-      );
+      const excluded = ChangelogBot.SETUP.EXCLUDED_COMMIT_TYPES.join(', ');
+      throw new Error(`Could not generate a meaningful changelog from the commit types given (excluded ${excluded}).`);
     }
   }
 


### PR DESCRIPTION
Sometimes our changes only include a `chore` or a `build`. These types (and some others) are excluded so in that scenario our bot posts empty changelogs:

**Screenshot**

![image](https://user-images.githubusercontent.com/469989/47572100-7b9cbc00-d93a-11e8-91a2-51fd3facf33d.png)

I refactored the code so that the bot is silent in such cases.