### PR TITLE
feat(changelog-bot): Exclude commit types, don't throw on empty changelog

### DIFF
--- a/packages/changelog-bot/src/main/Interfaces.ts
+++ b/packages/changelog-bot/src/main/Interfaces.ts
@@ -32,6 +32,7 @@ interface Parameters {
   conversationIds?: string;
   backend?: string;
   email: string;
+  excludeCommitTypes?: string[];
   message?: string;
   password: string;
   travisCommitRange: string;

--- a/packages/changelog-bot/src/main/Start.ts
+++ b/packages/changelog-bot/src/main/Start.ts
@@ -23,7 +23,7 @@ import {ChangelogBot} from './ChangelogBot';
 import {ChangelogData, LoginDataBackend, Parameters} from './Interfaces';
 
 export async function start(parameters: Parameters): Promise<void> {
-  const {backend, conversationIds, email, password, travisCommitRange, travisRepoSlug} = parameters;
+  const {backend, conversationIds, email, excludeCommitTypes, password, travisCommitRange, travisRepoSlug} = parameters;
   let message = parameters.message;
   const isCustomMessage = !!message;
 
@@ -51,7 +51,7 @@ export async function start(parameters: Parameters): Promise<void> {
   }
 
   if (!message) {
-    message = await ChangelogBot.generateChangelog(travisRepoSlug, travisCommitRange);
+    message = await ChangelogBot.generateChangelog(travisRepoSlug, travisCommitRange, undefined, excludeCommitTypes);
   }
 
   const messageData: ChangelogData = {

--- a/packages/changelog-bot/src/main/cli.ts
+++ b/packages/changelog-bot/src/main/cli.ts
@@ -44,12 +44,21 @@ program
   .option('-b, --backend <type>', 'Backend type ("production" or "staging")')
   .option('-s, --slug <slug>', 'A repo slug')
   .option('-r, --range <range>', 'The commit range')
+  .option('-x, --exclude-commit-types <type,...>', 'Commit types to exclude (e.g. chore,build,...)')
   .parse(process.argv);
+
+let excludeCommitTypes =
+  typeof program.excludeCommitTypes !== 'undefined' ? program.excludeCommitTypes : process.env.EXCLUDE_COMMIT_TYPES;
+
+if (typeof excludeCommitTypes !== 'undefined') {
+  excludeCommitTypes = excludeCommitTypes.includes(',') ? excludeCommitTypes.split(',') : [excludeCommitTypes];
+}
 
 const parameters: Parameters = {
   backend: program.backend,
   conversationIds: program.conversations || process.env.WIRE_CHANGELOG_BOT_CONVERSATION_IDS,
   email: program.email || process.env.WIRE_CHANGELOG_BOT_EMAIL,
+  excludeCommitTypes,
   message: program.message,
   password: program.password || process.env.WIRE_CHANGELOG_BOT_PASSWORD,
   travisCommitRange: program.range || process.env.TRAVIS_COMMIT_RANGE,


### PR DESCRIPTION
You can now run the changelog bot with the flag `-x` to customize the excluded commit types, e.g.
```
changelog-bot -e my@email.com -p mysecretpassword -c 1234 -x chore,build
```

To allow all commit types, simply use `-x ""`.

Furthermore, if the bot is unable to generate a changelog, it will display a warning and exit gracefully.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
