### PR TITLE
feat(api-client): Ship source code for source maps

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -46,7 +46,8 @@
   },
   "description": "Wire API Client to send and receive data.",
   "files": [
-    "dist/commonjs"
+    "dist/commonjs",
+    "src/main"
   ],
   "license": "GPL-3.0",
   "main": "./dist/commonjs/APIClient.js",


### PR DESCRIPTION
Source maps link to source code files, so they need the source code to be published to generate valid maps:

**Example**

```json
{
  "file": "WebSocketClient.js",
  "mappings": "...",
  "names": [],
  "sourceRoot": "",
  "sources": [
    "../../../src/main/tcp/WebSocketClient.ts"
  ],
  "version": 3
}
```