### PR TITLE
fix(api-client): Remove Dexie dependency

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -12,7 +12,6 @@
     "@wireapp/priority-queue": "1.0.14",
     "@wireapp/store-engine": "3.2.0",
     "axios": "0.19.0",
-    "dexie": "2.0.4",
     "html5-websocket": "2.0.4",
     "logdown": "3.2.8",
     "reconnecting-websocket": "3.2.2",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -12,6 +12,7 @@
     "@wireapp/priority-queue": "1.0.14",
     "@wireapp/store-engine": "3.2.0",
     "axios": "0.19.0",
+    "dexie": "2.0.4",
     "html5-websocket": "2.0.4",
     "logdown": "3.2.8",
     "reconnecting-websocket": "3.2.2",

--- a/packages/api-client/src/main/Config.ts
+++ b/packages/api-client/src/main/Config.ts
@@ -18,10 +18,9 @@
  */
 
 import {CRUDEngine} from '@wireapp/store-engine';
-import {Dexie} from 'dexie';
 import {BackendData} from './env/';
 
-export type SchemaCallbackFunction = (db: Dexie) => void;
+export type SchemaCallbackFunction = (db: any) => void;
 
 export interface Config {
   store: CRUDEngine;


### PR DESCRIPTION
The latest production version of our API Client is not working because it fails to compile. The reason for this is that Dexie got removed from our "store-engine" and thus the API Client cannot get it anymore as a transitive dependency. In our monorepo we did not have that problem because the Dexie dependency gets hoisted. Maybe we should apply the [nohoist](https://yarnpkg.com/blog/2018/02/15/nohoist/) schema here too, WDYT @Yserz? 

Anyhow, I removed Dexie completely from our API Client because it was just used for a type export and I think it's not justified to bring in a complete database lib just because we need the type once. 

The `store` of our `Config` also uses a generic type of `CRUDEngine` so its `schemaCallback` shouldn't require a specialized type like `Dexie`. It's okay to use a generic `db` instance of type `any` here.