### PR TITLE
feat(eslint-config): Warn when using fdescribe or fit

### DIFF
--- a/packages/eslint-config/eslintrc.json
+++ b/packages/eslint-config/eslintrc.json
@@ -50,6 +50,17 @@
         "ignore": [-1, 0, 1, 2]
       }
     ],
+    "no-restricted-globals": [
+      "warn",
+      {
+        "name": "fit",
+        "message": "Do not commit `fit`. Use `it` instead."
+      },
+      {
+        "name": "fdescribe",
+        "message": "Do not commit `fdescribe`. Use `describe` instead."
+      }
+    ],
     "no-return-await": "error",
     "no-sequences": "error",
     "no-sparse-arrays": "error",


### PR DESCRIPTION
This will warn users who are committing `fdescribe()` or `fit()`.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
