### PR TITLE
chore: Remove dotenv types

### DIFF
--- a/packages/cli-client/package.json
+++ b/packages/cli-client/package.json
@@ -3,7 +3,6 @@
     "wire-cli": "dist/commonjs/index.js"
   },
   "dependencies": {
-    "@types/dotenv": "6.1.1",
     "@types/fs-extra": "8.0.0",
     "@types/long": "4.0.0",
     "@wireapp/core": "13.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,13 +2020,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/dotenv@6.1.1":
-  version "6.1.1"
-  resolved "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz#f7ce1cc4fe34f0a4373ba99fefa437b0bec54b46"
-  integrity sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ed2curve@0.2.2":
   version "0.2.2"
   resolved "https://registry.npmjs.org/@types/ed2curve/-/ed2curve-0.2.2.tgz#8f8bc7e2c9a5895a941c63a4f7acd7a6a62a5b15"


### PR DESCRIPTION
They are not needed anymore [since v8.2.0](https://github.com/motdotla/dotenv/compare/v8.1.0...v8.2.0).

Follow-up to https://github.com/wireapp/wire-web-packages/pull/2430.

## Pull Request Checklist

- [ ] ~~My code is covered by tests~~
- [ ] ~~I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes~~
