### PR TITLE
chore: Better publish messages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "publish": {
       "allowBranch": "master",
       "conventionalCommits": true,
-      "message": "[skip ci] chore: Publish"
+      "message": "chore: Publish [skip ci]"
     }
   },
   "exact": true,


### PR DESCRIPTION
The "publish" commit messages actually don't follow semantic commit messages since they are not starting with `chore`.