### PR TITLE
feat(api-client): Remove `ignore_missing` URL parameter (BREAKING)

### DIFF
--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -37,7 +37,6 @@ export class BroadcastAPI {
    * @param ignoreMissing Whether to report missing clients or not:
    * `false`: Report about all missing clients
    * `true`: Ignore all missing clients and force sending
-   * `undefined`: Default to setting of `report_missing` in `NewOTRMessage`
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postOtrBroadcast
    */
   public async postBroadcastMessage(
@@ -57,6 +56,7 @@ export class BroadcastAPI {
 
     if (typeof ignoreMissing === 'boolean') {
       config.params = {ignore_missing: ignoreMissing};
+      delete messageData.report_missing;
     }
 
     const response =

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -37,8 +37,9 @@ export class BroadcastAPI {
    * @param ignoreMissing Whether to report missing clients or not:
    * `false`: Report about all missing clients
    * `true`: Ignore all missing clients and force sending
-   * Array: List of user IDs specifying which user IDs are allowed to have
-   * missing clients.
+   * Array: User IDs specifying which user IDs are allowed to have
+   * missing clients
+   * `undefined`: Default to setting of `report_missing` in `NewOTRMessage`
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postOtrBroadcast
    */
   public async postBroadcastMessage(

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -37,12 +37,14 @@ export class BroadcastAPI {
    * @param ignoreMissing Whether to report missing clients or not:
    * `false`: Report about all missing clients
    * `true`: Ignore all missing clients and force sending
+   * Array: List of user IDs specifying which user IDs are allowed to have
+   * missing clients.
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postOtrBroadcast
    */
   public async postBroadcastMessage(
     clientId: string,
     messageData: NewOTRMessage,
-    ignoreMissing?: boolean,
+    ignoreMissing?: boolean | string[],
   ): Promise<ClientMismatch> {
     if (!clientId) {
       throw new ValidationError('Unable to send OTR message without client ID.');
@@ -54,8 +56,9 @@ export class BroadcastAPI {
       url: BroadcastAPI.URL.BROADCAST,
     };
 
-    if (typeof ignoreMissing === 'boolean') {
-      config.params = {ignore_missing: ignoreMissing};
+    if (typeof ignoreMissing !== 'undefined') {
+      const ignore_missing = Array.isArray(ignoreMissing) ? ignoreMissing.join(',') : ignoreMissing;
+      config.params = {ignore_missing};
       delete messageData.report_missing;
     }
 

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -60,6 +60,8 @@ export class BroadcastAPI {
     if (typeof ignoreMissing !== 'undefined') {
       const ignore_missing = Array.isArray(ignoreMissing) ? ignoreMissing.join(',') : ignoreMissing;
       config.params = {ignore_missing};
+      // `ignore_missing` takes precedence on the server so we can remove
+      // `report_missing` to save some bandwidth.
       delete messageData.report_missing;
     }
 

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -63,6 +63,9 @@ export class BroadcastAPI {
       // `ignore_missing` takes precedence on the server so we can remove
       // `report_missing` to save some bandwidth.
       delete messageData.report_missing;
+    } else if (typeof messageData.report_missing === 'undefined') {
+      // both `ignore_missing` and `report_missing` are undefined
+      config.params = {ignore_missing: !!messageData.data};
     }
 
     const response =

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -475,6 +475,8 @@ export class ConversationAPI {
     if (typeof ignoreMissing !== 'undefined') {
       const ignore_missing = Array.isArray(ignoreMissing) ? ignoreMissing.join(',') : ignoreMissing;
       config.params = {ignore_missing};
+      // `ignore_missing` takes precedence on the server so we can remove
+      // `report_missing` to save some bandwidth.
       delete messageData.report_missing;
     }
 

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -445,8 +445,9 @@ export class ConversationAPI {
    * @param ignoreMissing Whether to report missing clients or not:
    * `false`: Report about all missing clients
    * `true`: Ignore all missing clients and force sending.
-   * Array: List of user IDs specifying which user IDs are allowed to have
-   * missing clients.
+   * Array: User IDs specifying which user IDs are allowed to have
+   * missing clients
+   * `undefined`: Default to setting of `report_missing` in `NewOTRMessage`
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/postOtrMessage
    */
   public async postOTRMessage(

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -478,6 +478,9 @@ export class ConversationAPI {
       // `ignore_missing` takes precedence on the server so we can remove
       // `report_missing` to save some bandwidth.
       delete messageData.report_missing;
+    } else if (typeof messageData.report_missing === 'undefined') {
+      // both `ignore_missing` and `report_missing` are undefined
+      config.params = {ignore_missing: !!messageData.data};
     }
 
     const response =

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -448,10 +448,7 @@ export class ConversationAPI {
     clientId: string,
     conversationId: string,
     messageData?: NewOTRMessage,
-    params?: {
-      ignore_missing?: boolean;
-      report_missing?: string;
-    },
+    ignoreMissing?: boolean,
   ): Promise<ClientMismatch> {
     if (!clientId) {
       throw new ValidationError('Unable to send OTR message without client ID.');
@@ -467,8 +464,7 @@ export class ConversationAPI {
       data: messageData,
       method: 'post',
       params: {
-        ignore_missing: !!messageData.data,
-        ...params,
+        ignore_missing: typeof ignoreMissing === 'boolean' ? ignoreMissing : !!messageData.data,
       },
       url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.OTR}/${ConversationAPI.URL.MESSAGES}`,
     };

--- a/packages/api-client/src/conversation/NewOTRMessage.ts
+++ b/packages/api-client/src/conversation/NewOTRMessage.ts
@@ -29,6 +29,7 @@ export interface NewOTRMessage {
   native_priority?: 'low' | 'high';
   /** Whether to issue a native push to offline clients */
   native_push?: boolean;
+  /** Map with per-recipient data */
   recipients: OTRRecipients;
   report_missing?: string[];
   /** The sender's client ID */

--- a/packages/api-client/src/conversation/NewOTRMessage.ts
+++ b/packages/api-client/src/conversation/NewOTRMessage.ts
@@ -31,6 +31,7 @@ export interface NewOTRMessage {
   native_push?: boolean;
   /** Map with per-recipient data */
   recipients: OTRRecipients;
+  /** Specifies which userIDs are forbidden from having missing clients. */
   report_missing?: string[];
   /** The sender's client ID */
   sender: string;

--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -63,11 +63,12 @@ export class BroadcastService {
     sendingClientId: string,
     recipients: OTRRecipients,
     plainTextArray: Uint8Array,
-    data?: any,
+    data?: Uint8Array | string,
   ): Promise<void> {
     const message: NewOTRMessage = {
       data,
       recipients,
+      report_missing: Object.keys(recipients),
       sender: sendingClientId,
     };
     try {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -215,9 +215,7 @@ export class ConversationService {
      * missing clients. We have to ignore missing clients because there can be the case that there are clients that
      * don't provide PreKeys (clients from the Pre-E2EE era).
      */
-    await this.apiClient.conversation.api.postOTRMessage(sendingClientId, conversationId, message, {
-      ignore_missing: true,
-    });
+    await this.apiClient.conversation.api.postOTRMessage(sendingClientId, conversationId, message, true);
   }
 
   // TODO: Move this to a generic "message sending class" and make it private.


### PR DESCRIPTION
BREAKING CHANGES:
- `postOTRMessage()` now takes a `boolean` as fourth parameter to avoid confusion because `report_missing` needs to be set in `messageData` anyway.
- `report_missing` will be deleted from the `messageData` since `ignore_missing` will take precedence anyway.


## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
