### PR TITLE
chore(copy-config): Enable logger by default

### DIFF
--- a/packages/copy-config/README.md
+++ b/packages/copy-config/README.md
@@ -32,12 +32,6 @@ Additionally, some parameters can be set via environment variables (which then t
 | `files`         | `WIRE_CONFIGURATION_FILES`        | `/path/to/source.txt:/path/to/destination.txt;/path/to/source/:/path/to/destination/` |
 | `repositoryUrl` | `WIRE_CONFIGURATION_REPOSITORY`   | `/path/to/anotherDir/*:[/path/to/thirdDir/,/path/to/destinationDir/]`                 |
 
-If you need logging, set the `NODE_DEBUG` environment variable:
-
-```sh
-export NODE_DEBUG="@wireapp/copy-config/*"
-```
-
 ### CLI Usage
 
 ```

--- a/packages/copy-config/src/main/CopyConfig.ts
+++ b/packages/copy-config/src/main/CopyConfig.ts
@@ -70,6 +70,7 @@ export class CopyConfig {
     this.logger = logdown('@wireapp/copy-config/CopyConfig', {
       markdown: false,
     });
+    this.logger.state.isEnabled = true;
   }
 
   private readEnvVars(): void {

--- a/packages/copy-config/src/main/cli.ts
+++ b/packages/copy-config/src/main/cli.ts
@@ -28,6 +28,7 @@ const configExplorer = cosmiconfig('copyconfig');
 const logger = logdown('@wireapp/copy-config/cli', {
   markdown: false,
 });
+logger.state.isEnabled = true;
 
 configExplorer
   .search()


### PR DESCRIPTION
I figured that, by default, we want to know which files were copied.

## Pull Request Checklist

- [ ] ~~My code is covered by tests~~
- [ ] ~~I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes~~
