### PR TITLE
fix(api-client,store-engine): Propagate database errors

### DIFF
--- a/packages/api-client/src/main/APIClient.ts
+++ b/packages/api-client/src/main/APIClient.ts
@@ -237,13 +237,15 @@ class APIClient {
         if (this.config.schemaCallback) {
           this.config.schemaCallback(db);
         } else {
-          throw new Error('Could not initialize database - missing schema definition');
+          const message = `Could not initialize store "${dbName}". Missing schema definition.`;
+          throw new Error(message);
         }
         // In case the database got purged, db.close() is called automatically and we have to reopen it.
         await db.open();
       }
     } catch (error) {
-      throw new Error(`Could not initialize database: "${error.message}`);
+      this.logger.error(`Could not initialize store "${dbName}": ${error.message}`);
+      throw error;
     }
     return this.config.store;
   }

--- a/packages/store-engine/src/main/engine/IndexedDBEngine.test.browser.js
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.test.browser.js
@@ -118,7 +118,26 @@ describe('IndexedDBEngine', () => {
       expect(hasEnoughQuota).toBe(true);
     });
 
-    it('throws an error if there is not enough disk space available', async done => {
+    it('throws an error if there is no quota available', async done => {
+      spyOn(navigator.storage, 'estimate').and.returnValue(
+        Promise.resolve({
+          quota: 26025,
+          usage: 26025,
+        })
+      );
+
+      engine = new IndexedDBEngine();
+
+      try {
+        await engine.hasEnoughQuota();
+        done.fail();
+      } catch (error) {
+        expect(error instanceof StoreEngineError.LowDiskSpaceError).toBe(true);
+        done();
+      }
+    });
+
+    it('throws an error if there is no quota is given', async done => {
       spyOn(navigator.storage, 'estimate').and.returnValue(
         Promise.resolve({
           quota: 0,

--- a/packages/store-engine/src/main/engine/IndexedDBEngine.test.browser.js
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.test.browser.js
@@ -114,8 +114,9 @@ describe('IndexedDBEngine', () => {
   describe('"hasEnoughQuota"', () => {
     it('says if there is enough storage available to use IndexedDB', async () => {
       engine = new IndexedDBEngine();
-      const hasEnoughQuota = await engine.hasEnoughQuota();
-      expect(hasEnoughQuota).toBe(true);
+      expect(async () => {
+        await engine.hasEnoughQuota();
+      }).not.toThrow();
     });
 
     it('throws an error if there is no quota available', async done => {

--- a/packages/store-engine/src/main/engine/IndexedDBEngine.ts
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.ts
@@ -36,9 +36,7 @@ export default class IndexedDBEngine implements CRUDEngine {
   }
 
   // @see https://developers.google.com/web/updates/2017/08/estimating-available-storage-space
-  private async hasEnoughQuota(): Promise<boolean> {
-    const hasEnoughQuota = true;
-
+  private async hasEnoughQuota(): Promise<void> {
     if ('storage' in navigator && 'estimate' in navigator.storage) {
       const {quota, usage} = await navigator.storage.estimate();
 
@@ -51,7 +49,7 @@ export default class IndexedDBEngine implements CRUDEngine {
       }
     }
 
-    return Promise.resolve(hasEnoughQuota);
+    return Promise.resolve();
   }
 
   public async isSupported(): Promise<void> {

--- a/packages/store-engine/src/main/engine/IndexedDBEngine.ts
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.ts
@@ -51,15 +51,19 @@ export default class IndexedDBEngine implements CRUDEngine {
 
   public async init(storeName: string): Promise<DexieInstance> {
     await this.isSupported();
-    this.db = new Dexie(storeName);
-    this.storeName = this.db.name;
-    return this.db;
+    return this.assignDb(new Dexie(storeName));
   }
 
   public initWithDb(db: DexieInstance): Promise<DexieInstance> {
+    return Promise.resolve(this.assignDb(db));
+  }
+
+  // If you want to add listeners to the database and you don't care if it is a new database (init)
+  // or an existing (initWithDB) one, then this method is the right place to do it.
+  private assignDb(db: DexieInstance): DexieInstance {
     this.db = db;
     this.storeName = this.db.name;
-    return Promise.resolve(this.db);
+    return this.db;
   }
 
   public purge(): Promise<void> {

--- a/packages/store-engine/src/main/engine/IndexedDBEngine.ts
+++ b/packages/store-engine/src/main/engine/IndexedDBEngine.ts
@@ -4,6 +4,7 @@ import {LowDiskSpaceError, RecordTypeError, UnsupportedError} from './error/';
 import RecordAlreadyExistsError from './error/RecordAlreadyExistsError';
 import RecordNotFoundError from './error/RecordNotFoundError';
 
+// @see https://dexie.org/docs/Typescript#create-a-subclass
 export interface DexieInstance extends Dexie {
   [index: string]: any;
 }

--- a/packages/store-engine/src/main/engine/error/LowDiskSpaceError.ts
+++ b/packages/store-engine/src/main/engine/error/LowDiskSpaceError.ts
@@ -1,5 +1,5 @@
 class LowDiskSpaceError extends Error {
-  constructor(public message: string) {
+  constructor(public message: string = 'Not enough storage to save the record.') {
     super(message);
     Object.setPrototypeOf(this, LowDiskSpaceError.prototype);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7126,8 +7126,8 @@ listr-silent-renderer@^1.1.1:
 
 listr-update-renderer@^0.4.0:
   version "0.4.0"
+  uid "06073fa93166277607a7814f4e1f83960081414c"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
-  integrity sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7126,8 +7126,8 @@ listr-silent-renderer@^1.1.1:
 
 listr-update-renderer@^0.4.0:
   version "0.4.0"
-  uid "06073fa93166277607a7814f4e1f83960081414c"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
+  integrity sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=
   dependencies:
     chalk "^1.1.3"
     cli-truncate "^0.2.1"


### PR DESCRIPTION
## Several improvements

### Propagate error from API Client

So far the API Client `initEngine` method was swalling unknown erros by creating a `new Error` which causes to lose the original errors instance and its source map. Now that's not the case anymore (replaced with `throw`).

### Streamline entry points for IndexedDB initialization

Our IndexedDB engine can be initialized with an existing database via `initWithEngine` or a completely new database (created by the engine itself) using `init`. Within the engine we don't know which entry point the application chose so I streamlined them into a `assignDb` function which can be used for modifying any given instance (no matter if new or pre-existing).

### More robust quota check

The `hasEnoughQuota` was so far only able to detect when there is no quota given. Now it can also detect if too much quota is consumed.

### Default message for LowDiskSpaceError

Title says it all.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes