### PR TITLE
fix(commons): Remove check for deprecated 'createEncodedVideoStreams'

### DIFF
--- a/packages/commons/src/main/util/Runtime.ts
+++ b/packages/commons/src/main/util/Runtime.ts
@@ -135,10 +135,7 @@ export class Runtime {
   };
 
   public static isSupportingConferenceCalling = (): boolean => {
-    if (!Runtime.isSupportingLegacyCalling() || !Runtime.isSupportingRTCInjectableStreams()) {
-      return false;
-    }
-    return true;
+    return Runtime.isSupportingLegacyCalling() && RTCRtpSender.prototype.hasOwnProperty('createEncodedStreams');
   };
 
   public static isSupportingRTCPeerConnection = (): boolean => 'RTCPeerConnection' in window;
@@ -150,12 +147,6 @@ export class Runtime {
 
     const peerConnection = new RTCPeerConnection(undefined);
     return 'createDataChannel' in peerConnection;
-  };
-
-  public static isSupportingRTCInjectableStreams = (): boolean => {
-    const isSupportingEncodedStreams = RTCRtpSender.prototype.hasOwnProperty('createEncodedStreams');
-    const isSupportingEncodedVideoStreams = RTCRtpSender.prototype.hasOwnProperty('createEncodedVideoStreams');
-    return isSupportingEncodedStreams || isSupportingEncodedVideoStreams;
   };
 
   public static isSupportingUserMedia = (): boolean => {


### PR DESCRIPTION
**From Chrome:**

> [Deprecation] RTCRtpReceiver.createEncodedVideoStreams is deprecated and will be removed in M85, around August 2020. Please use RTCRtpReceiver.createEncodedStreams instead. See https://www.chromestatus.com/features/6321945865879552 for more details.