### PR TITLE
fix(api-client,bazinga64,cbor,proteus,store-engine,store-engine-bro-fs): Don't return immediately in a try-catch block

### DIFF
--- a/packages/api-client/src/main/shims/node/cookie.ts
+++ b/packages/api-client/src/main/shims/node/cookie.ts
@@ -52,11 +52,12 @@ const loadExistingCookie = async (engine: CRUDEngine): Promise<Cookie> => {
   }
 };
 
-const setInternalCookie = (cookie: Cookie, engine: CRUDEngine): Promise<string> => {
+const setInternalCookie = async (cookie: Cookie, engine: CRUDEngine): Promise<string> => {
   const entity: PersistedCookie = {expiration: cookie.expiration, zuid: cookie.zuid};
 
   try {
-    return engine.create(AUTH_TABLE_NAME, AUTH_COOKIE_KEY, entity);
+    const primaryKey = await engine.create(AUTH_TABLE_NAME, AUTH_COOKIE_KEY, entity);
+    return primaryKey;
   } catch (error) {
     if (
       error instanceof StoreEngineError.RecordAlreadyExistsError ||

--- a/packages/bazinga64/src/Converter.ts
+++ b/packages/bazinga64/src/Converter.ts
@@ -22,7 +22,8 @@ import {UnsupportedInputError} from './UnsupportedInputError';
 export class Converter {
   public static arrayBufferViewToStringUTF8(arrayBufferView: Uint8Array): string {
     try {
-      return this.arrayBufferViewToString(arrayBufferView);
+      const string = this.arrayBufferViewToString(arrayBufferView);
+      return string;
     } catch (error) {
       if (typeof window === 'object' && 'TextDecoder' in window) {
         return new TextDecoder('utf-8').decode(arrayBufferView);

--- a/packages/cbor/src/main/cbor/Decoder.ts
+++ b/packages/cbor/src/main/cbor/Decoder.ts
@@ -487,7 +487,8 @@ export class Decoder {
 
   public optional<T>(closure: () => T): T | null | undefined {
     try {
-      return closure();
+      const result = closure();
+      return result;
     } catch (error) {
       if (error instanceof DecodeError && error.extra) {
         const type = error.extra[0];

--- a/packages/proteus/src/main/util/ClassUtil.ts
+++ b/packages/proteus/src/main/util/ClassUtil.ts
@@ -23,7 +23,8 @@ export interface ParameterlessConstructor<T> {
 
 export function new_instance<T>(proposedClass: ParameterlessConstructor<T>): T {
   try {
-    return new proposedClass();
+    const newClass = new proposedClass();
+    return newClass;
   } catch (error) {
     return error._instance;
   }

--- a/packages/store-engine-bro-fs/src/index.ts
+++ b/packages/store-engine-bro-fs/src/index.ts
@@ -138,7 +138,8 @@ export class FileSystemEngine implements CRUDEngine {
     }
 
     try {
-      return JSON.parse(data);
+      const parsed = JSON.parse(data);
+      return parsed;
     } catch (error) {
       return data as any;
     }

--- a/packages/store-engine/src/main/engine/LocalStorageEngine.ts
+++ b/packages/store-engine/src/main/engine/LocalStorageEngine.ts
@@ -122,7 +122,8 @@ export class LocalStorageEngine implements CRUDEngine {
       const record = window.localStorage.getItem(key);
       if (record) {
         try {
-          return JSON.parse(record);
+          const parsed = JSON.parse(record);
+          return parsed;
         } catch (error) {
           return record;
         }


### PR DESCRIPTION
See https://jakearchibald.com/2017/await-vs-return-vs-return-await/.

## Simple example

This logs an `UnhandledPromiseRejection`:
```ts
const foo = async () => {
  throw new Error('oh no')
};

(async () => {
  try {
    return foo();
  } catch(error) {
    console.log(error)
  }
})()
```

While this logs the thrown error:
```ts
const foo = async () => {
  throw new Error('oh no')
};

(async () => {
  try {
    const result = await foo();
    return result;
  } catch(error) {
    console.log(error)
  }
})()
```

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
