### PR TITLE
chore: Hoist @types/long dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     ],
     "nohoist": [
       "**/@jest/**/*",
-      "**/@types/**/*",
+      "**/@types/!(long)**/*",
       "**/emotion-normalize",
       "**/jest-emotion",
       "**/react"

--- a/packages/bot-api/package.json
+++ b/packages/bot-api/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@types/long": "4.0.1",
     "@types/node": "*",
     "@wireapp/core": "16.10.17",
     "uuidjs": "4.2.5"
@@ -11,7 +10,7 @@
     "jasmine": "3.5.0",
     "rimraf": "3.0.2",
     "ts-node": "8.6.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "dist",

--- a/packages/bot-handler-debug/package.json
+++ b/packages/bot-handler-debug/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@types/long": "4.0.1",
     "@types/node": "*"
   },
   "devDependencies": {
@@ -8,7 +7,7 @@
     "@wireapp/bot-api": "7.10.17",
     "jasmine": "3.5.0",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "dist",

--- a/packages/bot-handler-uptime/package.json
+++ b/packages/bot-handler-uptime/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@types/long": "4.0.1",
     "@types/moment-duration-format": "2.2.2",
     "moment": "2.26.0",
     "moment-duration-format": "2.3.2"

--- a/packages/changelog-bot/package.json
+++ b/packages/changelog-bot/package.json
@@ -4,7 +4,6 @@
   },
   "dependencies": {
     "@types/generate-changelog": "1.8.0",
-    "@types/long": "4.0.1",
     "@types/node": "~12",
     "@wireapp/core": "16.10.17",
     "commander": "5.1.0",
@@ -14,7 +13,7 @@
   "devDependencies": {
     "logdown": "3.3.1",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "dist"

--- a/packages/cli-client/package.json
+++ b/packages/cli-client/package.json
@@ -11,9 +11,8 @@
   },
   "devDependencies": {
     "@types/fs-extra": "8.1.0",
-    "@types/long": "4.0.1",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "description": "Command-line interface for Wire's secure messaging platform.",
   "files": [

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -19,7 +19,7 @@
     "karma-jasmine-diff-reporter": "2.0.0",
     "karma-typescript": "5.0.3",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "description": "Collection of common components that are used across Wire web applications.",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
     "./dist/cryptography/AssetCryptography.node": "./dist/cryptography/AssetCryptography.browser.js"
   },
   "dependencies": {
+    "@types/long": "4.0.1",
     "@types/node": "~12",
     "@wireapp/api-client": "11.20.16",
     "@wireapp/cryptobox": "12.2.16",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,6 @@
     "./dist/cryptography/AssetCryptography.node": "./dist/cryptography/AssetCryptography.browser.js"
   },
   "dependencies": {
-    "@types/long": "4.0.1",
     "@types/node": "~12",
     "@wireapp/api-client": "11.20.16",
     "@wireapp/cryptobox": "12.2.16",

--- a/packages/license-collector/package.json
+++ b/packages/license-collector/package.json
@@ -14,7 +14,7 @@
     "@types/node": "~12",
     "@types/npm-registry-package-info": "1.0.0",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "dist"

--- a/packages/store-engine-bro-fs/package.json
+++ b/packages/store-engine-bro-fs/package.json
@@ -14,7 +14,7 @@
     "karma-jasmine": "3.1.1",
     "karma-typescript": "5.0.3",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "description": "Store Engine implementation for the browser's File and Directory Entries API.",
   "files": [

--- a/packages/store-engine-dexie/package.json
+++ b/packages/store-engine-dexie/package.json
@@ -14,7 +14,7 @@
     "karma-typescript": "5.0.3",
     "logdown": "3.3.1",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "description": "Store Engine implementation for the browser's IndexedDB.",
   "files": [

--- a/packages/store-engine-fs/package.json
+++ b/packages/store-engine-fs/package.json
@@ -10,7 +10,7 @@
     "jasmine": "3.5.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "description": "Store Engine implementation for Node.js' File System.",
   "files": [

--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -10,7 +10,7 @@
     "karma-jasmine": "3.1.1",
     "karma-typescript": "5.0.3",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "description": "Store Engine wrapper for the browser's Web Storage API.",
   "files": [

--- a/packages/travis-bot/package.json
+++ b/packages/travis-bot/package.json
@@ -4,7 +4,6 @@
   },
   "dependencies": {
     "@types/generate-changelog": "1.8.0",
-    "@types/long": "4.0.1",
     "@types/node": "~12",
     "@wireapp/core": "16.10.17",
     "generate-changelog": "1.8.0"
@@ -13,7 +12,7 @@
   "devDependencies": {
     "logdown": "3.3.1",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "dist"

--- a/packages/webapp-events/package.json
+++ b/packages/webapp-events/package.json
@@ -2,7 +2,7 @@
   "description": "Events shared between Wire's web app and desktop app.",
   "devDependencies": {
     "rimraf": "3.0.2",
-    "typescript": "3.8.3"
+    "typescript": "3.9.2"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15419,11 +15419,6 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-
 typescript@3.9.2:
   version "3.9.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz#64e9c8e9be6ea583c54607677dd4680a1cf35db9"


### PR DESCRIPTION
The "@types/long" dependency should ship with ProtoBuf but it doesn't. That's why we added it in our "core" package. All packages based on the "core" package should receive "@types/long" as transitive dependency. However, when building scoped packages with lerna, this dependency is not hoisted because we added all packages of type "@types" to the "nohoist" list. This will change with my PR, so that "@types/long" will get hoisted when it comes in as a transitive dependency when building scoped packages.

I also streamlined the versions of TypeScript that are being used across our packages.