### PR TITLE
Revert "refactor(core): Remove unused "createPollMessage" function"

### DIFF
--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -18,15 +18,14 @@
  */
 
 import {APIClient} from '@wireapp/api-client';
-import {ClientAction, Confirmation} from '@wireapp/protocol-messaging';
+import {Button, ClientAction, Composite, Confirmation, Text} from '@wireapp/protocol-messaging';
 import {AbortReason, PayloadBundleSource, PayloadBundleState, PayloadBundleType} from '..';
 import {AssetService} from '../AssetService';
 import {
-  ButtonActionConfirmationContent,
   ButtonActionContent,
+  ButtonActionConfirmationContent,
   CallingContent,
   ClientActionContent,
-  CompositeContent,
   ConfirmationContent,
   EditedTextContent,
   FileAssetAbortContent,
@@ -43,11 +42,11 @@ import {
   LocationContent,
   ReactionContent,
   TextContent,
+  CompositeContent,
 } from '../content';
-import {CompositeContentBuilder} from './CompositeContentBuilder';
 import {
-  ButtonActionConfirmationMessage,
   ButtonActionMessage,
+  ButtonActionConfirmationMessage,
   CallMessage,
   CompositeMessage,
   ConfirmationMessage,
@@ -63,6 +62,8 @@ import {
   TextMessage,
 } from './OtrMessage';
 import {TextContentBuilder} from './TextContentBuilder';
+import Item = Composite.Item;
+import {CompositeContentBuilder} from './CompositeContentBuilder';
 
 const UUID = require('pure-uuid');
 
@@ -325,6 +326,34 @@ export class MessageBuilder {
       state: PayloadBundleState.OUTGOING_UNSENT,
       timestamp: Date.now(),
       type: PayloadBundleType.BUTTON_ACTION_CONFIRMATION,
+    };
+  }
+
+  createPollMessage(
+    conversationId: string,
+    text: Text,
+    buttons: string[],
+    messageId = MessageBuilder.createId(),
+  ): CompositeMessage {
+    const buttonProtos = [];
+    for (let counter = 0; counter < buttons.length; counter++) {
+      const buttonText = buttons[counter];
+      buttonProtos.push(Button.create({id: counter.toString(10), text: buttonText}));
+    }
+
+    const content: CompositeContent = {
+      items: [Item.create({text}), ...buttonProtos.map(button => Item.create({button}))],
+    };
+
+    return {
+      content,
+      conversation: conversationId,
+      from: this.getSelfUserId(),
+      id: messageId,
+      source: PayloadBundleSource.LOCAL,
+      state: PayloadBundleState.OUTGOING_UNSENT,
+      timestamp: Date.now(),
+      type: PayloadBundleType.COMPOSITE,
     };
   }
 


### PR DESCRIPTION
Reverts wireapp/wire-web-packages#2949

It's being used here: https://github.com/wireapp/wire-absence-bot/pull/36/files#diff-02f6bfe8e2721e987d0ff5f233a5349cR88