### PR TITLE
refactor(core): Refactor generation of generic messages

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -827,8 +827,7 @@ export class ConversationService {
     callbacks?: MessageSendingCallbacks;
   }): Promise<T> {
     let genericMessage: GenericMessage;
-    let hasMessageTimer: boolean = true;
-    let processedContent: AssetContent;
+    let processedContent: AssetContent | undefined = undefined;
 
     switch (payloadBundle.type) {
       case PayloadBundleType.ASSET:
@@ -847,15 +846,12 @@ export class ConversationService {
         break;
       case PayloadBundleType.BUTTON_ACTION:
         genericMessage = this.generateButtonActionGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.BUTTON_ACTION_CONFIRMATION:
         genericMessage = this.generateButtonActionConfirmationGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.CALL:
         genericMessage = this.generateCallGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.CLIENT_ACTION: {
         if (payloadBundle.content.clientAction !== ClientAction.RESET_SESSION) {
@@ -868,25 +864,21 @@ export class ConversationService {
       }
       case PayloadBundleType.COMPOSITE:
         genericMessage = this.generateCompositeGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.CONFIRMATION:
         genericMessage = this.generateConfirmationGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.LOCATION:
         genericMessage = this.generateLocationGenericMessage(payloadBundle);
         break;
       case PayloadBundleType.MESSAGE_EDIT:
         genericMessage = this.generateEditedTextGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.PING:
         genericMessage = this.generatePingGenericMessage(payloadBundle);
         break;
       case PayloadBundleType.REACTION:
         genericMessage = this.generateReactionGenericMessage(payloadBundle);
-        hasMessageTimer = false;
         break;
       case PayloadBundleType.TEXT:
         genericMessage = this.generateTextGenericMessage(payloadBundle);
@@ -909,7 +901,7 @@ export class ConversationService {
     return {
       ...payloadBundle,
       content: processedContent || payloadBundle.content,
-      messageTimer: hasMessageTimer ? this.messageTimer.getMessageTimer(payloadBundle.conversation) : 0,
+      messageTimer: genericMessage.ephemeral?.expireAfterMillis || 0,
       state: PayloadBundleState.OUTGOING_SENT,
     };
   }


### PR DESCRIPTION
This PR splits the work of sending generic messages into 2 parts:
- generating the generic payload
- actually sending the message


Since sending the message was common to all the message types, there was no need to keep it in the `send.*Message` and rather move it to the generic `send` method
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
