### PR TITLE
fix(eslint-config): Change warn to error for trailing space

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -38,7 +38,7 @@
       }
     ],
     "no-shadow": "error",
-    "no-trailing-spaces": "warn",
+    "no-trailing-spaces": "error",
     "no-undef": "error",
     "no-unneeded-ternary": "error",
     "no-unused-expressions": "error",


### PR DESCRIPTION
Since this rule is fixable in most cases it will be fixed during commits in case of trailing space.


## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
