### PR TITLE
fix: Publish releases with npm Automation token

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint:code": "eslint --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:other": "yarn prettier --list-different",
     "prettier": "prettier \"**/*.{json,md,scss,yml}\"",
-    "release": "lerna publish && (lerna publish from-package || true)",
+    "release": "lerna publish --no-verify-access && (lerna publish --no-verify-access from-package || true)",
     "test": "yarn && node bin/testUpdated.js",
     "test:all": "yarn && yarn dist && lerna run --no-sort --concurrency 8 test"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lint:code": "eslint --ignore-path .gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:other": "yarn prettier --list-different",
     "prettier": "prettier \"**/*.{json,md,scss,yml}\"",
-    "release": "lerna publish --no-verify-access && (lerna publish --no-verify-access from-package || true)",
+    "release": "lerna publish --no-verify-access && (lerna publish from-package --no-verify-access || true)",
     "test": "yarn && node bin/testUpdated.js",
     "test:all": "yarn && yarn dist && lerna run --no-sort --concurrency 8 test"
   },


### PR DESCRIPTION
We recently updated our npm token and are now using an [Automation token](https://docs.npmjs.com/creating-and-viewing-access-tokens). By default Lerna tries to authenticate the user using `npm whoami`. This is not possible with an automation token so we have to skip the user authentication step (see https://github.com/lerna/lerna/issues/2788).