### PR TITLE
refactor: Set prototype of errors

### DIFF
--- a/packages/api-client/src/auth/AuthenticationError.ts
+++ b/packages/api-client/src/auth/AuthenticationError.ts
@@ -22,7 +22,7 @@ import {BackendError, BackendErrorLabel, StatusCode, SyntheticErrorLabel} from '
 export class AuthenticationError extends BackendError {
   constructor(message: string, label: BackendErrorLabel | SyntheticErrorLabel, code: StatusCode) {
     super(message, label, code);
-    Object.setPrototypeOf(this, AuthenticationError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'AuthenticationError';
   }
 }
@@ -30,7 +30,7 @@ export class AuthenticationError extends BackendError {
 export class LoginTooFrequentError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.CLIENT_ERROR, code = StatusCode.TOO_MANY_REQUESTS) {
     super(message, label, code);
-    Object.setPrototypeOf(this, LoginTooFrequentError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'LoginTooFrequentError';
   }
 }
@@ -38,7 +38,7 @@ export class LoginTooFrequentError extends AuthenticationError {
 export class InvalidCredentialsError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.INVALID_CREDENTIALS, code = StatusCode.FORBIDDEN) {
     super(message, label, code);
-    Object.setPrototypeOf(this, InvalidCredentialsError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'InvalidCredentialsError';
   }
 }
@@ -46,7 +46,7 @@ export class InvalidCredentialsError extends AuthenticationError {
 export class SuspendedAccountError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.SUSPENDED_ACCOUNT, code = StatusCode.FORBIDDEN) {
     super(message, label, code);
-    Object.setPrototypeOf(this, SuspendedAccountError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'SuspendedAccountError';
   }
 }
@@ -54,7 +54,7 @@ export class SuspendedAccountError extends AuthenticationError {
 export class IdentifierExistsError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.KEY_EXISTS, code = StatusCode.CONFLICT) {
     super(message, label, code);
-    Object.setPrototypeOf(this, IdentifierExistsError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'IdentifierExistsError';
   }
 }
@@ -62,7 +62,7 @@ export class IdentifierExistsError extends AuthenticationError {
 export class TokenExpiredError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.INVALID_CREDENTIALS, code = StatusCode.FORBIDDEN) {
     super(message, label, code);
-    Object.setPrototypeOf(this, TokenExpiredError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'TokenExpiredError';
   }
 }
@@ -70,7 +70,7 @@ export class TokenExpiredError extends AuthenticationError {
 export class InvalidTokenError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.INVALID_CREDENTIALS, code = StatusCode.FORBIDDEN) {
     super(message, label, code);
-    Object.setPrototypeOf(this, InvalidTokenError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'InvalidTokenError';
   }
 }
@@ -78,7 +78,7 @@ export class InvalidTokenError extends AuthenticationError {
 export class MissingCookieError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.INVALID_CREDENTIALS, code = StatusCode.FORBIDDEN) {
     super(message, label, code);
-    Object.setPrototypeOf(this, MissingCookieError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'MissingCookieError';
   }
 }
@@ -86,7 +86,7 @@ export class MissingCookieError extends AuthenticationError {
 export class InvalidPhoneNumberError extends AuthenticationError {
   constructor(message: string, label = SyntheticErrorLabel.INVALID_PHONE_NUMBER, code = StatusCode.BAD_REQUEST) {
     super(message, label, code);
-    Object.setPrototypeOf(this, InvalidPhoneNumberError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'InvalidPhoneNumberError';
   }
 }
@@ -94,7 +94,7 @@ export class InvalidPhoneNumberError extends AuthenticationError {
 export class ForbiddenPhoneNumberError extends AuthenticationError {
   constructor(message: string, label = SyntheticErrorLabel.FORBIDDEN_PHONE_NUMBER, code = StatusCode.FORBIDDEN) {
     super(message, label, code);
-    Object.setPrototypeOf(this, ForbiddenPhoneNumberError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ForbiddenPhoneNumberError';
   }
 }
@@ -102,7 +102,7 @@ export class ForbiddenPhoneNumberError extends AuthenticationError {
 export class PasswordExistsError extends AuthenticationError {
   constructor(message: string, label = BackendErrorLabel.PASSWORD_EXISTS, code = StatusCode.UNAUTHORIZED) {
     super(message, label, code);
-    Object.setPrototypeOf(this, PasswordExistsError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'PasswordExistsError';
   }
 }

--- a/packages/api-client/src/conversation/ConversationError.ts
+++ b/packages/api-client/src/conversation/ConversationError.ts
@@ -22,7 +22,7 @@ import {BackendError, BackendErrorLabel, StatusCode} from '../http/';
 export class ConversationError extends BackendError {
   constructor(message: string, label: BackendErrorLabel, code: StatusCode) {
     super(message, label, code);
-    Object.setPrototypeOf(this, ConversationError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ConversationError';
   }
 }
@@ -34,7 +34,7 @@ export class ConversationIsUnknownError extends ConversationError {
     code: StatusCode = StatusCode.BAD_REQUEST,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, ConversationIsUnknownError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ConversationIsUnknownError';
   }
 }
@@ -46,7 +46,7 @@ export class ConversationOperationError extends ConversationError {
     code: StatusCode = StatusCode.FORBIDDEN,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, ConversationOperationError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ConversationOperationError';
   }
 }

--- a/packages/api-client/src/http/BackendError.ts
+++ b/packages/api-client/src/http/BackendError.ts
@@ -34,7 +34,6 @@ export class BackendError extends Error {
     this.code = code;
     this.label = label;
     this.message = message;
-    // see https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    Object.setPrototypeOf(this, BackendError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/api-client/src/http/NetworkError.ts
+++ b/packages/api-client/src/http/NetworkError.ts
@@ -20,7 +20,7 @@
 export class NetworkError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, NetworkError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'NetworkError';
     this.stack = new Error().stack;
   }

--- a/packages/api-client/src/team/TeamError.ts
+++ b/packages/api-client/src/team/TeamError.ts
@@ -22,7 +22,7 @@ import {BackendError, BackendErrorLabel, StatusCode, SyntheticErrorLabel} from '
 export class TeamError extends BackendError {
   constructor(message: string, label: BackendErrorLabel | SyntheticErrorLabel, code: StatusCode) {
     super(message, label, code);
-    Object.setPrototypeOf(this, TeamError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ConversationError';
   }
 }
@@ -34,7 +34,7 @@ export class InviteEmailInUseError extends TeamError {
     code: StatusCode = StatusCode.CONFLICT,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, InviteEmailInUseError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'InviteEmailInUseError';
   }
 }
@@ -46,7 +46,7 @@ export class InvalidInvitationCodeError extends TeamError {
     code: StatusCode = StatusCode.BAD_REQUEST,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, InvalidInvitationCodeError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'InvalidInvitationCodeError';
   }
 }
@@ -58,7 +58,7 @@ export class ServiceNotFoundError extends TeamError {
     code: StatusCode = StatusCode.NOT_FOUND,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, ServiceNotFoundError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'ServiceNotFoundError';
   }
 }

--- a/packages/api-client/src/user/UserError.ts
+++ b/packages/api-client/src/user/UserError.ts
@@ -22,7 +22,7 @@ import {BackendError, BackendErrorLabel, StatusCode} from '../http/';
 export class UserError extends BackendError {
   constructor(message: string, label: BackendErrorLabel, code: StatusCode) {
     super(message, label, code);
-    Object.setPrototypeOf(this, UserError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'UserError';
   }
 }
@@ -34,7 +34,7 @@ export class UserIsUnknownError extends UserError {
     code: StatusCode = StatusCode.BAD_REQUEST,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, UserIsUnknownError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'UserIsUnknownError';
   }
 }
@@ -46,7 +46,7 @@ export class UnconnectedUserError extends UserError {
     code: StatusCode = StatusCode.FORBIDDEN,
   ) {
     super(message, label, code);
-    Object.setPrototypeOf(this, UserIsUnknownError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'UnconnectedUserError';
   }
 }

--- a/packages/api-client/src/validation/ValidationError.ts
+++ b/packages/api-client/src/validation/ValidationError.ts
@@ -20,10 +20,6 @@
 export class ValidationError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, ValidationError.prototype);
-
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/bazinga64/src/UnsupportedInputError.ts
+++ b/packages/bazinga64/src/UnsupportedInputError.ts
@@ -20,9 +20,6 @@
 export class UnsupportedInputError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, UnsupportedInputError.prototype);
-    this.name = this.constructor.name;
-    this.message = message;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/cbor/src/main/cbor/BaseError.ts
+++ b/packages/cbor/src/main/cbor/BaseError.ts
@@ -20,9 +20,6 @@
 export class BaseError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, BaseError.prototype);
-
-    this.message = message;
-    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/cbor/src/main/cbor/DecodeError.ts
+++ b/packages/cbor/src/main/cbor/DecodeError.ts
@@ -30,8 +30,6 @@ export class DecodeError extends BaseError {
 
   constructor(public message: string, public extra?: Type[]) {
     super(message);
-
-    Object.setPrototypeOf(this, DecodeError.prototype);
-    this.extra = extra;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/cryptobox/src/main/DecryptionError.ts
+++ b/packages/cryptobox/src/main/DecryptionError.ts
@@ -20,10 +20,6 @@
 export class DecryptionError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, DecryptionError.prototype);
-
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/cryptobox/src/main/InvalidPreKeyFormatError.ts
+++ b/packages/cryptobox/src/main/InvalidPreKeyFormatError.ts
@@ -20,9 +20,6 @@
 export class InvalidPreKeyFormatError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, InvalidPreKeyFormatError.prototype);
-    this.name = this.constructor.name;
-    this.message = message;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/cryptobox/src/main/error/CryptoboxError.ts
+++ b/packages/cryptobox/src/main/error/CryptoboxError.ts
@@ -20,10 +20,6 @@
 export class CryptoboxError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, CryptoboxError.prototype);
-
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/proteus/src/main/errors/DecodeError.ts
+++ b/packages/proteus/src/main/errors/DecodeError.ts
@@ -29,7 +29,7 @@ export class DecodeError extends ProteusError {
 
   constructor(message = 'Unknown decoding error', code = 3) {
     super(message, code);
-    Object.setPrototypeOf(this, DecodeError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 
@@ -37,21 +37,21 @@ export namespace DecodeError {
   export class InvalidType extends DecodeError {
     constructor(message = 'Invalid type', code: number) {
       super(message, code);
-      Object.setPrototypeOf(this, InvalidType.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class InvalidArrayLen extends DecodeError {
     constructor(message = 'Invalid array length', code: number) {
       super(message, code);
-      Object.setPrototypeOf(this, InvalidArrayLen.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class LocalIdentityChanged extends DecodeError {
     constructor(message = 'Local identity changed', code: number) {
       super(message, code);
-      Object.setPrototypeOf(this, LocalIdentityChanged.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 }

--- a/packages/proteus/src/main/errors/DecryptError.ts
+++ b/packages/proteus/src/main/errors/DecryptError.ts
@@ -40,7 +40,7 @@ export class DecryptError extends ProteusError {
 
   constructor(message: string = 'Unknown decryption error', code: number = 2) {
     super(message, code);
-    Object.setPrototypeOf(this, DecryptError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 
@@ -48,42 +48,42 @@ export namespace DecryptError {
   export class DuplicateMessage extends DecryptError {
     constructor(message: string = 'Duplicate message', code: number = DecryptError.CODE.CASE_209) {
       super(message, code);
-      Object.setPrototypeOf(this, DuplicateMessage.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class InvalidMessage extends DecryptError {
     constructor(message: string = 'Invalid message', code?: number) {
       super(message, code);
-      Object.setPrototypeOf(this, InvalidMessage.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class InvalidSignature extends DecryptError {
     constructor(message: string = 'Invalid signature', code?: number) {
       super(message, code);
-      Object.setPrototypeOf(this, InvalidSignature.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class OutdatedMessage extends DecryptError {
     constructor(message: string = 'Outdated message', code: number = DecryptError.CODE.CASE_208) {
       super(message, code);
-      Object.setPrototypeOf(this, OutdatedMessage.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class PrekeyNotFound extends DecryptError {
     constructor(message: string = 'Pre-key not found', code?: number) {
       super(message, code);
-      Object.setPrototypeOf(this, PrekeyNotFound.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class RemoteIdentityChanged extends DecryptError {
     constructor(message: string = 'Remote identity changed', code?: number) {
       super(message, code);
-      Object.setPrototypeOf(this, RemoteIdentityChanged.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
@@ -93,14 +93,14 @@ export namespace DecryptError {
       code: number = DecryptError.CODE.CASE_213,
     ) {
       super(message, code);
-      Object.setPrototypeOf(this, RemoteEncryptionError.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class TooDistantFuture extends DecryptError {
     constructor(message: string = 'Message is from too distant in the future', code?: number) {
       super(message, code);
-      Object.setPrototypeOf(this, TooDistantFuture.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 }

--- a/packages/proteus/src/main/errors/InputError.ts
+++ b/packages/proteus/src/main/errors/InputError.ts
@@ -35,7 +35,7 @@ export class InputError extends ProteusError {
 
   constructor(message = 'Invalid input', code = 4) {
     super(message, code);
-    Object.setPrototypeOf(this, InputError.prototype);
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 
@@ -43,21 +43,21 @@ export namespace InputError {
   export class RangeError extends InputError {
     constructor(message = 'Invalid array length', code: number) {
       super(message, code);
-      Object.setPrototypeOf(this, RangeError.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class TypeError extends InputError {
     constructor(message = 'Invalid type', code: number) {
       super(message, code);
-      Object.setPrototypeOf(this, TypeError.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 
   export class ConversionError extends InputError {
     constructor(message = 'Conversion error', code: number) {
       super(message, code);
-      Object.setPrototypeOf(this, ConversionError.prototype);
+      Object.setPrototypeOf(this, new.target.prototype);
     }
   }
 }

--- a/packages/proteus/src/main/errors/ProteusError.ts
+++ b/packages/proteus/src/main/errors/ProteusError.ts
@@ -28,10 +28,6 @@ export class ProteusError extends Error {
 
   constructor(public message: string, public code = 1) {
     super(message);
-    Object.setPrototypeOf(this, ProteusError.prototype);
-
-    this.code = code;
-    this.message = message;
-    this.name = this.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/store-engine/src/main/engine/error/LowDiskSpaceError.ts
+++ b/packages/store-engine/src/main/engine/error/LowDiskSpaceError.ts
@@ -20,10 +20,6 @@
 export class LowDiskSpaceError extends Error {
   constructor(public message: string = 'Not enough storage to save the record.') {
     super(message);
-    Object.setPrototypeOf(this, LowDiskSpaceError.prototype);
-
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/store-engine/src/main/engine/error/PathValidationError.ts
+++ b/packages/store-engine/src/main/engine/error/PathValidationError.ts
@@ -20,10 +20,6 @@
 export class PathValidationError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, PathValidationError.prototype);
-
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/store-engine/src/main/engine/error/RecordAlreadyExistsError.ts
+++ b/packages/store-engine/src/main/engine/error/RecordAlreadyExistsError.ts
@@ -22,11 +22,7 @@ export class RecordAlreadyExistsError extends Error {
 
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, RecordAlreadyExistsError.prototype);
-
     this.code = 1;
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/store-engine/src/main/engine/error/RecordNotFoundError.ts
+++ b/packages/store-engine/src/main/engine/error/RecordNotFoundError.ts
@@ -22,11 +22,7 @@ export class RecordNotFoundError extends Error {
 
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, RecordNotFoundError.prototype);
-
     this.code = 2;
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/store-engine/src/main/engine/error/RecordTypeError.ts
+++ b/packages/store-engine/src/main/engine/error/RecordTypeError.ts
@@ -22,11 +22,7 @@ export class RecordTypeError extends Error {
 
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, RecordTypeError.prototype);
-
     this.code = 3;
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }

--- a/packages/store-engine/src/main/engine/error/UnsupportedError.ts
+++ b/packages/store-engine/src/main/engine/error/UnsupportedError.ts
@@ -22,11 +22,7 @@ export class UnsupportedError extends Error {
 
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, UnsupportedError.prototype);
-
     this.code = 4;
-    this.message = message;
-    this.name = this.constructor.name;
-    this.stack = new Error().stack;
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }


### PR DESCRIPTION
Let's use `new.target.prototype`!

See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html#support-for-newtarget

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
