### PR TITLE
feat(api-client): Get remote conversations

### DIFF
--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -18,6 +18,7 @@
  */
 
 import type {ConversationMembers} from './';
+import {QualifiedId} from '../user';
 
 export enum CONVERSATION_TYPE {
   REGULAR = 0,
@@ -48,6 +49,7 @@ export interface Conversation {
   members: ConversationMembers;
   message_timer: number | null;
   name: string;
+  qualified_id: QualifiedId;
   team: string | null;
   type: CONVERSATION_TYPE;
 }

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -74,9 +74,10 @@ export class ConversationAPI {
     CODE_CHECK: '/code-check',
     CONVERSATIONS: '/conversations',
     JOIN: '/join',
+    LIST_CONVERSATIONS: '/list-conversations',
     MEMBERS: 'members',
-    MESSAGES: 'messages',
     MESSAGE_TIMER: 'message-timer',
+    MESSAGES: 'messages',
     NAME: 'name',
     OTR: 'otr',
     PROTEUS: 'proteus',
@@ -233,6 +234,21 @@ export class ConversationAPI {
     limit = ConversationAPI.MAX_CHUNK_SIZE,
   ): Promise<Conversations> {
     return this._getConversations(startConversationId, undefined, limit);
+  }
+
+  /**
+   * Get all remote conversations from a federated backend.
+   * @see https://staging-nginz-https.zinfra.io/api/swagger-ui/#/default/post_list_conversations
+   */
+  public async getRemoteConversations(ownDomain: string): Promise<Conversation[]> {
+    const config: AxiosRequestConfig = {
+      data: {},
+      method: 'post',
+      url: ConversationAPI.URL.LIST_CONVERSATIONS,
+    };
+
+    const {data} = await this.client.sendJSON<Conversations>(config);
+    return data.conversations.filter(conversation => conversation.qualified_id.domain !== ownDomain);
   }
 
   /**


### PR DESCRIPTION
Can be tested with:

```typescript
const apiClient = await initClient();
const conversations = await apiClient.conversation.api.getRemoteConversations('staging.zinfra.io');
```