### PR TITLE
chore: Raise TS output to ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "tslint-react-hooks": "2.0.0"
   },
   "engines": {
-    "node": ">= 10",
+    "node": ">= 10.9",
     "yarn": ">= 1"
   },
   "lint-staged": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["dom", "es2016", "es2017.object", "es2017.string"],
+    "lib": ["dom", "esnext"],
     "jsx": "react",
     "module": "commonjs",
     "moduleResolution": "node",
@@ -13,6 +13,6 @@
     "removeComments": false,
     "sourceMap": true,
     "strict": true,
-    "target": "es5"
+    "target": "es6"
   }
 }


### PR DESCRIPTION
Follow-up to #1667.

I was wondering why we don't enable all available ES libs since they will be transpiled to ES5 (now ES6) anyway.