### PR TITLE
feat(core): Add callbacks for message sending state

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -22,6 +22,7 @@ import {ClientType} from '@wireapp/api-client/src/client';
 import {UserPreKeyBundleMap} from '@wireapp/api-client/src/user';
 import {GenericMessage, LegalHoldStatus, Text} from '@wireapp/protocol-messaging';
 import {MemoryEngine} from '@wireapp/store-engine';
+import {PayloadBundleSource, PayloadBundleState, PayloadBundleType} from '.';
 
 import {Account} from '../Account';
 import * as PayloadHelper from '../test/PayloadHelper';
@@ -81,6 +82,38 @@ describe('ConversationService', () => {
 
       const shouldSendAsExternal = account.service!.conversation['shouldSendAsExternal'](plainText, preKeyBundles);
       expect(shouldSendAsExternal).toBe(false);
+    });
+  });
+
+  describe('"send"', () => {
+    it('calls callbacks when federated message sending is starting and succesful', async () => {
+      account['apiClient'].context = {
+        clientType: ClientType.NONE,
+        userId: PayloadHelper.getUUID(),
+        clientId: PayloadHelper.getUUID(),
+      };
+      const conversationService = account.service!.conversation;
+      spyOn<any>(conversationService, 'sendGenericMessage').and.returnValue(Promise.resolve(undefined));
+      const callbacks = {onStart: jasmine.createSpy(), onSuccess: jasmine.createSpy()};
+      const promise = conversationService.send({
+        callbacks,
+        payloadBundle: {
+          type: PayloadBundleType.TEXT,
+          conversation: PayloadHelper.getUUID(),
+          from: PayloadHelper.getUUID(),
+          id: PayloadHelper.getUUID(),
+          timestamp: 0,
+          source: PayloadBundleSource.LOCAL,
+          state: PayloadBundleState.OUTGOING_UNSENT,
+          content: {text: 'test'},
+        },
+      });
+
+      expect(callbacks.onStart).toHaveBeenCalled();
+      expect(callbacks.onSuccess).not.toHaveBeenCalled();
+      return promise.then(() => {
+        expect(callbacks.onSuccess).toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -86,7 +86,7 @@ describe('ConversationService', () => {
   });
 
   describe('"send"', () => {
-    it('calls callbacks when federated message sending is starting and succesful', async () => {
+    it('calls callbacks when federated message sending is starting and successful', async () => {
       account['apiClient'].context = {
         clientType: ClientType.NONE,
         userId: PayloadHelper.getUUID(),
@@ -111,9 +111,8 @@ describe('ConversationService', () => {
 
       expect(callbacks.onStart).toHaveBeenCalled();
       expect(callbacks.onSuccess).not.toHaveBeenCalled();
-      return promise.then(() => {
-        expect(callbacks.onSuccess).toHaveBeenCalled();
-      });
+      await promise;
+      expect(callbacks.onSuccess).toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -90,8 +90,8 @@ import type {
 } from './message/OtrMessage';
 
 interface MessageSendingCallbacks {
-  onStart: (message: GenericMessage) => void;
-  onSuccess: (message: GenericMessage) => void;
+  onStart?: (message: GenericMessage) => void;
+  onSuccess?: (message: GenericMessage) => void;
 }
 
 export class ConversationService {
@@ -873,7 +873,7 @@ export class ConversationService {
     if (expireAfterMillis > 0) {
       genericMessage = this.createEphemeral(genericMessage, expireAfterMillis);
     }
-    callbacks?.onStart(genericMessage);
+    callbacks?.onStart?.(genericMessage);
 
     await this.sendGenericMessage(
       this.apiClient.validatedClientId,
@@ -883,7 +883,7 @@ export class ConversationService {
       sendAsProtobuf,
       conversationDomain,
     );
-    callbacks?.onSuccess(genericMessage);
+    callbacks?.onSuccess?.(genericMessage);
 
     return {
       ...payloadBundle,
@@ -1112,7 +1112,7 @@ export class ConversationService {
   /**
    * @param payloadBundle Outgoing message
    * @param userIds Only send message to specified user IDs or to certain clients of specified user IDs
-   * @param callbacks? Optional callbacks that will be called when the message starts being sent and when it has been succesfully sent
+   * @param [callbacks] Optional callbacks that will be called when the message starts being sent and when it has been succesfully sent
    * @returns Sent message
    */
   public async send({

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -89,6 +89,11 @@ import type {
   TextMessage,
 } from './message/OtrMessage';
 
+interface MessageSendingCallbacks {
+  onStart: (message: GenericMessage) => void;
+  onSuccess: (message: GenericMessage) => void;
+}
+
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
   public readonly messageBuilder: MessageBuilder;
@@ -857,6 +862,7 @@ export class ConversationService {
     userIds?: string[] | QualifiedId[] | UserClients | QualifiedUserClients,
     sendAsProtobuf?: boolean,
     conversationDomain?: string,
+    callbacks?: MessageSendingCallbacks,
   ): Promise<TextMessage> {
     let genericMessage = GenericMessage.create({
       messageId: payloadBundle.id,
@@ -867,6 +873,7 @@ export class ConversationService {
     if (expireAfterMillis > 0) {
       genericMessage = this.createEphemeral(genericMessage, expireAfterMillis);
     }
+    callbacks?.onStart(genericMessage);
 
     await this.sendGenericMessage(
       this.apiClient.validatedClientId,
@@ -876,6 +883,7 @@ export class ConversationService {
       sendAsProtobuf,
       conversationDomain,
     );
+    callbacks?.onSuccess(genericMessage);
 
     return {
       ...payloadBundle,
@@ -1104,6 +1112,7 @@ export class ConversationService {
   /**
    * @param payloadBundle Outgoing message
    * @param userIds Only send message to specified user IDs or to certain clients of specified user IDs
+   * @param callbacks? Optional callbacks that will be called when the message starts being sent and when it has been succesfully sent
    * @returns Sent message
    */
   public async send({
@@ -1111,11 +1120,13 @@ export class ConversationService {
     userIds,
     sendAsProtobuf,
     conversationDomain,
+    callbacks,
   }: {
     payloadBundle: OtrMessage;
     userIds?: string[] | QualifiedId[] | UserClients | QualifiedUserClients;
     sendAsProtobuf?: boolean;
     conversationDomain?: string;
+    callbacks?: MessageSendingCallbacks;
   }) {
     switch (payloadBundle.type) {
       case PayloadBundleType.ASSET:
@@ -1153,7 +1164,7 @@ export class ConversationService {
       case PayloadBundleType.REACTION:
         return this.sendReaction(payloadBundle, userIds, sendAsProtobuf, conversationDomain);
       case PayloadBundleType.TEXT:
-        return this.sendText(payloadBundle, userIds, sendAsProtobuf, conversationDomain);
+        return this.sendText(payloadBundle, userIds, sendAsProtobuf, conversationDomain, callbacks);
       default:
         throw new Error(`No send method implemented for "${payloadBundle['type']}".`);
     }

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -89,7 +89,7 @@ import type {
   TextMessage,
 } from './message/OtrMessage';
 
-interface MessageSendingCallbacks {
+export interface MessageSendingCallbacks {
   onStart?: (message: GenericMessage) => void;
   onSuccess?: (message: GenericMessage) => void;
 }
@@ -1112,7 +1112,7 @@ export class ConversationService {
   /**
    * @param payloadBundle Outgoing message
    * @param userIds Only send message to specified user IDs or to certain clients of specified user IDs
-   * @param [callbacks] Optional callbacks that will be called when the message starts being sent and when it has been succesfully sent
+   * @param [callbacks] Optional callbacks that will be called when the message starts being sent and when it has been succesfully sent. Currently only used for `sendText`.
    * @returns Sent message
    */
   public async send({


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->
This adds a new callbacks parameter to the `send` method of the conversationService that allows the consumer to get notified when the message is about to be sent and when it is successfully sent. 

It's a first draft that only works for text message, as of now, but can be easily generalized to all the other message types

# Use Cases
This can be used to update a UI state when the message starts being sent and update the UI again when the message is actually sent. 

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
