### PR TITLE
chore(api-client): Remove long debug output

### DIFF
--- a/packages/api-client/src/tcp/ReconnectingWebsocket.ts
+++ b/packages/api-client/src/tcp/ReconnectingWebsocket.ts
@@ -103,7 +103,7 @@ export class ReconnectingWebsocket {
   };
 
   private readonly internalOnOpen = (event: Event) => {
-    this.logger.debug('WebSocket opened', event);
+    this.logger.debug('WebSocket opened');
     if (this.socket) {
       this.socket.binaryType = 'arraybuffer';
     }
@@ -121,7 +121,7 @@ export class ReconnectingWebsocket {
   };
 
   private readonly internalOnClose = (event: CloseEvent) => {
-    this.logger.debug('WebSocket closed', event);
+    this.logger.debug('WebSocket closed');
     this.stopPinging();
     if (this.onClose) {
       this.onClose(event);


### PR DESCRIPTION
This removes long outputs from the logs since it's not possible to hide `debug` outputs from logdown.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
