### PR TITLE
feat(core): Surface the message sent time to consumer

### DIFF
--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -18,6 +18,7 @@
  */
 
 import type {APIClient} from '@wireapp/api-client';
+import {ClientMismatch} from '@wireapp/api-client/src/conversation';
 import type {UserPreKeyBundleMap} from '@wireapp/api-client/src/user/';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
@@ -56,7 +57,7 @@ export class BroadcastService {
     genericMessage: GenericMessage,
     preKeyBundles: UserPreKeyBundleMap,
     sendAsProtobuf?: boolean,
-  ): Promise<void> {
+  ): Promise<ClientMismatch> {
     const plainTextArray = GenericMessage.encode(genericMessage).finish();
     const recipients = await this.cryptographyService.encrypt(plainTextArray, preKeyBundles);
 

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -93,7 +93,8 @@ describe('ConversationService', () => {
         clientId: PayloadHelper.getUUID(),
       };
       const conversationService = account.service!.conversation;
-      spyOn<any>(conversationService, 'sendGenericMessage').and.returnValue(Promise.resolve(undefined));
+      const sentTime = new Date().toISOString();
+      spyOn<any>(conversationService, 'sendGenericMessage').and.returnValue(Promise.resolve({time: sentTime}));
       const callbacks = {onStart: jasmine.createSpy(), onSuccess: jasmine.createSpy()};
       const promise = conversationService.send({
         callbacks,
@@ -112,7 +113,7 @@ describe('ConversationService', () => {
       expect(callbacks.onStart).toHaveBeenCalled();
       expect(callbacks.onSuccess).not.toHaveBeenCalled();
       await promise;
-      expect(callbacks.onSuccess).toHaveBeenCalled();
+      expect(callbacks.onSuccess).toHaveBeenCalledWith(jasmine.any(Object), sentTime);
     });
   });
 

--- a/packages/core/src/main/user/UserService.ts
+++ b/packages/core/src/main/user/UserService.ts
@@ -93,6 +93,6 @@ export class UserService {
     });
 
     // Broadcast availability status to your team members & external 1:1 connections
-    return this.broadcastService.broadcastGenericMessage(genericMessage, allPreKeyBundles, sendAsProtobuf);
+    await this.broadcastService.broadcastGenericMessage(genericMessage, allPreKeyBundles, sendAsProtobuf);
   }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->
In order to know, for a consumer point of view, when a message was sent (with the backend timestamp), we need to surface the response from the server to the upper layers of the core in order to send the timestamp to the `messageSendingCallback.onSuccess` callback

See https://github.com/wireapp/wire-webapp/pull/11887 for an example of usage

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
