### PR TITLE
fix(api-client): Disconnect WebSocket before logout

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -250,6 +250,7 @@ export class APIClient extends EventEmitter {
 
   public async logout(options = {ignoreError: false}): Promise<void> {
     try {
+      this.disconnect('Closed by client logout');
       await this.auth.api.postLogout();
     } catch (error) {
       if (options.ignoreError) {
@@ -261,7 +262,6 @@ export class APIClient extends EventEmitter {
       CookieStore.deleteCookie();
     }
 
-    this.disconnect('Closed by client logout');
     await this.accessTokenStore.delete();
     delete this.context;
   }


### PR DESCRIPTION
Fixes @C663605 and @C669373

![image](https://user-images.githubusercontent.com/1138344/69983264-8e6ac280-1536-11ea-9d5f-d62852c6281a.png)

The issue is that we first call logout which invalidates the cookie. Then the websocket is running for some more time until it gets disconnected as well. During this time the websocket complaints about the missing cookie.