### PR TITLE
chore: Keep comments when building

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": false,
-    "removeComments": true,
+    "removeComments": false,
     "sourceMap": true,
     "strict": true,
     "target": "es5"


### PR DESCRIPTION
When removing comments, all JSDoc comments are removed, too.
It would be great to have JSDoc in the declaration files.

## Pull Request Checklist

- [ ] ~~My code is covered by tests~~
- [ ] ~~I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes~~
