### PR TITLE
chore(deps-dev): bump reconnecting-websocket to 4.4.0

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -11,7 +11,7 @@
     "@wireapp/priority-queue": "1.5.3",
     "axios": "0.19.2",
     "logdown": "3.3.0",
-    "reconnecting-websocket": "wireapp/reconnecting-websocket#96ac796ae8c7a7d9d857f46ed39dbedd7b9ad378",
+    "reconnecting-websocket": "4.4.0",
     "spark-md5": "3.0.0",
     "tough-cookie": "3.0.1",
     "ws": "7.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11815,9 +11815,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-reconnecting-websocket@wireapp/reconnecting-websocket#96ac796ae8c7a7d9d857f46ed39dbedd7b9ad378:
-  version "4.2.0"
-  resolved "https://codeload.github.com/wireapp/reconnecting-websocket/tar.gz/96ac796ae8c7a7d9d857f46ed39dbedd7b9ad378"
+reconnecting-websocket@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz#3b0e5b96ef119e78a03135865b8bb0af1b948783"
+  integrity sha512-D2E33ceRPga0NvTDhJmphEgJ7FUYF0v4lr1ki0csq06OdlxKfugGzN0dSkxM/NfqCxYELK4KcaTOUOjTV6Dcng==
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Since Florian's PR (https://github.com/pladaria/reconnecting-websocket/pull/113) got merged, we can take the official route. 😎 