### PR TITLE
fix(api-client): Change response type for broadcast OTR messages

### DIFF
--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -19,7 +19,7 @@
 
 import {AxiosRequestConfig} from 'axios';
 
-import {ClientMismatch, NewOTRMessage, UserClients} from '../conversation/';
+import {ClientMismatch, NewOTRMessage} from '../conversation/';
 import {HttpClient} from '../http/';
 import {ValidationError} from '../validation/';
 

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -19,7 +19,7 @@
 
 import {AxiosRequestConfig} from 'axios';
 
-import {NewOTRMessage, UserClients} from '../conversation/';
+import {ClientMismatch, NewOTRMessage, UserClients} from '../conversation/';
 import {HttpClient} from '../http/';
 import {ValidationError} from '../validation/';
 
@@ -43,7 +43,7 @@ export class BroadcastAPI {
       ignore_missing?: boolean;
       report_missing?: string;
     },
-  ): Promise<UserClients> {
+  ): Promise<ClientMismatch> {
     if (!clientId) {
       throw new ValidationError('Unable to send OTR message without client ID.');
     }

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -67,8 +67,8 @@ export class BroadcastAPI {
 
     const response =
       typeof messageData.recipients === 'object'
-        ? await this.client.sendJSON<UserClients>(config)
-        : await this.client.sendProtocolBuffer<UserClients>(config);
+        ? await this.client.sendJSON<ClientMismatch>(config)
+        : await this.client.sendProtocolBuffer<ClientMismatch>(config);
     return response.data;
   }
 }

--- a/packages/api-client/src/conversation/UserClients.ts
+++ b/packages/api-client/src/conversation/UserClients.ts
@@ -17,6 +17,8 @@
  *
  */
 
+type clientIds = string[];
+
 export interface UserClients {
-  [userId: string]: string[]; // User ID → Array of Client IDs
+  [userId: string]: clientIds;
 }

--- a/packages/api-client/src/conversation/UserClients.ts
+++ b/packages/api-client/src/conversation/UserClients.ts
@@ -20,5 +20,5 @@
 type ClientIds = string[];
 
 export interface UserClients {
-  [userId: string]: clientIds;
+  [userId: string]: ClientIds;
 }

--- a/packages/api-client/src/conversation/UserClients.ts
+++ b/packages/api-client/src/conversation/UserClients.ts
@@ -17,7 +17,7 @@
  *
  */
 
-type clientIds = string[];
+type ClientIds = string[];
 
 export interface UserClients {
   [userId: string]: clientIds;


### PR DESCRIPTION
POSTing ` /broadcast/otr/messages` returns the same as posting to `/conversations/{cnv}/otr/messages`.

See:
- https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postProtoOtrMessage
- https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postOtrBroadcast