### PR TITLE
fix(api-client): Property key is always a string

### DIFF
--- a/packages/api-client/src/main/user/UserAPI.ts
+++ b/packages/api-client/src/main/user/UserAPI.ts
@@ -199,13 +199,13 @@ export class UserAPI {
    * @param propertyKey The property key to get
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getProperty
    */
-  public async getProperty<T extends string>(propertyKey: T): Promise<Record<T, any>> {
+  public async getProperty<T>(propertyKey: string): Promise<T> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${UserAPI.URL.PROPERTIES}/${propertyKey}`,
     };
 
-    const response = await this.client.sendJSON<Record<T, any>>(config);
+    const response = await this.client.sendJSON<T>(config);
     return response.data;
   }
 
@@ -424,7 +424,7 @@ export class UserAPI {
    * @param propertyData The property data to set
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/setProperty
    */
-  public async putProperty<T extends string>(propertyKey: T, propertyData: Record<T, any>): Promise<void> {
+  public async putProperty<T>(propertyKey: string, propertyData: T): Promise<void> {
     const config: AxiosRequestConfig = {
       data: propertyData,
       method: 'put',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
