### PR TITLE
fix(copy-config): Download only if git is not available

### DIFF
--- a/packages/copy-config/.gitignore
+++ b/packages/copy-config/.gitignore
@@ -1,1 +1,2 @@
 .temp
+config

--- a/packages/copy-config/src/main/CopyConfig.test.js
+++ b/packages/copy-config/src/main/CopyConfig.test.js
@@ -131,7 +131,7 @@ describe('CopyConfig', () => {
     });
 
     it(
-      'downloads zip archives',
+      'downloads zip archives from an https url',
       async () => {
         await fs.ensureDir(TEMP_DIR);
         await fs.writeFile(path.join(TEMP_DIR, 'test1.txt'), '');
@@ -140,6 +140,7 @@ describe('CopyConfig', () => {
           files: {
             './package.json': TEMP_DIR,
           },
+          forceDownload: true,
           repositoryUrl: 'https://github.com/wireapp/wire-web-config-default#master',
         });
 
@@ -151,6 +152,28 @@ describe('CopyConfig', () => {
       TWENTY_SECONDS
     );
   });
+
+  it(
+    'downloads zip archives from a git url',
+    async () => {
+      await fs.ensureDir(TEMP_DIR);
+      await fs.writeFile(path.join(TEMP_DIR, 'test1.txt'), '');
+
+      const copyConfig = new CopyConfig({
+        files: {
+          './package.json': TEMP_DIR,
+        },
+        forceDownload: true,
+        repositoryUrl: 'git@github.com:wireapp/wire-web-config-default#master',
+      });
+
+      await copyConfig.copy();
+
+      const files = await fs.readdir(copyConfig.baseDir);
+      expect(files).toContain('wire-webapp');
+    },
+    TWENTY_SECONDS
+  );
 
   describe('getFilesFromString', () => {
     it('is compatible with Windows paths', () => {

--- a/packages/copy-config/src/main/CopyConfig.ts
+++ b/packages/copy-config/src/main/CopyConfig.ts
@@ -164,7 +164,8 @@ export class CopyConfig {
 
     if (stderrVersion || this.options.forceDownload) {
       if (bareUrl.startsWith('git')) {
-        bareUrl = bareUrl.replace(/^git(?::\/\/([^@]+@)?|@)([^:]+):(.*)(?:\.git)?/, 'https://$1$2/$3');
+        const gitProtocolRegex = new RegExp('^git(?::\\/\\/([^@]+@)?|@)([^:]+):(.*)(?:\\.git)?');
+        bareUrl = bareUrl.replace(gitProtocolRegex, 'https://$1$2/$3');
       }
       const url = `${bareUrl}/archive/${branch}.zip`;
       this.logger.info(`Downloading "${url}" ...`);

--- a/packages/copy-config/src/main/CopyConfig.ts
+++ b/packages/copy-config/src/main/CopyConfig.ts
@@ -27,6 +27,7 @@ import * as utils from './utils';
 const defaultOptions: Required<CopyConfigOptions> = {
   externalDir: '',
   files: {},
+  forceDownload: false,
   repositoryUrl: 'https://github.com/wireapp/wire-web-config-default#master',
 };
 
@@ -151,23 +152,20 @@ export class CopyConfig {
     let bareUrl = repositoryData[0];
     const branch = repositoryData[1] || 'master';
     const {stderr: stderrVersion} = await utils.execAsync('git --version');
-    let isHttpUrl = bareUrl.startsWith('http');
-
-    if (!isHttpUrl && stderrVersion) {
-      this.logger.error(`No git installation found: ${stderrVersion}. Trying to download the zip file ...`);
-      bareUrl = bareUrl
-        .replace(/^git(@|:\/\/)/, 'https://')
-        .replace(':', '/')
-        .replace(/\.git$/, '');
-      isHttpUrl = true;
-    }
 
     if (!this.noCleanup) {
       this.logger.info(`Removing clone directory before cloning ...`);
       await utils.rimrafAsync(this.baseDir);
     }
 
-    if (isHttpUrl) {
+    if (stderrVersion) {
+      this.logger.error(`No git installation found: (error: "${stderrVersion}"). Trying to download the zip file ...`);
+    }
+
+    if (stderrVersion || this.options.forceDownload) {
+      if (bareUrl.startsWith('git')) {
+        bareUrl = bareUrl.replace(/^git(?::\/\/([^@]+@)?|@)([^:]+):(.*)(?:\.git)?/, 'https://$1$2/$3');
+      }
       const url = `${bareUrl}/archive/${branch}.zip`;
       this.logger.info(`Downloading "${url}" ...`);
       await utils.downloadFileAsync(url, this.baseDir);

--- a/packages/copy-config/src/main/CopyConfigOptions.ts
+++ b/packages/copy-config/src/main/CopyConfigOptions.ts
@@ -40,6 +40,8 @@ export interface CopyConfigOptions {
   files?: {
     [source: string]: string | string[];
   };
+  /** Force using HTTPS download over `git clone` */
+  forceDownload?: boolean;
   /**
    * From where to clone the configuration.
    *


### PR DESCRIPTION
Downloading over HTTP(s) was slower than expected.
Let's clone with `git` if it is available and only download over HTTP(s) if it is not.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
