### PR TITLE
fix(prettier-config): Use bracketSameLine

### DIFF
--- a/packages/prettier-config/index.json
+++ b/packages/prettier-config/index.json
@@ -1,11 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
   "arrowParens": "avoid",
+  "bracketSameLine": false,
   "bracketSpacing": false,
   "endOfLine": "lf",
   "htmlWhitespaceSensitivity": "css",
-  "jsxBracketSameLine": false,
   "jsxSingleQuote": false,
+  "overrides": [
+    {
+      "files": ["*.json"],
+      "options": {
+        "printWidth": 200
+      }
+    }
+  ],
   "printWidth": 120,
   "proseWrap": "never",
   "quoteProps": "as-needed",
@@ -14,13 +22,5 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "all",
-  "useTabs": false,
-  "overrides": [
-    {
-      "files": ["*.json"],
-      "options": {
-        "printWidth": 200
-      }
-    }
-  ]
+  "useTabs": false
 }


### PR DESCRIPTION
`jsxBracketSameLine` was [deprecated](https://prettier.io/docs/en/options.html#deprecated-jsx-brackets).

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
