### PR TITLE
refactor(commons): Drop external ansi-regex definitions

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@types/ansi-regex": "5.0.0",
     "@types/fs-extra": "8.0.1",
     "@types/node": "~12",
     "@types/platform": "1.3.2",


### PR DESCRIPTION
 ansi-regex now provides its own type definitions, so no more external definitions needed.