### PR TITLE
fix(api-client): Optional User assets attribute

### DIFF
--- a/packages/api-client/src/user/User.ts
+++ b/packages/api-client/src/user/User.ts
@@ -24,7 +24,7 @@ import {UserAsset} from '../user/';
 
 export interface User {
   accent_id?: AccentColor.AccentColorID;
-  assets: UserAsset[];
+  assets?: UserAsset[];
   deleted?: boolean;
   email?: string;
   expires_at?: string;


### PR DESCRIPTION
The `assets` attribute is part of the `RegisterData` type via `Pick`. For guests `assets` are not required.