### PR TITLE
fix(commons): Don't print undefined namespace in log messages

### DIFF
--- a/packages/commons/src/main/LogFactory.test.js
+++ b/packages/commons/src/main/LogFactory.test.js
@@ -25,6 +25,11 @@ describe('LogFactory', () => {
       const loggerName = LogFactory.createLoggerName('LogFactory', '@wireapp/commons', '::');
       expect(loggerName).toBe('@wireapp/commons::LogFactory');
     });
+
+    it('does not add empty strings to the logger name', () => {
+      const loggerName = LogFactory.createLoggerName('LogFactory', '', '::');
+      expect(loggerName).toBe('LogFactory');
+    });
   });
 
   describe('getLogger', () => {

--- a/packages/commons/src/main/LogFactory.ts
+++ b/packages/commons/src/main/LogFactory.ts
@@ -88,22 +88,22 @@ class LogFactory {
     }
   }
 
-  static createLoggerName(fileName: string, namespace: string, separator: string): string {
+  static createLoggerName(fileName: string, namespace?: string, separator?: string): string {
     if (typeof window === 'undefined') {
       fileName = path.basename(fileName, path.extname(fileName));
     }
-    return [namespace, fileName].join(separator);
+    return [namespace, fileName].filter(Boolean).join(separator);
   }
 
   static getLogger(name: string, options?: LoggerOptions): logdown.Logger {
-    const defaults = {
+    const defaults: LoggerOptions = {
       color: LogFactory.getColor(),
       forceEnable: false,
       logFilePath: '',
-      namespace: typeof window === 'undefined' ? String(process.env.npm_package_name) : '',
+      namespace: typeof window === 'undefined' ? process.env.npm_package_name || '' : '',
       separator: '::',
     };
-    const config = {...defaults, ...options};
+    const config: LoggerOptions = {...defaults, ...options};
 
     if (logdown.transports.length === 0) {
       logdown.transports.push(LogFactory.addTimestamp.bind({namespace: config.namespace}));


### PR DESCRIPTION
When running Node.js code not via a npm script, then `process.env.npm_package_name` is undefined and cannot be used to autodetect a namespace. In that case we have been showing `undefined` which is now replaced by an empty string.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
