### PR TITLE
chore(eslint-config): Use "error" instead of 2

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -15,59 +15,59 @@
   },
   "plugins": ["prettier", "no-unsanitized", "jsdoc", "react"],
   "rules": {
-    "curly": 2,
-    "dot-notation": 2,
-    "id-length": 2,
-    "jsdoc/require-hyphen-before-param-description": 2,
+    "curly": "error",
+    "dot-notation": "error",
+    "id-length": "error",
+    "jsdoc/require-hyphen-before-param-description": "error",
     "no-console": [
-      2,
+      "error",
       {
         "allow": ["error", "info"]
       }
     ],
-    "no-const-assign": 2,
-    "no-dupe-class-members": 2,
-    "no-else-return": 2,
-    "no-inner-declarations": 2,
-    "no-lonely-if": 2,
+    "no-const-assign": "error",
+    "no-dupe-class-members": "error",
+    "no-else-return": "error",
+    "no-inner-declarations": "error",
+    "no-lonely-if": "error",
     "no-magic-numbers": [
-      2,
+      "error",
       {
         "ignore": [-1, 0, 1, 2]
       }
     ],
-    "no-shadow": 2,
-    "no-undef": 2,
-    "no-unneeded-ternary": 2,
-    "no-unused-expressions": 2,
+    "no-shadow": "error",
+    "no-undef": "error",
+    "no-unneeded-ternary": "error",
+    "no-unused-expressions": "error",
     "no-unused-vars": [
-      2,
+      "error",
       {
         "args": "none"
       }
     ],
-    "no-useless-return": 2,
-    "no-var": 2,
-    "one-var": [2, "never"],
-    "prefer-arrow-callback": 2,
-    "prefer-const": 2,
-    "prefer-promise-reject-errors": 2,
-    "prefer-spread": 2,
-    "prefer-template": 2,
-    "prettier/prettier": 2,
-    "react/prefer-stateless-function": 2,
-    "react/prop-types": 0,
-    "sort-imports": 2,
+    "no-useless-return": "error",
+    "no-var": "error",
+    "one-var": ["error", "never"],
+    "prefer-arrow-callback": "error",
+    "prefer-const": "error",
+    "prefer-promise-reject-errors": "error",
+    "prefer-spread": "error",
+    "prefer-template": "error",
+    "prettier/prettier": "error",
+    "react/prefer-stateless-function": "error",
+    "react/prop-types": "off",
+    "sort-imports": "error",
     "sort-keys": [
-      2,
+      "error",
       "asc",
       {
         "caseSensitive": true,
         "natural": true
       }
     ],
-    "sort-vars": 2,
-    "strict": [2, "global"],
+    "sort-vars": "error",
+    "strict": ["error", "global"],
     "valid-jsdoc": [
       "error",
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,6 +1979,16 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@wireapp/eslint-config@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@wireapp/eslint-config/-/eslint-config-0.0.8.tgz#1667144fe615c643cd40ccfbaf649c69ef3959b7"
+  integrity sha512-yfG1wsf/0vKFYSGvC+cEtDnwYOJfc1gp0I3O8yD5uwFz+x6URcJDLQ4P7KnqM18+lmqf4VVVn6s2VRDMuWIa4Q==
+
+"@wireapp/prettier-config@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@wireapp/prettier-config/-/prettier-config-0.1.0.tgz#9013de56087eb865b7fd3559d6d3a81558573719"
+  integrity sha512-/NnQFYE+Hbz46Cfz3NhiOT9JxfaKFON4lHI+qzg19Zb2d8B0pxd/I6HZRSRH6ofV29IP+OT+IynvUFQOO2WUpg==
+
 "@wireapp/protocol-messaging@1.23.0":
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/@wireapp/protocol-messaging/-/protocol-messaging-1.23.0.tgz#aa26b96eb0933c9b95d34d9502098d7c582036a0"


### PR DESCRIPTION
`"error"` is more explicit and understandable than `2`.

See https://eslint.org/docs/user-guide/configuring#configuring-rules.