### PR TITLE
fix(api-client): Use new endpoint to update a conversation's name

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -23,7 +23,6 @@ import {
   Conversation,
   ConversationCode,
   ConversationIds,
-  ConversationUpdate,
   Conversations,
   Invite,
   Member,
@@ -39,7 +38,12 @@ import {
 } from '../event/';
 import {HttpClient} from '../http/';
 import {ValidationError} from '../validation/';
-import {ConversationMemberUpdateData, ConversationMessageTimerUpdateData, ConversationTypingData} from './data';
+import {
+  ConversationMemberUpdateData,
+  ConversationNameUpdateData,
+  ConversationMessageTimerUpdateData,
+  ConversationTypingData,
+} from './data';
 
 export class ConversationAPI {
   public static readonly MAX_CHUNK_SIZE = 500;
@@ -51,6 +55,7 @@ export class ConversationAPI {
     JOIN: '/join',
     MEMBERS: 'members',
     MESSAGES: 'messages',
+    NAME: 'name',
     OTR: 'otr',
     SELF: 'self',
     TYPING: 'typing',
@@ -429,17 +434,17 @@ export class ConversationAPI {
   /**
    * Update conversation properties.
    * @param conversationId The conversation ID
-   * @param conversationData The new conversation
+   * @param conversationNameData The new conversation name
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateConversation
    */
   public async putConversation(
     conversationId: string,
-    conversationData: ConversationUpdate,
+    conversationNameData: ConversationNameUpdateData,
   ): Promise<ConversationRenameEvent> {
     const config: AxiosRequestConfig = {
-      data: conversationData,
+      data: conversationNameData,
       method: 'put',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}`,
+      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.NAME}`,
     };
 
     const response = await this.client.sendJSON<ConversationRenameEvent>(config);

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -40,8 +40,8 @@ import {HttpClient} from '../http/';
 import {ValidationError} from '../validation/';
 import {
   ConversationMemberUpdateData,
-  ConversationNameUpdateData,
   ConversationMessageTimerUpdateData,
+  ConversationNameUpdateData,
   ConversationTypingData,
 } from './data';
 

--- a/packages/api-client/src/conversation/data/ConversationNameUpdateData.ts
+++ b/packages/api-client/src/conversation/data/ConversationNameUpdateData.ts
@@ -17,6 +17,6 @@
  *
  */
 
-export interface ConversationUpdate {
+export interface ConversationNameUpdateData {
   name: string;
 }

--- a/packages/api-client/src/conversation/data/index.ts
+++ b/packages/api-client/src/conversation/data/index.ts
@@ -25,6 +25,7 @@ export * from './ConversationMemberJoinData';
 export * from './ConversationMemberLeaveData';
 export * from './ConversationMemberUpdateData';
 export * from './ConversationMessageTimerUpdateData';
+export * from './ConversationNameUpdateData';
 export * from './ConversationOtrMessageAddData';
 export * from './ConversationReceiptModeUpdateData';
 export * from './ConversationRenameData';

--- a/packages/api-client/src/conversation/index.ts
+++ b/packages/api-client/src/conversation/index.ts
@@ -25,7 +25,6 @@ export * from './ConversationError';
 export * from './ConversationIds';
 export * from './ConversationMembers';
 export * from './Conversations';
-export * from './ConversationUpdate';
 export * from './Invite';
 export * from './Member';
 export * from './MutedStatus';


### PR DESCRIPTION
Posting to `/conversations/{cnv}` is [deprecated](https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!//updateConversationName) and the new endpoint `/conversations/{cnv}/name` [should be used](https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!//updateConversationName_0).

To align this function with the others, I renamed and moved the appropriate interface.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
