### PR TITLE
refactor(core): Make context always available after login

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -16,6 +16,29 @@ Wire for Web's communication core.
 yarn add @wireapp/core
 ```
 
+### Setup
+
+```ts
+import {Account} from '@wireapp/core';
+import {APIClient} from '@wireapp/api-client';
+import {ClientType} from '@wireapp/api-client/dist/commonjs/client';
+import {LoginData} from '@wireapp/api-client/dist/commonjs/auth/';
+import {MemoryEngine} from '@wireapp/store-engine';
+
+const client = new APIClient({store: new MemoryEngine(), urls: APIClient.BACKEND.PRODUCTION});
+const account = new Account(client);
+const credentials: LoginData = {
+  clientType: ClientType.TEMPORARY,
+  email: 'email@wire.com',
+  password: 'password',
+};
+
+account.login(credentials).then(context => {
+  console.log('User ID', context.userId);
+  console.log('Client ID', context.clientId);
+});
+```
+
 #### Demo
 
 - [echo.js](./src/demo/echo.js)

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -144,11 +144,7 @@ export class Account extends EventEmitter {
     };
   }
 
-  public async login(
-    loginData: LoginData,
-    initClient: boolean = true,
-    clientInfo?: ClientInfo,
-  ): Promise<Context | undefined> {
+  public async login(loginData: LoginData, initClient: boolean = true, clientInfo?: ClientInfo): Promise<Context> {
     this.resetContext();
     await this.init();
 
@@ -160,7 +156,11 @@ export class Account extends EventEmitter {
       await this.initClient(loginData, clientInfo);
     }
 
-    return this.apiClient.context;
+    if (this.apiClient.context) {
+      return this.apiClient.context;
+    }
+
+    throw Error('Login failed.');
   }
 
   public async initClient(

--- a/packages/store-engine-fs/src/index.ts
+++ b/packages/store-engine-fs/src/index.ts
@@ -21,15 +21,16 @@ import {CRUDEngine, error as StoreEngineError} from '@wireapp/store-engine';
 import fs from 'fs-extra';
 import path from 'path';
 
+export interface FileEngineOptions {
+  fileExtension: string;
+}
+
 export class FileEngine implements CRUDEngine {
   [index: string]: any;
 
   private autoIncrementedPrimaryKey: number = 1;
 
   public storeName = '';
-  public options: {fileExtension: string} = {
-    fileExtension: '.dat',
-  };
   // Using a reference to Node.js' "path" module to influence the platform-specific behaviour in our tests
   public static path: any = path;
 
@@ -51,7 +52,12 @@ export class FileEngine implements CRUDEngine {
     return unsafePath;
   }
 
-  constructor(private readonly baseDirectory = './') {}
+  constructor(
+    private readonly baseDirectory: string = './',
+    public options: FileEngineOptions = {
+      fileExtension: '.dat',
+    },
+  ) {}
 
   public async isSupported(): Promise<void> {
     const isNodeOrElectron = typeof process === 'object';


### PR DESCRIPTION
Without this PR you have to check after calling `account.login` if `context` is existent. With the changes of this PR the conetxt will always be present after calling `login`.