### PR TITLE
fix(store-engine-dexie): Remove dexie support check

### DIFF
--- a/packages/store-engine-dexie/src/index.ts
+++ b/packages/store-engine-dexie/src/index.ts
@@ -88,7 +88,6 @@ export class IndexedDBEngine implements CRUDEngine {
 
   public async initWithDb(db: Dexie, registerPersisted: boolean = false): Promise<Dexie> {
     const dexie = this.assignDb(db);
-    await this.isSupported();
     if (registerPersisted) {
       await this.registerPersistentStorage();
     }


### PR DESCRIPTION
Checking if the IndexedDB is usable **after** using Dexie doesn't really make sense and checking before using Dexie created a lot of errors in the WebApp, so let's revert it to [the state it was before](https://github.com/wireapp/wire-web-packages/commit/4a5b91c7ceaaa145c14adcad95cdb321ca7096c2#diff-bb108c1edd78163078083c97f40ec441L77).

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
