### PR TITLE
refactor(store-engine): Unify entry points

### DIFF
--- a/packages/store-engine/src/main/engine/IndexedDBEngine.ts
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.ts
@@ -51,15 +51,19 @@ export default class IndexedDBEngine implements CRUDEngine {
 
   public async init(storeName: string): Promise<DexieInstance> {
     await this.isSupported();
-    this.db = new Dexie(storeName);
-    this.storeName = this.db.name;
-    return this.db;
+    return this.assignDb(new Dexie(storeName));
   }
 
   public initWithDb(db: DexieInstance): Promise<DexieInstance> {
+    return Promise.resolve(this.assignDb(db));
+  }
+
+  // If you want to add listeners to the database and you don't care if it is a new database (init)
+  // or an existing (initWithDB) one, then this method is the right place to do it.
+  private assignDb(db: DexieInstance): DexieInstance {
     this.db = db;
     this.storeName = this.db.name;
-    return Promise.resolve(this.db);
+    return this.db;
   }
 
   public purge(): Promise<void> {

--- a/packages/store-engine/src/main/engine/IndexedDBEngine.ts
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.ts
@@ -4,6 +4,7 @@ import {LowDiskSpaceError, RecordTypeError, UnsupportedError} from './error/';
 import RecordAlreadyExistsError from './error/RecordAlreadyExistsError';
 import RecordNotFoundError from './error/RecordNotFoundError';
 
+// @see https://dexie.org/docs/Typescript#create-a-subclass
 export interface DexieInstance extends Dexie {
   [index: string]: any;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7126,8 +7126,8 @@ listr-silent-renderer@^1.1.1:
 
 listr-update-renderer@^0.4.0:
   version "0.4.0"
-  uid "06073fa93166277607a7814f4e1f83960081414c"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
+  integrity sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"


### PR DESCRIPTION
Our IndexedDB engine can be initialized with an existing database via `initWithEngine` or a completely new database (created by the engine itself) using `init`. Within the engine we don't know which entry point the application chose so I streamlined them into a `assignDb` function which can be used for modifying any given instance (no matter if new or pre-existing).

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes