### PR TITLE
fix(bot-api,core): Don't re-init an initialized store engine

### DIFF
--- a/packages/bot-api/src/Bot.ts
+++ b/packages/bot-api/src/Bot.ts
@@ -129,10 +129,10 @@ export class Bot {
         throw new Error('Store engine not provided');
       }
       const cookie = await this.getCookie(storeEngine);
-      await this.account.init(this.config.clientType, cookie);
+      await this.account.init(this.config.clientType, cookie, storeEngine);
     } catch (error) {
       this.logger.warn('Failed to init account from cookie', error);
-      await this.account.login(login);
+      await this.account.login(login, true, undefined, storeEngine);
     }
 
     await this.account.listen();


### PR DESCRIPTION
Code for Testing:

```typescript
import 'dotenv-defaults/config';

import path from "path";
import {ClientType} from "@wireapp/api-client/dist/client";
import {Bot, BotConfig, BotCredentials} from "..";
import {FileEngine} from "@wireapp/store-engine-fs";

async function main() {
  const {EMAIL, PASSWORD} = process.env;

  const config: BotConfig = {
    backend: 'production',
    clientType: ClientType.PERMANENT,
    conversations: [],
    owners: [],
  };

  const wireDirectory = path.join(process.cwd(), 'db');
  const storeEngine = new FileEngine(wireDirectory, {fileExtension: '.json'});
  await storeEngine.init('my-bot');

  const credentials: BotCredentials = {
    email: EMAIL!,
    password: PASSWORD!,
  };

  const bot = new Bot(credentials, config);

  await bot.start(storeEngine);
}

main().catch(console.error);
```