### PR TITLE
refactor(webapp-events): Use plain TypeScript locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ node_modules/
 npm-debug.log*
 package-lock.json
 packages/react-ui-kit/styleguide
+**/src/**/*.d.ts
+**/src/**/*.js
+**/src/**/*.js.map
 temp/
 yarn-error.log

--- a/packages/webapp-events/package.json
+++ b/packages/webapp-events/package.json
@@ -5,16 +5,17 @@
     "typescript": "3.9.2"
   },
   "files": [
-    "dist"
+    "src",
+    "!src/**/*.ts"
   ],
   "license": "GPL-3.0",
-  "main": "dist/index.js",
+  "main": "src/index",
   "name": "@wireapp/webapp-events",
   "repository": "https://github.com/wireapp/wire-web-packages/tree/master/packages/webapp-events",
   "scripts": {
     "build": "tsc",
     "build:node": "tsc",
-    "clean": "rimraf .nyc_output coverage dist",
+    "clean": "rimraf .nyc_output coverage src/**/*{.js,.js.map,.d.ts}",
     "dist": "yarn clean && yarn build",
     "test": "exit 0"
   },

--- a/packages/webapp-events/tsconfig.json
+++ b/packages/webapp-events/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "outDir": "dist",
+    "outDir": "src",
     "rootDir": "src"
   },
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["node_modules"],
   "extends": "../../tsconfig.json"
 }


### PR DESCRIPTION
This PR will allow us to solely use TypeScript code in our mono repo structure by doing the following:

- It links to a "main" entry in "package.json" without file extension
- If there are no JavaScript sources, the TypeScript compiler will auto-complete the missing file extension with ".ts"
- Because the TypeScript compiler defaults to ".ts" extension, other TypeScript packages can link to the original sources within the mono-repo, so if A consumes B, B does not need to be compiled anymore because it can be used directly by A (if A is also written in TypeScript)
- During a "yarn release", the JavaScript code gets built, so that a Node.js environment can auto-complete the missing file extension to ".js", so it will be able to pick-up an "index.js" file which is uploaded to npmjs
- If needed we can run a "yarn clean" on "yarn postpublish" to guarantee that JavaScript code won't be around in the repo after a release but since we only release from our CI pipeline, we actually don't run into this scenario