### PR TITLE
fix(api-client,core,cryptobox): Improve type compatibility with Node 13

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import logdown from 'logdown';
 
 import {AccountAPI} from './account/AccountAPI';

--- a/packages/api-client/src/auth/AccessTokenStore.ts
+++ b/packages/api-client/src/auth/AccessTokenStore.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import logdown from 'logdown';
 
 import {AccessTokenData} from '../auth/';

--- a/packages/api-client/src/auth/CookieStore.ts
+++ b/packages/api-client/src/auth/CookieStore.ts
@@ -18,7 +18,7 @@
  */
 
 import {Runtime} from '@wireapp/commons';
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import {Cookie} from './Cookie';
 
 enum TOPIC {

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -20,7 +20,7 @@
 import {TimeUtil} from '@wireapp/commons';
 import {PriorityQueue} from '@wireapp/priority-queue';
 import axios, {AxiosError, AxiosRequestConfig, AxiosResponse} from 'axios';
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import logdown from 'logdown';
 import {AccessTokenData, AccessTokenStore, AuthAPI} from '../auth/';
 import {BackendErrorMapper, ConnectionState, ContentType, NetworkError, StatusCode} from '../http/';

--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import logdown from 'logdown';
 import {CloseEvent, ErrorEvent, Event} from 'reconnecting-websocket';
 

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -33,7 +33,7 @@ import {StatusCode} from '@wireapp/api-client/dist/http/';
 import {WebSocketClient} from '@wireapp/api-client/dist/tcp/';
 import * as cryptobox from '@wireapp/cryptobox';
 import {CRUDEngine, MemoryEngine, error as StoreEngineError} from '@wireapp/store-engine';
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import logdown from 'logdown';
 import {LoginSanitizer} from './auth/';
 import {BroadcastService} from './broadcast/';

--- a/packages/cryptobox/src/main/Cryptobox.ts
+++ b/packages/cryptobox/src/main/Cryptobox.ts
@@ -22,7 +22,7 @@ import {PriorityQueue} from '@wireapp/priority-queue';
 import {keys as ProteusKeys, message as ProteusMessage, session as ProteusSession} from '@wireapp/proteus';
 import {CRUDEngine} from '@wireapp/store-engine';
 import {Decoder, Encoder} from 'bazinga64';
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 import logdown from 'logdown';
 import {CryptoboxSession} from './CryptoboxSession';
 import {DecryptionError} from './DecryptionError';


### PR DESCRIPTION
When a project uses "@types/node" 12.x and our "@wireapp/core" everything works great but when a project uses "@types/node" 13.x and our "@wireapp/core" then we will see this TypeScript error:

> error TS2507: Type 'typeof EventEmitter' is not a constructor function type.

Starting with Node 13 the `EventEmitter` should **not** be consumed from the default export: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/42164#issuecomment-583045095