### PR TITLE
feat(commons): Remove Omit and use types (BREAKING)

### DIFF
--- a/packages/commons/src/main/util/TypeUtil.ts
+++ b/packages/commons/src/main/util/TypeUtil.ts
@@ -29,14 +29,3 @@ export type RecursivePartial<T> = {
     ? RecursivePartial<T[P]>
     : T[P];
 };
-
-/**
- * Creates a type from a given interface but excludes the selected keys
- * ```
- * interface AB {a: string, b: string};
- * type ABwithoutA = Omit<AB, "a">;
- * ```
- * @see https://stackoverflow.com/questions/48215950/exclude-property-from-type
- * @since TypeScript 2.8
- */
-export type Omit<T, U> = Pick<T, Exclude<keyof T, U>>;

--- a/packages/react-ui-kit/src/Form/Checkbox.tsx
+++ b/packages/react-ui-kit/src/Form/Checkbox.tsx
@@ -98,7 +98,7 @@ export const Checkbox: React.FC<CheckboxProps<HTMLInputElement>> = React.forward
   </div>
 ));
 
-export interface CheckboxLabelProps<T = HTMLSpanElement> extends TextProps<T> {}
+export type CheckboxLabelProps<T = HTMLSpanElement> = TextProps<T>;
 
 export const CheckboxLabel = ({
   bold = true,

--- a/packages/react-ui-kit/src/Form/CodeInput.tsx
+++ b/packages/react-ui-kit/src/Form/CodeInput.tsx
@@ -33,7 +33,7 @@ const CodeInputWrapper = (props: React.HTMLProps<HTMLDivElement>) => (
   />
 );
 
-interface DigitInputProps<T = HTMLInputElement> extends InputProps<T> {}
+type DigitInputProps<T = HTMLInputElement> = InputProps<T>;
 
 const digitInputStyle: <T>(props: DigitInputProps<T>) => ObjectInterpolation<undefined> = props => ({
   ...inputStyle(props),

--- a/packages/react-ui-kit/src/Form/ErrorMessage.tsx
+++ b/packages/react-ui-kit/src/Form/ErrorMessage.tsx
@@ -22,7 +22,7 @@ import {ObjectInterpolation, jsx} from '@emotion/core';
 import {COLOR} from '../Identity';
 import {Text, TextProps, linkStyle, textStyle} from '../Text';
 
-interface ErrorMessageProps<T = HTMLSpanElement> extends TextProps<T> {}
+type ErrorMessageProps<T = HTMLSpanElement> = TextProps<T>;
 
 export const errorMessageStyle: <T>(props: ErrorMessageProps<T>) => ObjectInterpolation<undefined> = ({
   bold = true,

--- a/packages/react-ui-kit/src/Form/InputBlock.tsx
+++ b/packages/react-ui-kit/src/Form/InputBlock.tsx
@@ -23,7 +23,7 @@ import {COLOR} from '../Identity';
 import {INPUT_CLASSNAME} from './Input';
 import {INPUT_SUBMIT_COMBO_CLASSNAME} from './InputSubmitCombo';
 
-export interface InputBlockProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type InputBlockProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 const inputBlockStyle: (props: InputBlockProps) => ObjectInterpolation<undefined> = props => ({
   backgroundColor: COLOR.GRAY_LIGHTEN_88,

--- a/packages/react-ui-kit/src/Form/InputSubmitCombo.tsx
+++ b/packages/react-ui-kit/src/Form/InputSubmitCombo.tsx
@@ -21,7 +21,7 @@
 import {jsx} from '@emotion/core';
 import {INPUT_CLASSNAME, InputProps, inputStyle} from './Input';
 
-export interface InputSubmitComboProps<T = HTMLDivElement> extends InputProps<T> {}
+export type InputSubmitComboProps<T = HTMLDivElement> = InputProps<T>;
 
 export const INPUT_SUBMIT_COMBO_CLASSNAME = 'inputSubmitCombo';
 

--- a/packages/react-ui-kit/src/Layout/Box.tsx
+++ b/packages/react-ui-kit/src/Layout/Box.tsx
@@ -22,7 +22,7 @@ import {ObjectInterpolation, jsx} from '@emotion/core';
 import React from 'react';
 import {COLOR} from '../Identity';
 
-export interface BoxProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type BoxProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 export const boxStyle: <T>(props: BoxProps<T>) => ObjectInterpolation<undefined> = props => ({
   border: `2px solid ${COLOR.GRAY_LIGHTEN_72}`,

--- a/packages/react-ui-kit/src/Layout/Column.tsx
+++ b/packages/react-ui-kit/src/Layout/Column.tsx
@@ -22,7 +22,7 @@ import {ObjectInterpolation, jsx} from '@emotion/core';
 import {QueryKeys, media} from '../mediaQueries';
 import {GUTTER} from './sizes';
 
-export interface ColumnsProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type ColumnsProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 const columnsStyle: <T>(props: ColumnsProps<T>) => ObjectInterpolation<undefined> = props => ({
   display: 'flex',
@@ -32,7 +32,7 @@ const columnsStyle: <T>(props: ColumnsProps<T>) => ObjectInterpolation<undefined
 
 export const Columns = (props: ColumnsProps) => <div css={columnsStyle(props)} {...props} />;
 
-export interface ColumnProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type ColumnProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 const columnStyle: <T>(props: ColumnProps<T>) => ObjectInterpolation<undefined> = props => ({
   display: 'block',

--- a/packages/react-ui-kit/src/Layout/Container.tsx
+++ b/packages/react-ui-kit/src/Layout/Container.tsx
@@ -21,7 +21,7 @@
 import {ObjectInterpolation, jsx} from '@emotion/core';
 import React from 'react';
 import {QueryKeys, media} from '../mediaQueries';
-import {Omit, filterProps} from '../util';
+import {filterProps} from '../util';
 import {GUTTER, WIDTH} from './sizes';
 
 export interface ContainerProps<T = HTMLDivElement> extends React.HTMLProps<T> {
@@ -70,7 +70,7 @@ export const Container: React.FC<ContainerProps> = React.forwardRef<HTMLDivEleme
   <div ref={ref} css={containerStyle(props)} {...filterContainerProps(props)} />
 ));
 
-export interface LevelContainerProps extends Omit<ContainerProps, 'level'> {}
+export type LevelContainerProps = Omit<ContainerProps, 'level'>;
 
 export const ContainerLG = React.forwardRef<HTMLDivElement, LevelContainerProps>((props, ref) => (
   <Container ref={ref} level={'lg'} {...props} />

--- a/packages/react-ui-kit/src/Layout/Content.tsx
+++ b/packages/react-ui-kit/src/Layout/Content.tsx
@@ -21,7 +21,7 @@
 import {ObjectInterpolation, jsx} from '@emotion/core';
 import {GUTTER} from './sizes';
 
-export interface ContentProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type ContentProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 export const contentStyle: <T>(props: ContentProps<T>) => ObjectInterpolation<undefined> = props => ({
   display: 'flex',

--- a/packages/react-ui-kit/src/Layout/Footer.tsx
+++ b/packages/react-ui-kit/src/Layout/Footer.tsx
@@ -20,6 +20,6 @@
 /** @jsx jsx */
 import {jsx} from '@emotion/core';
 
-interface FooterProps extends React.HTMLProps<HTMLElement> {}
+type FooterProps = React.HTMLProps<HTMLElement>;
 
 export const Footer = (props: FooterProps) => <footer {...props} />;

--- a/packages/react-ui-kit/src/Layout/Header.tsx
+++ b/packages/react-ui-kit/src/Layout/Header.tsx
@@ -20,7 +20,7 @@
 /** @jsx jsx */
 import {ObjectInterpolation, jsx} from '@emotion/core';
 
-export interface HeaderProps<T = HTMLHeadingElement> extends React.HTMLProps<T> {}
+export type HeaderProps<T = HTMLHeadingElement> = React.HTMLProps<T>;
 
 export const headerStyle: <T>(props: HeaderProps<T>) => ObjectInterpolation<undefined> = props => ({
   alignItems: 'center',

--- a/packages/react-ui-kit/src/Layout/MatchMedia.tsx
+++ b/packages/react-ui-kit/src/Layout/MatchMedia.tsx
@@ -21,7 +21,6 @@
 import {jsx} from '@emotion/core';
 import React, {ReactFragment, useEffect, useState} from 'react';
 import {QUERY, QueryKeys} from '../mediaQueries';
-import {Omit} from '../util';
 
 type Query = string | keyof QueryKeys;
 
@@ -51,7 +50,7 @@ export const MatchMedia: React.FC<MatchMediaProps> = ({query, children, not}) =>
   return <React.Fragment>{isMatching ? children : null}</React.Fragment>;
 };
 
-export interface NamedMatchMediaProps extends Omit<MatchMediaProps, 'query'> {}
+export type NamedMatchMediaProps = Omit<MatchMediaProps, 'query'>;
 
 export const IsDesktop = (props: NamedMatchMediaProps) => <MatchMedia query={QueryKeys.DESKTOP} {...props} />;
 export const IsDesktopXL = (props: NamedMatchMediaProps) => <MatchMedia query={QueryKeys.DESKTOP_XL} {...props} />;

--- a/packages/react-ui-kit/src/Layout/headerMenu/HeaderSubMenu.tsx
+++ b/packages/react-ui-kit/src/Layout/headerMenu/HeaderSubMenu.tsx
@@ -24,7 +24,7 @@ import {DURATION} from '../../Identity/motions';
 import {QUERY} from '../../mediaQueries';
 import {MenuSubLink} from './MenuSubLink';
 
-export interface DesktopStyledHeaderSubMenuProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type DesktopStyledHeaderSubMenuProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 const desktopStyledHeaderSubMenuStyle: (
   props: DesktopStyledHeaderSubMenuProps

--- a/packages/react-ui-kit/src/Layout/headerMenu/MenuSubLink.tsx
+++ b/packages/react-ui-kit/src/Layout/headerMenu/MenuSubLink.tsx
@@ -25,7 +25,7 @@ import {defaultTransition} from '../../Identity/motions';
 import {QueryKeys, media} from '../../mediaQueries';
 import {TextProps, textStyle} from '../../Text';
 
-interface MenuSubLinkProps<T = HTMLDivElement> extends TextProps<T> {}
+type MenuSubLinkProps<T = HTMLDivElement> = TextProps<T>;
 
 export const menuSubLinkStyle: <T>(props: MenuSubLinkProps<T>) => ObjectInterpolation<undefined> = props => ({
   ...textStyle(props),

--- a/packages/react-ui-kit/src/Menu/MenuModal.tsx
+++ b/packages/react-ui-kit/src/Menu/MenuModal.tsx
@@ -102,7 +102,7 @@ export const MenuModal = ({
   </MenuModalWrapper>
 );
 
-export interface MenuItemProps<T = HTMLLIElement> extends React.HTMLProps<T> {}
+export type MenuItemProps<T = HTMLLIElement> = React.HTMLProps<T>;
 
 export const MenuItem = ({children = null, ...props}: MenuItemProps & React.HTMLProps<HTMLLIElement>) => (
   <li

--- a/packages/react-ui-kit/src/Menu/TabBar.tsx
+++ b/packages/react-ui-kit/src/Menu/TabBar.tsx
@@ -24,7 +24,7 @@ import {COLOR} from '../Identity';
 import {TextProps, textStyle} from '../Text';
 import {filterProps} from '../util';
 
-export interface TabBarProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type TabBarProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 const tabBarStyle: <T>(props: TabBarProps<T>) => ObjectInterpolation<undefined> = ({}) => {
   return {

--- a/packages/react-ui-kit/src/Modal/Overlay.tsx
+++ b/packages/react-ui-kit/src/Modal/Overlay.tsx
@@ -24,7 +24,7 @@ import {COLOR} from '../Identity';
 import {ANIMATION, DURATION, EASE} from '../Identity/motions';
 import {QueryKeys, media} from '../mediaQueries';
 
-export interface OverlayWrapperProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type OverlayWrapperProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 export const overlayWrapperStyle: <T>(props: OverlayWrapperProps<T>) => ObjectInterpolation<undefined> = () => ({
   bottom: 0,
@@ -64,7 +64,7 @@ export const OverlayContent = (props: React.HTMLProps<HTMLDivElement>) => (
   />
 );
 
-export interface OverlayBackgroundProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type OverlayBackgroundProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 export const overlayBackgroundStyle: <T>(props: OverlayBackgroundProps<T>) => ObjectInterpolation<undefined> = () => ({
   animation: `${ANIMATION.fadeIn} ${DURATION.PROACTIVE_SLOW}ms ${EASE.QUART}`,
@@ -79,7 +79,7 @@ export const overlayBackgroundStyle: <T>(props: OverlayBackgroundProps<T>) => Ob
 
 export const OverlayBackground = (props: OverlayBackgroundProps) => <div css={overlayBackgroundStyle} {...props} />;
 
-export interface OverlayProps<T = HTMLDivElement> extends React.HTMLProps<T> {}
+export type OverlayProps<T = HTMLDivElement> = React.HTMLProps<T>;
 
 export const Overlay = ({children = null, ...props}: OverlayProps) => (
   <OverlayWrapper {...props} data-uie-name="modal">

--- a/packages/react-ui-kit/src/Text/Label.tsx
+++ b/packages/react-ui-kit/src/Text/Label.tsx
@@ -23,7 +23,7 @@ import {COLOR} from '../Identity';
 import {LinkProps, linkStyle} from './Link';
 import {TextProps, filterTextProps, textStyle} from './Text';
 
-export interface LabelProps<T = HTMLSpanElement> extends TextProps<T> {}
+export type LabelProps<T = HTMLSpanElement> = TextProps<T>;
 
 const labelStyle: <T>(props: LabelProps<T>) => ObjectInterpolation<undefined> = ({
   bold = true,
@@ -36,7 +36,7 @@ const labelStyle: <T>(props: LabelProps<T>) => ObjectInterpolation<undefined> = 
 
 export const Label = (props: LabelProps) => <span css={labelStyle(props)} {...filterTextProps(props)} />;
 
-export interface LabelLinkProps<T = HTMLAnchorElement> extends LinkProps<T> {}
+export type LabelLinkProps<T = HTMLAnchorElement> = LinkProps<T>;
 
 const labelLinkStyle: <T>(props: LabelLinkProps<T>) => ObjectInterpolation<undefined> = ({
   fontSize = '12px',

--- a/packages/react-ui-kit/src/Text/Paragraph.tsx
+++ b/packages/react-ui-kit/src/Text/Paragraph.tsx
@@ -22,7 +22,7 @@ import {ObjectInterpolation, jsx} from '@emotion/core';
 import {QueryKeys, media} from '../mediaQueries';
 import {TextProps, filterTextProps, textStyle} from './Text';
 
-export interface ParagraphProps<T = HTMLParagraphElement> extends TextProps<T> {}
+export type ParagraphProps<T = HTMLParagraphElement> = TextProps<T>;
 
 export const paragraphStyle: <T>(props: ParagraphProps<T>) => ObjectInterpolation<undefined> = ({
   block = true,
@@ -35,7 +35,7 @@ export const paragraphStyle: <T>(props: ParagraphProps<T>) => ObjectInterpolatio
 
 export const Paragraph = (props: ParagraphProps) => <p css={paragraphStyle(props)} {...filterTextProps(props)} />;
 
-export interface LeadProps<T = HTMLParagraphElement> extends TextProps<T> {}
+export type LeadProps<T = HTMLParagraphElement> = TextProps<T>;
 
 export const leadStyle: <T>(props: LeadProps<T>) => ObjectInterpolation<undefined> = ({
   block = true,

--- a/packages/react-ui-kit/src/Text/TextLink.tsx
+++ b/packages/react-ui-kit/src/Text/TextLink.tsx
@@ -22,7 +22,7 @@ import {ObjectInterpolation, jsx} from '@emotion/core';
 import {COLOR} from '../Identity';
 import {LinkProps, filterLinkProps, linkStyle} from './Link';
 
-export interface TextLinkProps<T = HTMLAnchorElement> extends LinkProps<T> {}
+export type TextLinkProps<T = HTMLAnchorElement> = LinkProps<T>;
 
 export const textLinkStyle: <T>(props: TextLinkProps<T>) => ObjectInterpolation<undefined> = ({
   color = COLOR.BLUE,

--- a/packages/react-ui-kit/src/Text/Title.tsx
+++ b/packages/react-ui-kit/src/Text/Title.tsx
@@ -22,7 +22,7 @@ import {ObjectInterpolation, jsx} from '@emotion/core';
 import {COLOR} from '../Identity';
 import {TextProps, filterTextProps, textStyle} from './Text';
 
-export interface TitleProps<T = HTMLDivElement> extends TextProps<T> {}
+export type TitleProps<T = HTMLDivElement> = TextProps<T>;
 
 const titleStyle: <T>(props: TitleProps<T>) => ObjectInterpolation<undefined> = ({
   block = true,

--- a/packages/react-ui-kit/src/util.ts
+++ b/packages/react-ui-kit/src/util.ts
@@ -17,8 +17,6 @@
  *
  */
 
-export type Omit<T, U> = Pick<T, Exclude<keyof T, U>>;
-
 export const noop = () => {};
 
 export const inlineSVG = (svg: string) => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;


### PR DESCRIPTION
In TypeScript 3.5, the `Omit` type was added to the standard library, see https://devblogs.microsoft.com/typescript/announcing-typescript-3-5-rc/#the-omit-helper-type

Additionally, I converted empty interfaces to types, which makes more sense and shouldn't change any behavior.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
