### PR TITLE
refactor: Resolve monorepo path aliases with ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "husky": "4.2.5",
     "lerna": "3.20.2",
     "lint-staged": "10.2.9",
-    "prettier": "2.0.5"
+    "prettier": "2.0.5",
+    "ts-node": "8.10.2",
+    "tsconfig-paths": "3.9.0"
   },
   "engines": {
     "node": ">= 10.9",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -77,7 +77,7 @@
     "coverage": "istanbul cover --report html ./node_modules/jasmine/bin/jasmine.js",
     "dist": "yarn clean && yarn build",
     "start": "yarn build:node && concurrently \"tsc -w\" \"webpack -w\" \"browser-sync start -c bs-config.js\"",
-    "start:node": "ts-node demo.ts",
+    "start:node": "ts-node -r tsconfig-paths/register demo.ts",
     "test": "yarn test:node && yarn test:browser",
     "test:project": "yarn dist && yarn test",
     "test:browser": "karma start",

--- a/packages/bot-api/package.json
+++ b/packages/bot-api/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:node",
     "build:node": "tsc",
     "clean": "rimraf dist",
-    "demo:admin": "ts-node src/demo/admin.ts",
+    "demo:admin": "ts-node -r tsconfig-paths/register src/demo/admin.ts",
     "dist": "yarn clean && yarn build",
     "test": "yarn test:node",
     "test:node": "jasmine --config=jasmine.json",

--- a/packages/bot-handler-debug/package.json
+++ b/packages/bot-handler-debug/package.json
@@ -8,7 +8,6 @@
     "@wireapp/bot-api": "7.10.6",
     "jasmine": "3.5.0",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "files": [

--- a/packages/cli-client/package.json
+++ b/packages/cli-client/package.json
@@ -13,7 +13,6 @@
     "@types/fs-extra": "8.1.0",
     "@types/long": "4.0.1",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "description": "Command-line interface for Wire's secure messaging platform.",
@@ -29,7 +28,7 @@
     "build:node": "tsc",
     "clean": "rimraf dist",
     "dist": "yarn clean && yarn build",
-    "start": "ts-node src/index.ts",
+    "start": "ts-node -r tsconfig-paths/register src/index.ts",
     "test": "yarn test:node",
     "test:project": "yarn dist && yarn test",
     "test:node": "exit 0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,6 @@
     "nock": "12.0.3",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.9.2",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.12"

--- a/packages/license-collector/package.json
+++ b/packages/license-collector/package.json
@@ -14,7 +14,6 @@
     "@types/node": "~12",
     "@types/npm-registry-package-info": "1.0.0",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "files": [
@@ -29,7 +28,7 @@
     "build:node": "tsc",
     "clean": "rimraf dist",
     "dist": "yarn clean && yarn build",
-    "start": "ts-node ./src/cli.ts",
+    "start": "ts-node -r tsconfig-paths/register ./src/cli.ts",
     "test": "exit 0"
   },
   "version": "0.8.0"

--- a/packages/lru-cache/package.json
+++ b/packages/lru-cache/package.json
@@ -6,7 +6,6 @@
     "jasmine": "3.5.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.9.2",
     "webpack": "4.43.0",
     "webpack-cli": "3.3.12"

--- a/packages/proteus/package.json
+++ b/packages/proteus/package.json
@@ -28,7 +28,7 @@
   "name": "@wireapp/proteus",
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/proteus",
   "scripts": {
-    "benchmark": "ts-node src/demo/benchmark.ts",
+    "benchmark": "ts-node -r tsconfig-paths/register src/demo/benchmark.ts",
     "build:node": "tsc",
     "clean": "rimraf dist",
     "dist": "yarn clean && yarn build:node",

--- a/packages/store-engine-bro-fs/package.json
+++ b/packages/store-engine-bro-fs/package.json
@@ -14,7 +14,6 @@
     "karma-jasmine": "3.1.1",
     "karma-typescript": "5.0.2",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "description": "Store Engine implementation for the browser's File and Directory Entries API.",

--- a/packages/store-engine-dexie/package.json
+++ b/packages/store-engine-dexie/package.json
@@ -14,7 +14,6 @@
     "karma-typescript": "5.0.2",
     "logdown": "3.3.1",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "description": "Store Engine implementation for the browser's IndexedDB.",

--- a/packages/store-engine-fs/package.json
+++ b/packages/store-engine-fs/package.json
@@ -10,7 +10,6 @@
     "jasmine": "3.5.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "description": "Store Engine implementation for Node.js' File System.",

--- a/packages/store-engine-sqleet/package.json
+++ b/packages/store-engine-sqleet/package.json
@@ -24,7 +24,6 @@
     "karma-jasmine": "3.1.1",
     "karma-webpack": "4.0.2",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.9.2",
     "webpack": "4.43.0"
   },

--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -10,7 +10,6 @@
     "karma-jasmine": "3.1.1",
     "karma-typescript": "5.0.2",
     "rimraf": "3.0.2",
-    "ts-node": "8.6.2",
     "typescript": "3.8.3"
   },
   "description": "Store Engine wrapper for the browser's Web Storage API.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,6 +2500,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/karma-webpack@2.0.7":
   version "2.0.7"
   resolved "https://registry.npmjs.org/@types/karma-webpack/-/karma-webpack-2.0.7.tgz#967e7971d8bc3d8da31110f44556842eca3aed85"
@@ -14125,6 +14130,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.16"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -15123,6 +15136,17 @@ trough@^1.0.0:
   resolved "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-node@8.10.2:
+  version "8.10.2"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
+  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-node@8.6.2:
   version "8.6.2"
   resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
@@ -15144,6 +15168,16 @@ ts-node@8.8.2:
     make-error "^1.1.1"
     source-map-support "^0.5.6"
     yn "3.1.1"
+
+tsconfig-paths@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
## What has been changed?

- With this PR "ts-node" becomes a shared dev dependency between all packages, there is no need anymore to declare it for every single package if you want to use it to run a demo script

- With this PR "ts-node" will be equipped with "tsconfig-paths". This allows us to run ts-node on a top level project without rebuilding transitive dependencies first. **Example:** When changing TypeScript code in the "api-client" and running a script with ts-node in our "core" module, the changes from the API client won't be usable until you rebuild the API client (compiling it to JavaScript). With "tsconfig-paths" you don't need to recompile packages from deep down as it will help the top-level ts-node script to resolve the TypeScript monorepo links.