### PR TITLE
feat(store-engine): Optional primary key [BREAKING]

### DIFF
--- a/packages/api-client/src/main/shims/node/cookie.ts
+++ b/packages/api-client/src/main/shims/node/cookie.ts
@@ -56,13 +56,13 @@ const setInternalCookie = (cookie: Cookie, engine: CRUDEngine): Promise<string> 
   const entity: PersistedCookie = {expiration: cookie.expiration, zuid: cookie.zuid};
 
   try {
-    return engine.create(AUTH_TABLE_NAME, AUTH_COOKIE_KEY, entity);
+    return engine.create(AUTH_TABLE_NAME, entity, AUTH_COOKIE_KEY);
   } catch (error) {
     if (
       error instanceof StoreEngineError.RecordAlreadyExistsError ||
       error.constructor.name === StoreEngineError.RecordAlreadyExistsError.name
     ) {
-      return engine.update(AUTH_TABLE_NAME, AUTH_COOKIE_KEY, entity);
+      return engine.update(AUTH_TABLE_NAME, entity, AUTH_COOKIE_KEY);
     } else {
       throw error;
     }

--- a/packages/core/src/main/client/ClientDatabaseRepository.ts
+++ b/packages/core/src/main/client/ClientDatabaseRepository.ts
@@ -66,8 +66,8 @@ export class ClientDatabaseRepository {
     const transformedClient = this.transformLocalClient(client);
     await this.storeEngine.create(
       ClientDatabaseRepository.STORES.CLIENTS,
-      ClientDatabaseRepository.KEYS.LOCAL_IDENTITY,
       transformedClient,
+      ClientDatabaseRepository.KEYS.LOCAL_IDENTITY,
     );
     return transformedClient;
   }
@@ -76,8 +76,8 @@ export class ClientDatabaseRepository {
     const transformedClient = this.transformLocalClient(client);
     await this.storeEngine.update(
       ClientDatabaseRepository.STORES.CLIENTS,
-      ClientDatabaseRepository.KEYS.LOCAL_IDENTITY,
       transformedClient,
+      ClientDatabaseRepository.KEYS.LOCAL_IDENTITY,
     );
     return transformedClient;
   }
@@ -86,8 +86,8 @@ export class ClientDatabaseRepository {
     const transformedClient = this.transformClient(userId, client);
     await this.storeEngine.update(
       ClientDatabaseRepository.STORES.CLIENTS,
-      CryptographyService.constructSessionId(userId, client.id),
       transformedClient,
+      CryptographyService.constructSessionId(userId, client.id),
     );
     return transformedClient;
   }
@@ -96,8 +96,8 @@ export class ClientDatabaseRepository {
     const transformedClient = this.transformClient(userId, client);
     await this.storeEngine.create(
       ClientDatabaseRepository.STORES.CLIENTS,
-      CryptographyService.constructSessionId(userId, client.id),
       transformedClient,
+      CryptographyService.constructSessionId(userId, client.id),
     );
     return transformedClient;
   }

--- a/packages/core/src/main/notification/NotificationDatabaseRepository.ts
+++ b/packages/core/src/main/notification/NotificationDatabaseRepository.ts
@@ -50,12 +50,12 @@ export class NotificationDatabaseRepository {
   }
 
   public async updateLastEventDate(eventDate: Date): Promise<Date> {
-    await this.storeEngine.update(STORE_AMPLIFY, DatabaseKeys.PRIMARY_KEY_LAST_EVENT, {value: eventDate.toISOString()});
+    await this.storeEngine.update(STORE_AMPLIFY, {value: eventDate.toISOString()}, DatabaseKeys.PRIMARY_KEY_LAST_EVENT);
     return eventDate;
   }
 
   public async createLastEventDate(eventDate: Date): Promise<Date> {
-    await this.storeEngine.create(STORE_AMPLIFY, DatabaseKeys.PRIMARY_KEY_LAST_EVENT, {value: eventDate.toISOString()});
+    await this.storeEngine.create(STORE_AMPLIFY, {value: eventDate.toISOString()}, DatabaseKeys.PRIMARY_KEY_LAST_EVENT);
     return eventDate;
   }
 
@@ -67,16 +67,24 @@ export class NotificationDatabaseRepository {
   }
 
   public async updateLastNotificationId(lastNotification: Notification): Promise<string> {
-    await this.storeEngine.update(STORE_AMPLIFY, DatabaseKeys.PRIMARY_KEY_LAST_NOTIFICATION, {
-      value: lastNotification.id,
-    });
+    await this.storeEngine.update(
+      STORE_AMPLIFY,
+      {
+        value: lastNotification.id,
+      },
+      DatabaseKeys.PRIMARY_KEY_LAST_NOTIFICATION,
+    );
     return lastNotification.id;
   }
 
   public async createLastNotificationId(lastNotification: Notification): Promise<string> {
-    await this.storeEngine.create(STORE_AMPLIFY, DatabaseKeys.PRIMARY_KEY_LAST_NOTIFICATION, {
-      value: lastNotification.id,
-    });
+    await this.storeEngine.create(
+      STORE_AMPLIFY,
+      {
+        value: lastNotification.id,
+      },
+      DatabaseKeys.PRIMARY_KEY_LAST_NOTIFICATION,
+    );
     return lastNotification.id;
   }
 }

--- a/packages/store-engine-fs/src/index.test.ts
+++ b/packages/store-engine-fs/src/index.test.ts
@@ -163,7 +163,7 @@ describe('FileEngine', () => {
       };
       engine = new FileEngine(BASE_DIRECTORY);
       await engine.init(STORE_NAME, options);
-      await engine.create('test', 'index', {});
+      await engine.create('test', {}, 'index');
 
       try {
         await engine.append('test', 'index', 'oh no');

--- a/packages/store-engine-fs/src/index.ts
+++ b/packages/store-engine-fs/src/index.ts
@@ -82,14 +82,14 @@ export class FileEngine implements CRUDEngine {
     return fs.remove(this.storeName);
   }
 
-  public async create<T>(tableName: string, primaryKey: string, entity: any): Promise<string> {
+  public async create<T>(tableName: string, entity: T, primaryKey: string): Promise<string> {
     if (entity) {
       const filePath = this.resolvePath(tableName, primaryKey);
       if (typeof entity === 'object') {
         try {
-          entity = JSON.stringify(entity);
+          entity = JSON.stringify(entity) as any;
         } catch (error) {
-          entity = entity.toString();
+          entity = (entity as any).toString();
         }
       }
 
@@ -190,7 +190,7 @@ export class FileEngine implements CRUDEngine {
     return primaryKey;
   }
 
-  public async update(tableName: string, primaryKey: string, changes: Object): Promise<string> {
+  public async update<T>(tableName: string, changes: T, primaryKey: string): Promise<string> {
     const file = this.resolvePath(tableName, primaryKey);
     let record = await this.read(tableName, primaryKey);
     if (typeof record === 'string') {
@@ -201,12 +201,12 @@ export class FileEngine implements CRUDEngine {
     return primaryKey;
   }
 
-  public async updateOrCreate(tableName: string, primaryKey: string, changes: Object): Promise<string> {
+  public async updateOrCreate<T>(tableName: string, changes: T, primaryKey: string): Promise<string> {
     try {
-      await this.update(tableName, primaryKey, changes);
+      await this.update(tableName, changes, primaryKey);
     } catch (error) {
       if (error instanceof RecordNotFoundError) {
-        return this.create(tableName, primaryKey, changes);
+        return this.create(tableName, changes, primaryKey);
       }
       throw error;
     }

--- a/packages/store-engine-sqleet/src/index.test.ts
+++ b/packages/store-engine-sqleet/src/index.test.ts
@@ -134,7 +134,7 @@ describe('SQLeetEngine', () => {
           name: SQLiteType.TEXT,
         },
       });
-      await engine.create<DBRecord>('users', '1', {name: 'Otto'});
+      await engine.create('users', {name: 'Otto'}, '1');
       const result = await engine.read<DBRecord>('users', '1');
       expect(result.name).toBe('Otto');
     });
@@ -148,7 +148,7 @@ describe('SQLeetEngine', () => {
 
       try {
         const entity = {'name\'"`': 'Otto'};
-        await engine.create<DBRecord>('users', '1', entity);
+        await engine.create('users', entity, '1');
         fail();
       } catch (error) {
         expect(error.message).toBe(
@@ -195,7 +195,7 @@ describe('SQLeetEngine', () => {
 
       const RECORDS_COUNT = 100;
       for (let i = 0; i < RECORDS_COUNT; i++) {
-        await engine.create<DBRecord>('users', i.toString(), {name: 'Lion'});
+        await engine.create('users', {name: 'Lion'}, i.toString());
       }
       const results = await engine.readAll<DBRecord>('users');
       expect(results.length).toBe(RECORDS_COUNT);
@@ -231,8 +231,8 @@ describe('SQLeetEngine', () => {
           name: SQLiteType.TEXT,
         },
       });
-      await engine.updateOrCreate<DBRecord>('users', '1', {name: 'Otto'});
-      await engine.updateOrCreate<DBRecord>('users', '1', {name: 'Lion'});
+      await engine.updateOrCreate('users', {name: 'Otto'}, '1');
+      await engine.updateOrCreate('users', {name: 'Lion'}, '1');
 
       const result = await engine.read<DBRecord>('users', '1');
       expect(result.name).toBe('Lion');
@@ -246,7 +246,7 @@ describe('SQLeetEngine', () => {
       });
 
       try {
-        await engine.updateOrCreate<DBRecord>('ffff', '1', {name: 'Otto'});
+        await engine.updateOrCreate('ffff', {name: 'Otto'}, '1');
         fail();
       } catch (error) {
         expect(error.message).toBe('Table "ffff" does not exist.');
@@ -276,10 +276,10 @@ describe('SQLeetEngine', () => {
           name: SQLiteType.TEXT,
         },
       });
-      await engine.create<DBRecord>('users', '1', {name: 'Otto', age: 1});
+      await engine.create('users', {name: 'Otto', age: 1}, '1');
       const result = await engine.read<DBRecord>('users', '1');
       expect(result.name).toBe('Otto');
-      await engine.update('users', '1', {name: 'Hans', age: 2});
+      await engine.update('users', {name: 'Hans', age: 2}, '1');
       const changedResult = await engine.read<DBRecord>('users', '1');
       expect(changedResult.age).toBe(2);
       expect(changedResult.name).toBe('Hans');
@@ -293,7 +293,7 @@ describe('SQLeetEngine', () => {
           name: SQLiteType.TEXT,
         },
       });
-      await engine.updateOrCreate<DBRecord>('users', '1', {name: 'Otto'});
+      await engine.updateOrCreate('users', {name: 'Otto'}, '1');
       await engine.purge();
 
       try {
@@ -322,7 +322,7 @@ describe('SQLeetEngine', () => {
       const engine = await initEngine(schema);
 
       // Write and save
-      await engine.create<DBRecord>('users', '1', {name: 'Otto', age: 1});
+      await engine.create('users', {name: 'Otto', age: 1}, '1');
       await indexedDB.updateOrCreate(this.storeName, primaryKeyName, await engine.export());
 
       // Import and read

--- a/packages/store-engine-sqleet/src/index.ts
+++ b/packages/store-engine-sqleet/src/index.ts
@@ -167,7 +167,7 @@ export class SQLeetEngine implements CRUDEngine {
     return {columns, values};
   }
 
-  async create<T>(tableName: string, primaryKey: string, entity: Record<string, any>): Promise<string> {
+  async create<T>(tableName: string, entity: Record<string, any>, primaryKey: string): Promise<string> {
     if (!entity) {
       const message = `Record "${primaryKey}" cannot be saved in "${tableName}" because it's "undefined" or "null".`;
       throw new RecordTypeError(message);
@@ -267,7 +267,7 @@ export class SQLeetEngine implements CRUDEngine {
     return [];
   }
 
-  async update(tableName: string, primaryKey: string, changes: Record<string, any>): Promise<string> {
+  async update(tableName: string, changes: Record<string, any>, primaryKey: string): Promise<string> {
     await this.read(tableName, primaryKey);
     const {values, columns} = this.buildValues(tableName, changes);
     const escapedTableName = escape(tableName);
@@ -281,13 +281,13 @@ export class SQLeetEngine implements CRUDEngine {
     return primaryKey;
   }
 
-  async updateOrCreate<T>(tableName: string, primaryKey: string, changes: Record<string, any>): Promise<string> {
+  async updateOrCreate(tableName: string, changes: Record<string, any>, primaryKey: string): Promise<string> {
     try {
-      await this.update(tableName, primaryKey, changes);
+      await this.update(tableName, changes, primaryKey);
     } catch (error) {
       const isRecordNotFound = error instanceof RecordNotFoundError;
       if (isRecordNotFound) {
-        await this.create(tableName, primaryKey, changes);
+        await this.create(tableName, changes, primaryKey);
       } else {
         throw error;
       }

--- a/packages/store-engine/src/main/engine/CRUDEngine.ts
+++ b/packages/store-engine/src/main/engine/CRUDEngine.ts
@@ -23,97 +23,99 @@ export interface CRUDEngine {
 
   /**
    * Appends a string to an existing record.
-   * @param {string} tableName - Table name
-   * @param {string} primaryKey - Primary key of record which should get extended
-   * @param {Object} additions - Text to append
-   * @returns {Promise<string>} Resolves with the primary key of the extended record.
+   * @param tableName - Table name
+   * @param primaryKey - Primary key of record which should get extended
+   * @param additions - Text to append
+   * @returns Resolves with the primary key of the extended record.
    */
   append(tableName: string, primaryKey: string, additions: string): Promise<string>;
 
   /**
    * Initializes the store engine. This needs to be done prior to operating with it.
-   * @param {string} storeName - Name of the store
-   * @param {Array} settings - Database-specific settings
-   * @returns {Promise<any>} Resolves with the underlying (unwrapped) instance of a database.
+   * @param storeName - Name of the store
+   * @param settings - Database-specific settings
+   * @returns Resolves with the underlying (unwrapped) instance of a database.
    * @throws {UnsupportedError} Error when feature is not available on targeted platform.
    */
   init(storeName: string, ...settings: any[]): Promise<any>;
 
   /**
    * Deletes the store.
-   * @returns {Promise<void>} Resolves if store got deleted.
+   * @returns Resolves if store got deleted.
    */
   purge(): Promise<void>;
 
   /**
    * Creates a record by its primary key within a table.
-   * @param {string} tableName - Table name
-   * @param {string} primaryKey - Primary key to be used to store the record
-   * @param {T} entity - Any kind of object that should be stored
-   * @returns {Promise<string>} Resolves with the primary key of the stored record.
+   * @param tableName - Table name
+   * @param primaryKey - Primary key to be used to store the record
+   * @param entity - Any kind of object that should be stored
+   * @returns Resolves with the primary key of the stored record.
    */
-  create<T>(tableName: string, primaryKey: string, entity: T): Promise<string>;
+  create<T>(tableName: string, entity: T, primaryKey: string): Promise<string>;
 
   /**
    * Deletes a record by its primary key within a table.
-   * @param {string} tableName - Table name
-   * @param {string} primaryKey - Primary key to be used to delete the record
-   * @returns {Promise<string>} Resolves with the primary key of the deleted record.
+   * @param tableName - Table name
+   * @param primaryKey - Primary key to be used to delete the record
+   * @returns Resolves with the primary key of the deleted record.
    */
   delete(tableName: string, primaryKey: string): Promise<string>;
 
   /**
    * Deletes all records within a table.
-   * @param {string} tableName - Table name
-   * @returns {Promise<boolean>} Resolves with `true`, if all records have been removed.
+   * @param tableName - Table name
+   * @returns Resolves with `true`, if all records have been removed.
    */
   deleteAll(tableName: string): Promise<boolean>;
 
   /**
    * Finds a record by its primary key within a table.
-   * @param {string} tableName - Table name
-   * @param {string} primaryKey - Primary key to query the record
+   * @param tableName - Table name
+   * @param primaryKey - Primary key to query the record
    * @throws {RecordNotFoundError} Will be thrown, if the record could not be found.
-   * @returns {Promise<T>} Resolves with the record.
+   * @returns Resolves with the record.
    */
   read<T>(tableName: string, primaryKey: string): Promise<T>;
 
   /**
    * Reads all records from a table.
-   * @param {string} tableName - Table name
-   * @returns {Promise<T[]>} Resolves with an array of records from a table.
+   * @param tableName - Table name
+   * @returns Resolves with an array of records from a table.
    */
   readAll<T>(tableName: string): Promise<T[]>;
 
   /**
    * Returns all primary keys of records that are stored in a table.
-   * @param {string} tableName - Table name
-   * @returns {Promise<string[]>} Returns an array of primary keys.
+   * @param tableName - Table name
+   * @returns Returns an array of primary keys.
    */
   readAllPrimaryKeys(tableName: string): Promise<string[]>;
 
   /**
    * Updates a record with a set of properties.
-   * @param {string} tableName - Table name
-   * @param {string} primaryKey - Primary key of record which should get updated
-   * @param {Object} changes - Updated properties that should be saved for the record
-   * @returns {Promise<string>} Resolves with the primary key of the updated record.
+   * @param tableName - Table name
+   * @param entity - Updated properties that should be saved for the record
+   * @param primaryKey - Primary key of record which should get updated
+   * @returns Resolves with the primary key of the updated record.
    */
-  update(tableName: string, primaryKey: string, changes: Object): Promise<string>;
+  update<T>(tableName: string, entity: T, primaryKey: string): Promise<string>;
+  update<T>(tableName: string, entity: T, primaryKey?: string): Promise<string>;
 
   /**
    * Updates a record with a set of properties.
    * If the record doesn't exist, The record will be created automatically.
-   * @param {string} tableName - Table name
-   * @param {string} primaryKey - Primary key of record which should get updated
-   * @param {Object} changes - Updated properties that should be saved for the record
-   * @returns {Promise<string>} Resolves with the primary key of the updated record.
+   * @param tableName - Table name
+   * @param entity - Updated properties that should be saved for the record
+   * @param primaryKey - Primary key of record which should get updated
+   * @returns Resolves with the primary key of the updated record.
    */
-  updateOrCreate(tableName: string, primaryKey: string, changes: Object): Promise<string>;
+  updateOrCreate<T>(tableName: string, entity: T, primaryKey: string): Promise<string>;
+  updateOrCreate<T>(tableName: string, entity: T, primaryKey?: string): Promise<string>;
 
   /**
    * Checks wether the engine is supported in the current environment.
-   * @returns {Promise<void>} Resolves if supported, rejects if unsupported.
+   * @returns Resolves if supported, rejects if unsupported.
    */
   isSupported(): Promise<void>;
 }

--- a/packages/store-engine/src/main/engine/MemoryEngine.ts
+++ b/packages/store-engine/src/main/engine/MemoryEngine.ts
@@ -46,7 +46,7 @@ export class MemoryEngine implements CRUDEngine {
     }
   }
 
-  public create<T>(tableName: string, primaryKey: string, entity: T): Promise<string> {
+  public create<T>(tableName: string, entity: T, primaryKey: string): Promise<string> {
     if (entity) {
       this.prepareTable(tableName);
 
@@ -107,20 +107,20 @@ export class MemoryEngine implements CRUDEngine {
     return Promise.resolve(Object.keys(this.stores[this.storeName][tableName]));
   }
 
-  public async update(tableName: string, primaryKey: string, changes: Object): Promise<string> {
+  public async update<T>(tableName: string, changes: T, primaryKey: string): Promise<string> {
     this.prepareTable(tableName);
-    const entity: Object = await this.read(tableName, primaryKey);
-    const updatedEntity: Object = {...entity, ...changes};
+    const entity = await this.read<T>(tableName, primaryKey);
+    const updatedEntity: T = {...entity, ...changes};
     this.stores[this.storeName][tableName][primaryKey] = updatedEntity;
     return primaryKey;
   }
 
-  public updateOrCreate(tableName: string, primaryKey: string, changes: Object): Promise<string> {
+  public updateOrCreate<T>(tableName: string, changes: T, primaryKey: string): Promise<string> {
     this.prepareTable(tableName);
-    return this.update(tableName, primaryKey, changes)
+    return this.update(tableName, changes, primaryKey)
       .catch(error => {
         if (error instanceof RecordNotFoundError) {
-          return this.create(tableName, primaryKey, changes);
+          return this.create(tableName, changes, primaryKey);
         }
         throw error;
       })
@@ -129,7 +129,7 @@ export class MemoryEngine implements CRUDEngine {
 
   append(tableName: string, primaryKey: string, additions: string): Promise<string> {
     this.prepareTable(tableName);
-    return this.read(tableName, primaryKey).then((record: any) => {
+    return this.read<string>(tableName, primaryKey).then(record => {
       if (typeof record === 'string') {
         record += additions;
       } else {

--- a/packages/store-engine/src/main/store/TransientStore.ts
+++ b/packages/store-engine/src/main/store/TransientStore.ts
@@ -68,8 +68,8 @@ export class TransientStore extends EventEmitter {
 
   /**
    * Returns a fully qualified name (FQN) which can be used to cache a transient bundle.
-   * @param {string} primaryKey - Primary key from which the FQN is created
-   * @returns {string} A fully qualified name
+   * @param primaryKey - Primary key from which the FQN is created
+   * @returns A fully qualified name
    */
   private constructCacheKey(primaryKey: string): string {
     return `${this.engine.storeName}@${this.tableName}@${primaryKey}`;
@@ -88,7 +88,7 @@ export class TransientStore extends EventEmitter {
 
   public get(primaryKey: string): Promise<TransientBundle | undefined> {
     return this.getFromCache(primaryKey)
-      .then((cachedBundle: TransientBundle) => {
+      .then(cachedBundle => {
         return cachedBundle !== undefined ? cachedBundle : this.getFromStore(primaryKey);
       })
       .catch(error => {
@@ -110,10 +110,10 @@ export class TransientStore extends EventEmitter {
 
   /**
    * Saves a transient record to the store and starts a timer to remove this record when the time to live (TTL) ended.
-   * @param {string} primaryKey - Primary key from which the FQN is created
-   * @param {string} record - A payload which should be kept in the TransientStore
-   * @param {number} ttl - The time to live (TTL) in milliseconds (ex. 1000 is 1s)
-   * @returns {Promise<TransientBundle>} A transient bundle, wrapping the initial record
+   * @param primaryKey - Primary key from which the FQN is created
+   * @param A payload which should be kept in the TransientStore
+   * @param The time to live (TTL) in milliseconds (ex. 1000 is 1s)
+   * @returns ransientBundle>} A transient bundle, wrapping the initial record
    */
   public set<T>(primaryKey: string, record: T, ttl: number): Promise<TransientBundle> {
     const bundle: TransientBundle = this.createTransientBundle(record, ttl);
@@ -142,7 +142,7 @@ export class TransientStore extends EventEmitter {
   }
 
   private saveInStore<TransientBundle>(primaryKey: string, bundle: TransientBundle): Promise<string> {
-    return this.engine.create(this.tableName, primaryKey, bundle);
+    return this.engine.create(this.tableName, bundle, primaryKey);
   }
 
   private saveInCache<TransientBundle>(cacheKey: string, bundle: TransientBundle): TransientBundle {

--- a/packages/store-engine/src/main/test/appendSpec.ts
+++ b/packages/store-engine/src/main/test/appendSpec.ts
@@ -27,7 +27,7 @@ export const appendSpec = {
 
     const text = 'Hello';
     const textExtension = '\r\nWorld';
-    const primaryKey = await engine.create(TABLE_NAME, PRIMARY_KEY, text);
+    const primaryKey = await engine.create(TABLE_NAME, text, PRIMARY_KEY);
     await engine.append(TABLE_NAME, primaryKey, textExtension);
     const record = await engine.read(TABLE_NAME, primaryKey);
     expect(record).toBe(`${text}${textExtension}`);

--- a/packages/store-engine/src/main/test/createSpec.ts
+++ b/packages/store-engine/src/main/test/createSpec.ts
@@ -30,7 +30,7 @@ export const createSpec = {
       some: 'value',
     };
 
-    const primaryKey = await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
+    const primaryKey = await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
     expect(primaryKey).toEqual(PRIMARY_KEY);
   },
   "doesn't save empty values.": async (engine: CRUDEngine) => {
@@ -39,7 +39,7 @@ export const createSpec = {
     const entity = undefined;
 
     try {
-      await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
+      await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
       fail(new Error('Method is supposed to throw an error.'));
     } catch (error) {
       expect(error).toEqual(jasmine.any(RecordTypeError));
@@ -51,7 +51,7 @@ export const createSpec = {
     const entity = undefined;
 
     try {
-      await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
+      await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
       fail(new Error('Method is supposed to throw an error.'));
     } catch (error) {
       expect(error).toEqual(jasmine.any(RecordTypeError));
@@ -69,8 +69,8 @@ export const createSpec = {
     };
 
     try {
-      await engine.create(TABLE_NAME, PRIMARY_KEY, firstEntity);
-      await engine.create(TABLE_NAME, PRIMARY_KEY, secondEntity);
+      await engine.create(TABLE_NAME, firstEntity, PRIMARY_KEY);
+      await engine.create(TABLE_NAME, secondEntity, PRIMARY_KEY);
       fail();
     } catch (error) {
       expect(error).toEqual(jasmine.any(RecordAlreadyExistsError));

--- a/packages/store-engine/src/main/test/deleteAllSpec.ts
+++ b/packages/store-engine/src/main/test/deleteAllSpec.ts
@@ -48,9 +48,9 @@ export const deleteAllSpec = {
     };
 
     await Promise.all([
-      engine.create(TABLE_NAME, homer.primaryKey, homer.entity),
-      engine.create(TABLE_NAME, lisa.primaryKey, lisa.entity),
-      engine.create(TABLE_NAME, marge.primaryKey, marge.entity),
+      engine.create(TABLE_NAME, homer.entity, homer.primaryKey),
+      engine.create(TABLE_NAME, lisa.entity, lisa.primaryKey),
+      engine.create(TABLE_NAME, marge.entity, marge.primaryKey),
     ]);
     const hasBeenDeleted = await engine.deleteAll(TABLE_NAME);
     expect(hasBeenDeleted).toBe(true);

--- a/packages/store-engine/src/main/test/deleteSpec.ts
+++ b/packages/store-engine/src/main/test/deleteSpec.ts
@@ -50,9 +50,9 @@ export const deleteSpec = {
     const expectedRemainingEntities = 2;
 
     await Promise.all([
-      engine.create(TABLE_NAME, homer.primaryKey, homer.entity),
-      engine.create(TABLE_NAME, lisa.primaryKey, lisa.entity),
-      engine.create(TABLE_NAME, marge.primaryKey, marge.entity),
+      engine.create(TABLE_NAME, homer.entity, homer.primaryKey),
+      engine.create(TABLE_NAME, lisa.entity, lisa.primaryKey),
+      engine.create(TABLE_NAME, marge.entity, marge.primaryKey),
     ]);
     await engine.delete(TABLE_NAME, lisa.primaryKey);
     const primaryKeys = await engine.readAllPrimaryKeys(TABLE_NAME);
@@ -67,7 +67,7 @@ export const deleteSpec = {
       some: 'value',
     };
 
-    const primaryKey = await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
+    const primaryKey = await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
     const deletedKey = await engine.delete(TABLE_NAME, primaryKey);
     expect(deletedKey).toBe(PRIMARY_KEY);
   },

--- a/packages/store-engine/src/main/test/purgeSpec.ts
+++ b/packages/store-engine/src/main/test/purgeSpec.ts
@@ -26,7 +26,7 @@ export const purgeSpec = {
     engine: CRUDEngine,
     initEngine: (shouldCreateNewEngine?: boolean) => Promise<CRUDEngine>,
   ) => {
-    await engine.create(TABLE_NAME, 'one', {name: 'Alpha'});
+    await engine.create(TABLE_NAME, {name: 'Alpha'}, 'one');
     const SAVED_RECORDS = 1;
     let keys = await engine.readAllPrimaryKeys(TABLE_NAME);
     expect(keys.length).toBe(SAVED_RECORDS);
@@ -37,7 +37,7 @@ export const purgeSpec = {
     keys = await engine.readAllPrimaryKeys(TABLE_NAME);
     expect(keys.length).toBe(0);
 
-    await engine.create(TABLE_NAME, 'one', {name: 'Alpha'});
+    await engine.create(TABLE_NAME, {name: 'Alpha'}, 'one');
 
     keys = await engine.readAllPrimaryKeys(TABLE_NAME);
     expect(keys.length).toBe(SAVED_RECORDS);
@@ -46,10 +46,10 @@ export const purgeSpec = {
     engine: CRUDEngine,
     initEngine: (shouldCreateNewEngine?: boolean) => Promise<CRUDEngine>,
   ) => {
-    await engine.create(TABLE_NAME, 'one', {name: 'Alpha'});
-    await engine.create(TABLE_NAME, 'two', {name: 'Bravo'});
-    await engine.create(TABLE_NAME, 'three', {name: 'Charlie'});
-    await engine.create(TABLE_NAME, 'four', {name: 'Delta'});
+    await engine.create(TABLE_NAME, {name: 'Alpha'}, 'one');
+    await engine.create(TABLE_NAME, {name: 'Bravo'}, 'two');
+    await engine.create(TABLE_NAME, {name: 'Charlie'}, 'three');
+    await engine.create(TABLE_NAME, {name: 'Delta'}, 'four');
     const SAVED_RECORDS = 4;
     let keys = await engine.readAllPrimaryKeys(TABLE_NAME);
     expect(keys.length).toBe(SAVED_RECORDS);

--- a/packages/store-engine/src/main/test/readAllPrimaryKeysSpec.ts
+++ b/packages/store-engine/src/main/test/readAllPrimaryKeysSpec.ts
@@ -48,9 +48,9 @@ export const readAllPrimaryKeysSpec = {
     };
 
     await Promise.all([
-      engine.create(TABLE_NAME, homer.primaryKey, homer.entity),
-      engine.create(TABLE_NAME, lisa.primaryKey, lisa.entity),
-      engine.create(TABLE_NAME, marge.primaryKey, marge.entity),
+      engine.create(TABLE_NAME, homer.entity, homer.primaryKey),
+      engine.create(TABLE_NAME, lisa.entity, lisa.primaryKey),
+      engine.create(TABLE_NAME, marge.entity, marge.primaryKey),
     ]);
     const primaryKeys = await engine.readAllPrimaryKeys(TABLE_NAME);
     expect(primaryKeys.length).toBe(3);

--- a/packages/store-engine/src/main/test/readAllSpec.ts
+++ b/packages/store-engine/src/main/test/readAllSpec.ts
@@ -52,9 +52,9 @@ export const readAllSpec = {
       primaryKey: 'marge-simpson',
     };
 
-    await engine.create(TABLE_NAME, homer.primaryKey, homer.entity);
-    await engine.create(TABLE_NAME, lisa.primaryKey, lisa.entity);
-    await engine.create(TABLE_NAME, marge.primaryKey, marge.entity);
+    await engine.create(TABLE_NAME, homer.entity, homer.primaryKey);
+    await engine.create(TABLE_NAME, lisa.entity, lisa.primaryKey);
+    await engine.create(TABLE_NAME, marge.entity, marge.primaryKey);
     const records = await engine.readAll<DomainEntity>(TABLE_NAME);
     expect(records.length).toBe(3);
     expect(records).toEqual(jasmine.arrayContaining([homer.entity, lisa.entity, marge.entity]));

--- a/packages/store-engine/src/main/test/readSpec.ts
+++ b/packages/store-engine/src/main/test/readSpec.ts
@@ -34,7 +34,7 @@ export const readSpec = {
       some: 'value',
     };
 
-    const primaryKey = await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
+    const primaryKey = await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
     const record = await engine.read<DomainEntity>(TABLE_NAME, primaryKey);
     expect(record.some).toBe(entity.some);
   },

--- a/packages/store-engine/src/main/test/updateOrCreateSpec.ts
+++ b/packages/store-engine/src/main/test/updateOrCreateSpec.ts
@@ -35,7 +35,7 @@ export const updateOrCreateSpec = {
 
     const expectedAmountOfProperties = 1;
 
-    const primaryKey = await engine.updateOrCreate(TABLE_NAME, PRIMARY_KEY, entity);
+    const primaryKey = await engine.updateOrCreate(TABLE_NAME, entity, PRIMARY_KEY);
     const updatedRecord = await engine.read<DomainEntity>(TABLE_NAME, primaryKey);
     expect(updatedRecord.name).toBe(entity.name);
     expect(Object.keys(updatedRecord).length).toBe(expectedAmountOfProperties);
@@ -51,8 +51,8 @@ export const updateOrCreateSpec = {
       name: 'Old monitor2',
     };
 
-    await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
-    const primaryKey = await engine.updateOrCreate(TABLE_NAME, PRIMARY_KEY, update);
+    await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
+    const primaryKey = await engine.updateOrCreate(TABLE_NAME, update, PRIMARY_KEY);
     const updatedRecord = await engine.read<DomainEntity>(TABLE_NAME, primaryKey);
     expect(updatedRecord.name).toBe(update.name);
   },

--- a/packages/store-engine/src/main/test/updateSpec.ts
+++ b/packages/store-engine/src/main/test/updateSpec.ts
@@ -44,7 +44,7 @@ export const updateSpec = {
     };
 
     try {
-      await engine.update(TABLE_NAME, PRIMARY_KEY, updates);
+      await engine.update(TABLE_NAME, updates, PRIMARY_KEY);
       fail();
     } catch (error) {
       expect(error).toEqual(jasmine.any(RecordNotFoundError));
@@ -67,8 +67,8 @@ export const updateSpec = {
 
     const expectedAmountOfProperties = 2;
 
-    await engine.create(TABLE_NAME, PRIMARY_KEY, entity);
-    const primaryKey = await engine.update(TABLE_NAME, PRIMARY_KEY, updates);
+    await engine.create(TABLE_NAME, entity, PRIMARY_KEY);
+    const primaryKey = await engine.update(TABLE_NAME, updates, PRIMARY_KEY);
     const updatedRecord = await engine.read<DomainEntity>(TABLE_NAME, primaryKey);
     expect(updatedRecord.name).toBe(entity.name);
     expect(updatedRecord.age).toBe(updates.age);


### PR DESCRIPTION
Since the `primaryKey` in [`IDBObjectStore.put()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/put#Syntax) is optional, we need to reflect this in our engine, too.

Therefore we need to change the order of `changes` and `primaryKey` to have `primaryKey` as last argument since TypeScript allows only the arguments after the last required argument to be optional.

That means
```ts
function foo(yay: boolean, nay?: boolean)
```
works while
```ts
function foo(yay?: boolean; nay: boolean)
```
doesn't.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
