### PR TITLE
refactor: Configure Husky through config file

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  "hooks": {
+    "pre-commit": "lint-staged"
+  }
+};

--- a/package.json
+++ b/package.json
@@ -15,11 +15,6 @@
     "tslint-config-prettier": "1.17.0",
     "tslint-plugin-prettier": "2.0.1"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "*.{js,jsx}": [
       "eslint --fix",


### PR DESCRIPTION
From Husky:

> Warning: Setting pre-commit script in package.json > scripts will be deprecated
Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file

- https://github.com/typicode/husky#upgrading-from-014