### PR TITLE
fix(api-client): Align user event definitions

### DIFF
--- a/packages/api-client/src/event/UserEvent.ts
+++ b/packages/api-client/src/event/UserEvent.ts
@@ -26,6 +26,7 @@ import type {
   UserLegalHoldDisableData,
   UserLegalHoldEnableData,
   UserLegalHoldRequestData,
+  UserPropertiesDeleteData,
   UserPropertiesSetData,
   UserPushRemoveData,
   UserUpdateData,
@@ -56,6 +57,7 @@ export type UserEventData =
   | UserConnectionData
   | UserDeleteData
   | UserPropertiesSetData
+  | UserPropertiesDeleteData
   | UserUpdateData
   | UserPushRemoveData
   | null;
@@ -70,6 +72,7 @@ export type UserEvent =
   | UserConnectionEvent
   | UserDeleteEvent
   | UserPropertiesSetEvent
+  | UserPropertiesDeleteEvent
   | UserUpdateEvent
   | UserPushRemoveEvent;
 
@@ -111,6 +114,10 @@ export interface UserDeleteEvent extends BaseUserEvent, UserDeleteData {
 
 export interface UserPropertiesSetEvent extends BaseUserEvent, UserPropertiesSetData {
   type: USER_EVENT.PROPERTIES_SET;
+}
+
+export interface UserPropertiesDeleteEvent extends BaseUserEvent, UserPropertiesDeleteData {
+  type: USER_EVENT.PROPERTIES_DELETE;
 }
 
 export interface UserUpdateEvent extends BaseUserEvent, UserUpdateData {

--- a/packages/api-client/src/user/data/UserDeleteData.ts
+++ b/packages/api-client/src/user/data/UserDeleteData.ts
@@ -18,5 +18,5 @@
  */
 
 export interface UserDeleteData {
-  client: {id: string};
+  id: string;
 }

--- a/packages/api-client/src/user/data/UserLegalHoldRequestData.ts
+++ b/packages/api-client/src/user/data/UserLegalHoldRequestData.ts
@@ -20,7 +20,7 @@
 import type {PreKey} from '../../auth';
 
 export interface UserLegalHoldRequestData {
-  client: string;
+  client: {id: string};
   /** The ID of the user that is targeted (formally `target_user`) */
   id: string;
   last_prekey: PreKey;

--- a/packages/api-client/src/user/data/UserPropertiesDeleteData.ts
+++ b/packages/api-client/src/user/data/UserPropertiesDeleteData.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2019 Wire Swiss GmbH
+ * Copyright (C) 2021 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,15 +17,6 @@
  *
  */
 
-export * from './UserActivateData';
-export * from './UserClientAddData';
-export * from './UserLegalHoldRequestData';
-export * from './UserClientRemoveData';
-export * from './UserConnectionData';
-export * from './UserDeleteData';
-export * from './UserLegalHoldDisableData';
-export * from './UserLegalHoldEnableData';
-export * from './UserPropertiesSetData';
-export * from './UserPropertiesDeleteData';
-export * from './UserPushRemoveData';
-export * from './UserUpdateData';
+export interface UserPropertiesDeleteData {
+  key: string;
+}


### PR DESCRIPTION
The typing for `UserDelete` and `UserLegalHoldRequest` data were off. 
It was also missing the `UserPropertiesDelete` event.  
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
