### PR TITLE
fix(api-client): Force protobuf arrays to be recreated before sent

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -654,7 +654,11 @@ export class ConversationAPI {
     messageData: ProtobufOTR.QualifiedNewOtrMessage,
   ): Promise<MessageSendingStatus> {
     const config: AxiosRequestConfig = {
-      data: ProtobufOTR.QualifiedNewOtrMessage.encode(messageData).finish(),
+      /*
+       * We need to slice the content of what protobuf has generated in order for Axios to send the correct data (see https://github.com/axios/axios/issues/4068)
+       * FIXME: The `slice` can be removed as soon as Axios publishes a version with the dataview issue fixed.
+       */
+      data: ProtobufOTR.QualifiedNewOtrMessage.encode(messageData).finish().slice(),
       method: 'post',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${domain}/${conversationId}/${ConversationAPI.URL.PROTEUS}/${ConversationAPI.URL.MESSAGES}`,
     };
@@ -687,7 +691,11 @@ export class ConversationAPI {
     }
 
     const config: AxiosRequestConfig = {
-      data: ProtobufOTR.NewOtrMessage.encode(messageData).finish(),
+      /*
+       * We need to slice the content of what protobuf has generated in order for Axios to send the correct data (see https://github.com/axios/axios/issues/4068)
+       * FIXME: The `slice` can be removed as soon as Axios publishes a version with the dataview issue fixed.
+       */
+      data: ProtobufOTR.NewOtrMessage.encode(messageData).finish().slice(),
       method: 'post',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.OTR}/${ConversationAPI.URL.MESSAGES}`,
     };


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->
To optimize performance when protobuf encodes an entity, it first generates a big ArrayBuffer which it fills with the content of the entity and then generates a DataView (namely `Uint8Array`) on top of it that has `byteOffset` and `byteLength` properties that tell how the buffer should be read.

Axios currently ignores those properties and send the entire 8k buffer through the wire. 

This fix slices the `Uint8Array` in order to create a new array that has exactly the right amount of bytes in it. Axios still uses the complete buffer but this time it only has the right bytes, no more, no less.

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
