### PR TITLE
feat(commons): Expose log writing errors

### DIFF
--- a/packages/commons/src/main/LogFactory.ts
+++ b/packages/commons/src/main/LogFactory.ts
@@ -78,14 +78,10 @@ class LogFactory {
 
   static async writeMessage(message: string, logFilePath: string): Promise<void> {
     const withoutColor = message.replace(ansiRegex(), '');
-    try {
-      await fs.outputFile(logFilePath, `${withoutColor}\r\n`, {
-        encoding: 'utf8',
-        flag: 'a',
-      });
-    } catch (error) {
-      console.warn(`Cannot write to log file "${this.logFilePath}": ${error.message}`, error);
-    }
+    return fs.outputFile(logFilePath, `${withoutColor}\r\n`, {
+      encoding: 'utf8',
+      flag: 'a',
+    });
   }
 
   static createLoggerName(fileName: string, namespace?: string, separator?: string): string {


### PR DESCRIPTION
@ffflorian After working with our wrapper I realized that it's better if the consuming application handles errors from our common module. Especially when using a linter that warns you about "floating promises" because then you would need to wrap a call to a promise anyway with a try-catch block.

See: https://github.com/wireapp/wire-desktop/pull/2316/commits/9104c1c364437a6411f47c57801ab3ae4240b0e6#diff-acab454f418662fe6f697507e4c4103aR401

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
