### PR TITLE
feat(core): Expose "init" and "register" calls from API client

### DIFF
--- a/packages/bot-api/src/MessageHandler.test.node.js
+++ b/packages/bot-api/src/MessageHandler.test.node.js
@@ -38,7 +38,7 @@ describe('MessageHandler', () => {
   beforeEach(async () => {
     mainHandler = new MainHandler();
     mainHandler.account = new Account();
-    await mainHandler.account.init(new MemoryEngine());
+    await mainHandler.account.initServices(new MemoryEngine());
     mainHandler.account.apiClient.createContext('', '');
 
     spyOn(mainHandler.account.service.conversation, 'send').and.returnValue(Promise.resolve());

--- a/packages/core/src/main/Account.test.browser.js
+++ b/packages/core/src/main/Account.test.browser.js
@@ -62,7 +62,7 @@ describe('Account', () => {
       };
 
       const account = new Account(apiClient, () => Promise.resolve(engine));
-      await account.init(engine);
+      await account.initServices(engine);
       spyOn(account.service.client, 'register').and.callThrough();
       account.service.client.synchronizeClients = () => Promise.resolve();
       account.service.notification.backend.getLastNotification = () => Promise.resolve({id: 'notification-id'});
@@ -82,7 +82,7 @@ describe('Account', () => {
       });
       const clientId = new UUID(UUIDVersion).toString();
       const account = new Account(apiClient, () => Promise.resolve(engine));
-      await account.init(engine);
+      await account.initServices(engine);
       spyOn(account.service.cryptography, 'initCryptobox').and.returnValue(Promise.resolve());
       spyOn(account.service.client, 'getLocalClient').and.returnValue(Promise.resolve({id: clientId}));
       spyOn(account.apiClient.client.api, 'getClient').and.returnValue(Promise.resolve({id: clientId}));
@@ -102,7 +102,7 @@ describe('Account', () => {
       });
       const clientId = new UUID(UUIDVersion).toString();
       const account = new Account(apiClient, () => Promise.resolve(engine));
-      await account.init(engine);
+      await account.initServices(engine);
       spyOn(account.service.client, 'register').and.returnValue(Promise.resolve({id: clientId}));
       spyOn(account.service.client, 'synchronizeClients').and.returnValue(Promise.resolve());
       spyOn(account.service.notification, 'initializeNotificationStream').and.returnValue(Promise.resolve());

--- a/packages/core/src/main/Account.test.node.ts
+++ b/packages/core/src/main/Account.test.node.ts
@@ -41,7 +41,7 @@ const MOCK_BACKEND = {
 async function createAccount(storageName = `test-${Date.now()}`): Promise<Account> {
   const apiClient = new APIClient({urls: MOCK_BACKEND});
   const account = new Account(apiClient);
-  await account.init(new MemoryEngine());
+  await account.initServices(new MemoryEngine());
   return account;
 }
 
@@ -135,7 +135,7 @@ describe('Account', () => {
     it('initializes the Protocol buffers', async () => {
       const account = new Account();
 
-      await account.init(new MemoryEngine());
+      await account.initServices(new MemoryEngine());
 
       expect(account.service!.conversation).toBeDefined();
       expect(account.service!.cryptography).toBeDefined();
@@ -154,7 +154,7 @@ describe('Account', () => {
       const apiClient = new APIClient({urls: MOCK_BACKEND});
       const account = new Account(apiClient);
 
-      await account.init(new MemoryEngine());
+      await account.initServices(new MemoryEngine());
       const {clientId, clientType, userId} = (await account.login({
         clientType: ClientType.TEMPORARY,
         email: 'hello@example.com',
@@ -170,7 +170,7 @@ describe('Account', () => {
       const apiClient = new APIClient({urls: MOCK_BACKEND});
       const account = new Account(apiClient);
 
-      await account.init(new MemoryEngine());
+      await account.initServices(new MemoryEngine());
 
       try {
         await account.login({

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -18,6 +18,7 @@
  */
 
 import {APIClient} from '@wireapp/api-client';
+import {RegisterData} from '@wireapp/api-client/dist/auth';
 import {
   AUTH_COOKIE_KEY,
   AUTH_TABLE_NAME,
@@ -159,7 +160,21 @@ export class Account extends EventEmitter {
     return this.apiClient.validatedUserId;
   }
 
-  public async init(storeEngine: CRUDEngine): Promise<void> {
+  public async register(registration: RegisterData, clientType: ClientType): Promise<Context> {
+    const context = await this.apiClient.register(registration, clientType);
+    const storeEngine = await this.initEngine(context);
+    await this.initServices(storeEngine);
+    return context;
+  }
+
+  public async init(clientType: ClientType): Promise<Context> {
+    const context = await this.apiClient.init(clientType);
+    const storeEngine = await this.initEngine(context);
+    await this.initServices(storeEngine);
+    return context;
+  }
+
+  public async initServices(storeEngine: CRUDEngine): Promise<void> {
     const assetService = new AssetService(this.apiClient);
     const cryptographyService = new CryptographyService(this.apiClient, storeEngine);
 
@@ -195,7 +210,7 @@ export class Account extends EventEmitter {
 
     const context = await this.apiClient.login(loginData);
     const storeEngine = await this.initEngine(context);
-    await this.init(storeEngine);
+    await this.initServices(storeEngine);
 
     if (initClient) {
       await this.initClient(loginData, clientInfo);

--- a/packages/core/src/main/conversation/AssetService.test.node.ts
+++ b/packages/core/src/main/conversation/AssetService.test.node.ts
@@ -28,7 +28,7 @@ describe('AssetService', () => {
   beforeAll(async () => {
     const client = new APIClient({urls: APIClient.BACKEND.STAGING});
     account = new Account(client);
-    await account.init(new MemoryEngine());
+    await account.initServices(new MemoryEngine());
   });
 
   describe('"uploadImageAsset"', () => {

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -56,7 +56,7 @@ describe('ConversationService', () => {
   beforeAll(async () => {
     const client = new APIClient({urls: APIClient.BACKEND.STAGING});
     account = new Account(client);
-    await account.init(new MemoryEngine());
+    await account.initServices(new MemoryEngine());
   });
 
   describe("'shouldSendAsExternal'", () => {


### PR DESCRIPTION
- `initServices` will be made "private" in my upcoming / next PR