### PR TITLE
refactor(store-engine-bro-fs,store-engine-dexie,store-engine-fs,store-engine-sqleet,store-engine-web-storage): Move StoreEngine interface to peer dependencies

### DIFF
--- a/packages/store-engine-bro-fs/package.json
+++ b/packages/store-engine-bro-fs/package.json
@@ -7,6 +7,7 @@
     "@types/jasmine": "3.4.0",
     "@types/karma": "3.0.3",
     "@types/node": "~10",
+    "@wireapp/store-engine": "3.9.6",
     "jasmine": "3.4.0",
     "karma": "4.2.0",
     "karma-chrome-launcher": "3.1.0",

--- a/packages/store-engine-bro-fs/package.json
+++ b/packages/store-engine-bro-fs/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@types/bro-fs": "0.4.2",
-    "@wireapp/store-engine": "3.9.6",
     "bro-fs": "0.5.0"
   },
   "devDependencies": {
@@ -24,6 +23,9 @@
   "license": "GPL-3.0",
   "main": "./dist/index.js",
   "name": "@wireapp/store-engine-bro-fs",
+  "peerDependencies": {
+    "@wireapp/store-engine": "3.x.x"
+  },
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/store-engine-bro-fs",
   "scripts": {
     "build": "yarn build:node",

--- a/packages/store-engine-dexie/package.json
+++ b/packages/store-engine-dexie/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@wireapp/store-engine": "3.9.6",
     "dexie": "2.0.4"
   },
   "devDependencies": {
@@ -24,6 +23,9 @@
   "license": "GPL-3.0",
   "main": "./dist/index.js",
   "name": "@wireapp/store-engine-dexie",
+  "peerDependencies": {
+    "@wireapp/store-engine": "3.x.x"
+  },
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/store-engine-dexie",
   "scripts": {
     "build": "yarn build:node",

--- a/packages/store-engine-dexie/package.json
+++ b/packages/store-engine-dexie/package.json
@@ -6,6 +6,7 @@
     "@types/jasmine": "3.4.0",
     "@types/karma": "3.0.3",
     "@types/node": "~10",
+    "@wireapp/store-engine": "3.9.6",
     "jasmine": "3.4.0",
     "karma": "4.2.0",
     "karma-chrome-launcher": "3.1.0",

--- a/packages/store-engine-fs/package.json
+++ b/packages/store-engine-fs/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "@types/fs-extra": "8.0.0",
-    "@wireapp/store-engine": "3.9.6",
     "fs-extra": "8.1.0"
   },
   "devDependencies": {
@@ -20,6 +19,9 @@
   "license": "GPL-3.0",
   "main": "./dist/index.js",
   "name": "@wireapp/store-engine-fs",
+  "peerDependencies": {
+    "@wireapp/store-engine": "3.x.x"
+  },
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/store-engine-fs",
   "scripts": {
     "build": "yarn build:node",

--- a/packages/store-engine-fs/package.json
+++ b/packages/store-engine-fs/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@types/jasmine": "3.4.0",
     "@types/node": "~10",
+    "@wireapp/store-engine": "3.9.6",
     "jasmine": "3.4.0",
     "nyc": "14.1.1",
     "rimraf": "3.0.0",

--- a/packages/store-engine-sqleet/package.json
+++ b/packages/store-engine-sqleet/package.json
@@ -13,6 +13,7 @@
     "@types/karma": "3.0.3",
     "@types/node": "~10",
     "@types/uint32": "0.2.0",
+    "@wireapp/store-engine": "3.9.6",
     "babel-loader": "8.0.6",
     "bazinga64": "5.5.13",
     "jasmine": "3.4.0",

--- a/packages/store-engine-sqleet/package.json
+++ b/packages/store-engine-sqleet/package.json
@@ -5,7 +5,6 @@
     "@babel/plugin-proposal-object-rest-spread": "7.5.5",
     "@babel/preset-typescript": "7.3.3",
     "@types/sql.js": "1.0.2",
-    "@wireapp/store-engine": "3.9.6",
     "sql.js": "https://github.com/pwnsdx/sqleet.js#8075c8ed6a95f6fe7ab7a41703b2fcc3a412be2f",
     "uint32": "0.2.1"
   },
@@ -32,6 +31,9 @@
   "license": "GPL-3.0",
   "main": "./dist/index.js",
   "name": "@wireapp/store-engine-sqleet",
+  "peerDependencies": {
+    "@wireapp/store-engine": "3.x.x"
+  },
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/store-engine-sqleet",
   "scripts": {
     "build": "yarn build:node",

--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -3,6 +3,7 @@
     "@types/jasmine": "3.4.0",
     "@types/karma": "3.0.3",
     "@types/node": "~10",
+    "@wireapp/store-engine": "3.9.6",
     "jasmine": "3.4.0",
     "karma": "4.2.0",
     "karma-chrome-launcher": "3.1.0",

--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -1,7 +1,4 @@
 {
-  "dependencies": {
-    "@wireapp/store-engine": "3.9.0"
-  },
   "devDependencies": {
     "@types/jasmine": "3.4.0",
     "@types/karma": "3.0.3",
@@ -22,6 +19,9 @@
   "license": "GPL-3.0",
   "main": "./dist/LocalStorageEngine.js",
   "name": "@wireapp/store-engine-web-storage",
+  "peerDependencies": {
+    "@wireapp/store-engine": "3.x.x"
+  },
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/store-engine-web-storage",
   "scripts": {
     "build": "yarn build:node",

--- a/packages/store-engine-web-storage/src/WebStorageEngine.ts
+++ b/packages/store-engine-web-storage/src/WebStorageEngine.ts
@@ -54,7 +54,7 @@ export class WebStorageEngine implements CRUDEngine {
     entity: EntityType,
   ): Promise<PrimaryKey> {
     if (entity) {
-      const internalPrimaryKey = this.createKey<PrimaryKey>(tableName, primaryKey);
+      const internalPrimaryKey: any = this.createKey<PrimaryKey>(tableName, primaryKey);
       return this.read(tableName, primaryKey)
         .catch(error => {
           if (error instanceof StoreEngineError.RecordNotFoundError) {
@@ -73,11 +73,11 @@ export class WebStorageEngine implements CRUDEngine {
               this.webStorage.setItem(`${internalPrimaryKey}`, JSON.stringify(entity));
             }
 
-            if (typeof internalPrimaryKey === 'string') {
-              return (<unknown>internalPrimaryKey.replace(this.createPrefix(tableName), '')) as PrimaryKey;
-            }
+            const keyWithoutPrefix = internalPrimaryKey.replace(this.createPrefix(tableName), '');
+            const numericKey = parseInt(keyWithoutPrefix, 10);
+            const returnKey = isNaN(numericKey) ? keyWithoutPrefix : numericKey;
 
-            return primaryKey;
+            return returnKey as PrimaryKey;
           }
         });
     }

--- a/packages/store-engine/src/main/test/updateOrCreateSpec.ts
+++ b/packages/store-engine/src/main/test/updateOrCreateSpec.ts
@@ -38,10 +38,10 @@ export const updateOrCreateSpec = {
     };
 
     const firstPrimaryKey = await engine.updateOrCreate<PrimaryKey, DomainEntity>(TABLE_NAME, undefined, first);
-    expect(firstPrimaryKey).toBe(1);
+    expect(firstPrimaryKey).toEqual(1);
 
     const secondPrimaryKey = await engine.updateOrCreate<PrimaryKey, DomainEntity>(TABLE_NAME, undefined, second);
-    expect(secondPrimaryKey).toBe(2);
+    expect(secondPrimaryKey).toEqual(2);
 
     const persistedRecords = await engine.readAll(TABLE_NAME);
     expect(persistedRecords.length).toBe(2);

--- a/packages/store-engine/src/main/test/updateOrCreateSpec.ts
+++ b/packages/store-engine/src/main/test/updateOrCreateSpec.ts
@@ -38,10 +38,10 @@ export const updateOrCreateSpec = {
     };
 
     const firstPrimaryKey = await engine.updateOrCreate<PrimaryKey, DomainEntity>(TABLE_NAME, undefined, first);
-    expect(firstPrimaryKey).toEqual(1);
+    expect(firstPrimaryKey).toBe(1);
 
     const secondPrimaryKey = await engine.updateOrCreate<PrimaryKey, DomainEntity>(TABLE_NAME, undefined, second);
-    expect(secondPrimaryKey).toEqual(2);
+    expect(secondPrimaryKey).toBe(2);
 
     const persistedRecords = await engine.readAll(TABLE_NAME);
     expect(persistedRecords.length).toBe(2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2049,7 +2049,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/filesystem@*", "@types/filesystem@0.0.29":
+"@types/filesystem@*":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"
   integrity sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==
@@ -2421,16 +2421,6 @@
   integrity sha512-GX+ffTWSgNI5JLIaWfHPf6R8CkMSFqoquud7zQ2PRvIZWPIeXissQDWlmxQbqrJ9sKCD85+faEA2aFLs2vjENw==
   dependencies:
     protobufjs "6.8.8"
-
-"@wireapp/store-engine@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@wireapp/store-engine/-/store-engine-3.9.0.tgz#11e5d531a0878a529585589a2531bf4442cd25c6"
-  integrity sha512-91p+CJxya/xKRIDQSf84x+maOrvPj22o+SdlKX4Qp0hKUO82RrFHjwKgRgHN20/m7qtWeEyBHHL3drPyyh7y1w==
-  dependencies:
-    "@types/bro-fs" "0.4.2"
-    "@types/filesystem" "0.0.29"
-    "@types/node" "~10"
-    bro-fs "0.5.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
If you wanted to update a specific store engine (like `store-engine-dexie`) in your project, you always had to update the main `store-engine` and the `store-engine-dexie` simultaneously. With this PR it becomes handier since you just need to update one at a time.

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
