### PR TITLE
chore: Enforce modern versions of node and yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "engines": {
     "node": ">= 10",
-    "yarn": ">= 1.10.0"
+    "yarn": ">= 1"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tslint-react-hooks": "2.0.0"
   },
   "engines": {
-    "node": "10.x.x",
+    "node": ">= 10",
     "yarn": "1.x.x"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "engines": {
     "node": ">= 10",
-    "yarn": "1.x.x"
+    "yarn": ">= 1.10.0"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "tslint-react": "3.6.0",
     "tslint-react-hooks": "2.0.0"
   },
+  "engines": {
+    "node": "10.x.x",
+    "yarn": "1.x.x"
+  },
   "lint-staged": {
     "*.{js,jsx}": [
       "eslint --fix",


### PR DESCRIPTION
Currently when you try to run `yarn && yarn boot` with yarn v0.15 it will fail because we need a very recent version of yarn. 

@ffflorian Do you know which version of yarn enforced https links in `yarn.lock` file? Then we could even make this our lower end requirement.