### PR TITLE
refactor(core): Simplify and streamline responsibilities of the MessageService

### DIFF
--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -59,10 +59,8 @@ export class BroadcastService {
     sendAsProtobuf?: boolean,
   ): Promise<ClientMismatch> {
     const plainTextArray = GenericMessage.encode(genericMessage).finish();
-    const recipients = await this.cryptographyService.encrypt(plainTextArray, preKeyBundles);
-
-    return sendAsProtobuf
-      ? this.messageService.sendOTRProtobufMessage(this.apiClient.validatedClientId, recipients, null, plainTextArray)
-      : this.messageService.sendOTRMessage(this.apiClient.validatedClientId, recipients, null, plainTextArray);
+    return this.messageService.sendMessage(this.apiClient.validatedClientId, preKeyBundles, plainTextArray, {
+      sendAsProtobuf,
+    });
   }
 }

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -19,8 +19,7 @@
 
 import {APIClient} from '@wireapp/api-client';
 import {ClientType} from '@wireapp/api-client/src/client';
-import {UserPreKeyBundleMap} from '@wireapp/api-client/src/user';
-import {GenericMessage, LegalHoldStatus, Text} from '@wireapp/protocol-messaging';
+import {LegalHoldStatus} from '@wireapp/protocol-messaging';
 import {MemoryEngine} from '@wireapp/store-engine';
 import {PayloadBundleSource, PayloadBundleState, PayloadBundleType} from '.';
 
@@ -29,31 +28,6 @@ import * as PayloadHelper from '../test/PayloadHelper';
 import {MentionContent, QuoteContent} from './content';
 import {OtrMessage} from './message/OtrMessage';
 
-const createMessage = (content: string) => {
-  const customTextMessage = GenericMessage.create({
-    messageId: PayloadHelper.getUUID(),
-    text: Text.create({content}),
-  });
-
-  return GenericMessage.encode(customTextMessage).finish();
-};
-
-const generatePreKeyBundle = (userCount: number, clientsPerUser: number): UserPreKeyBundleMap => {
-  const prekeyBundle: UserPreKeyBundleMap = {};
-  for (let userIndex = 0; userIndex < userCount; userIndex++) {
-    const userId = PayloadHelper.getUUID();
-    prekeyBundle[userId] = {};
-    for (let clientIndex = 0; clientIndex < clientsPerUser; clientIndex++) {
-      const clientId = PayloadHelper.getUUID();
-      prekeyBundle[userId][clientId] = {
-        id: -1,
-        key: '',
-      };
-    }
-  }
-  return prekeyBundle;
-};
-
 describe('ConversationService', () => {
   let account: Account;
 
@@ -61,29 +35,6 @@ describe('ConversationService', () => {
     const client = new APIClient({urls: APIClient.BACKEND.STAGING});
     account = new Account(client);
     await account.initServices(new MemoryEngine());
-  });
-
-  describe("'shouldSendAsExternal'", () => {
-    it('returns true for a big payload', () => {
-      const preKeyBundles = generatePreKeyBundle(128, 4);
-
-      const longMessage =
-        'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem';
-      const plainText = createMessage(longMessage);
-
-      const shouldSendAsExternal = account.service!.conversation['shouldSendAsExternal'](plainText, preKeyBundles);
-      expect(shouldSendAsExternal).toBe(true);
-    });
-
-    it('returns false for a small payload', async () => {
-      const preKeyBundles = generatePreKeyBundle(2, 1);
-
-      const shortMessage = PayloadHelper.getUUID();
-      const plainText = createMessage(shortMessage);
-
-      const shouldSendAsExternal = account.service!.conversation['shouldSendAsExternal'](plainText, preKeyBundles);
-      expect(shouldSendAsExternal).toBe(false);
-    });
   });
 
   describe('"send"', () => {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -285,18 +285,17 @@ export class ConversationService {
         reportMissing: isQualifiedUserClients(options.userIds), // we want to check mismatch in case the consumer gave an exact list of users/devices
         onClientMismatch: options.onClientMismatch,
       });
-    } else {
-      if (!isStringArray(userIds) && !isUserClients(userIds)) {
-        throw new Error('Invalid userIds option for sending');
-      }
-      const recipients = await this.getRecipientsForConversation(conversationId, userIds);
-      return this.messageService.sendMessage(sendingClientId, recipients, plainText, {
-        conversationId,
-        sendAsProtobuf: options.sendAsProtobuf,
-        reportMissing: isUserClients(options.userIds), // we want to check mismatch in case the consumer gave an exact list of users/devices
-        onClientMismatch: options.onClientMismatch,
-      });
     }
+    if (!isStringArray(userIds) && !isUserClients(userIds)) {
+      throw new Error('Invalid userIds option for sending');
+    }
+    const recipients = await this.getRecipientsForConversation(conversationId, userIds);
+    return this.messageService.sendMessage(sendingClientId, recipients, plainText, {
+      conversationId,
+      sendAsProtobuf: options.sendAsProtobuf,
+      reportMissing: isUserClients(options.userIds), // we want to check mismatch in case the consumer gave an exact list of users/devices
+      onClientMismatch: options.onClientMismatch,
+    });
   }
 
   private generateButtonActionGenericMessage(payloadBundle: ButtonActionMessage): GenericMessage {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -286,6 +286,7 @@ export class ConversationService {
         onClientMismatch: options.onClientMismatch,
       });
     }
+
     if (!isStringArray(userIds) && !isUserClients(userIds)) {
       throw new Error('Invalid userIds option for sending');
     }

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -248,12 +248,13 @@ export class ConversationService {
   }
 
   /**
-   * Sends a message to a federated environment.
+   * Sends a message to a conversation
    *
    * @param sendingClientId The clientId from which the message is sent
    * @param conversationId The conversation in which to send the message
-   * @param conversationDomain The domain where the conversation lives
    * @param genericMessage The payload of the message to send
+   * @param options.domain? The federated domain the server runs on. Should only be set for federation enabled envs
+   * @param options.sendAsProtobuf? Will send the message as a protobuf payload
    * @param options.userIds? can be either a QualifiedId[] or QualfiedUserClients or undefined. The type has some effect on the behavior of the method.
    *    When given undefined the method will fetch both the members of the conversations and their devices. No ClientMismatch can happen in that case
    *    When given a QualifiedId[] the method will fetch the freshest list of devices for those users (since they are not given by the consumer). As a consequence no ClientMismatch error will trigger and we will ignore missing clients when sending

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -213,23 +213,17 @@ describe('MessageService', () => {
     it('should broadcast if no conversationId is given', () => {});
 
     it('should not send as external if payload small', async () => {
-      const longMessage =
-        'Lorem ipsum dolor sit amet';
+      const longMessage = 'Lorem ipsum dolor sit amet';
       spyOn(apiClient.conversation.api, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
-      await messageService.sendMessage(
-        clientId,
-        generateRecipients(generateUsers(3, 3)),
-        createMessage(longMessage),
-        {
-          conversationId,
-        },
-      );
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(longMessage), {
+        conversationId,
+      });
       expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledWith(
         clientId,
         conversationId,
         jasmine.objectContaining({data: undefined}),
-        undefined
+        undefined,
       );
     });
 
@@ -250,7 +244,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.objectContaining({data: jasmine.any(String)}),
-        undefined
+        undefined,
       );
     });
   });

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -220,7 +220,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.any(Object),
-        undefined,
+        true,
       );
     });
 
@@ -238,7 +238,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.any(Object),
-        undefined,
+        true,
       );
     });
 
@@ -247,11 +247,7 @@ describe('MessageService', () => {
       spyOn(apiClient.broadcast.api, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
       await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message));
-      expect(apiClient.broadcast.api.postBroadcastMessage).toHaveBeenCalledWith(
-        clientId,
-        jasmine.any(Object),
-        undefined,
-      );
+      expect(apiClient.broadcast.api.postBroadcastMessage).toHaveBeenCalledWith(clientId, jasmine.any(Object), true);
     });
 
     it('should broadcast protobuf message if no conversationId is given', async () => {
@@ -267,7 +263,7 @@ describe('MessageService', () => {
       expect(apiClient.broadcast.api.postBroadcastProtobufMessage).toHaveBeenCalledWith(
         clientId,
         jasmine.any(Object),
-        undefined,
+        true,
       );
     });
 
@@ -282,7 +278,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.objectContaining({data: undefined}),
-        undefined,
+        true,
       );
     });
 
@@ -303,7 +299,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.objectContaining({data: jasmine.any(String)}),
-        undefined,
+        true,
       );
     });
   });

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -209,14 +209,73 @@ describe('MessageService', () => {
       return GenericMessage.encode(customTextMessage).finish();
     };
 
-    it('should send as protobuf', () => {});
-    it('should broadcast if no conversationId is given', () => {});
-
-    it('should not send as external if payload small', async () => {
-      const longMessage = 'Lorem ipsum dolor sit amet';
+    it('should send regular to conversation', async () => {
+      const message = 'Lorem ipsum dolor sit amet';
       spyOn(apiClient.conversation.api, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
-      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(longMessage), {
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
+        conversationId,
+      });
+      expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledWith(
+        clientId,
+        conversationId,
+        jasmine.any(Object),
+        undefined,
+      );
+    });
+
+    it('should send protobuf message to conversation', async () => {
+      const message = 'Lorem ipsum dolor sit amet';
+      spyOn(apiClient.conversation.api, 'postOTRProtobufMessage').and.returnValue(
+        Promise.resolve({} as ClientMismatch),
+      );
+
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
+        conversationId,
+        sendAsProtobuf: true,
+      });
+      expect(apiClient.conversation.api.postOTRProtobufMessage).toHaveBeenCalledWith(
+        clientId,
+        conversationId,
+        jasmine.any(Object),
+        undefined,
+      );
+    });
+
+    it('should broadcast regular message if no conversationId is given', async () => {
+      const message = 'Lorem ipsum dolor sit amet';
+      spyOn(apiClient.broadcast.api, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
+
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message));
+      expect(apiClient.broadcast.api.postBroadcastMessage).toHaveBeenCalledWith(
+        clientId,
+        jasmine.any(Object),
+        undefined,
+      );
+    });
+
+    it('should broadcast protobuf message if no conversationId is given', async () => {
+      const message = 'Lorem ipsum dolor sit amet';
+      spyOn(apiClient.broadcast.api, 'postBroadcastProtobufMessage').and.returnValue(
+        Promise.resolve({} as ClientMismatch),
+      );
+
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
+        sendAsProtobuf: true,
+      });
+
+      expect(apiClient.broadcast.api.postBroadcastProtobufMessage).toHaveBeenCalledWith(
+        clientId,
+        jasmine.any(Object),
+        undefined,
+      );
+    });
+
+    it('should not send as external if payload small', async () => {
+      const message = 'Lorem ipsum dolor sit amet';
+      spyOn(apiClient.conversation.api, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
+
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
         conversationId,
       });
       expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledWith(

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -230,7 +230,6 @@ export class MessageService {
     const messageInBytes = new Uint8Array(plainText).length;
     const estimatedPayloadInBytes = clientCount * messageInBytes;
 
-    console.log(estimatedPayloadInBytes, EXTERNAL_MESSAGE_THRESHOLD_BYTES);
     return estimatedPayloadInBytes > EXTERNAL_MESSAGE_THRESHOLD_BYTES;
   }
 

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -181,7 +181,7 @@ export class MessageService {
 
     const {id, domain} = options.conversationId;
 
-    return await this.apiClient.conversation.api.postOTRMessageV2(id, domain, protoMessage);
+    return this.apiClient.conversation.api.postOTRMessageV2(id, domain, protoMessage);
   }
 
   private async sendOTRMessage(
@@ -196,8 +196,8 @@ export class MessageService {
     };
 
     return !options.conversationId
-      ? await this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, options.ignoreMissing)
-      : await this.apiClient.conversation.api.postOTRMessage(
+      ? this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, options.ignoreMissing)
+      : this.apiClient.conversation.api.postOTRMessage(
           sendingClientId,
           options.conversationId,
           message,
@@ -326,12 +326,8 @@ export class MessageService {
     }
 
     return !options.conversationId
-      ? await this.apiClient.broadcast.api.postBroadcastProtobufMessage(
-          sendingClientId,
-          protoMessage,
-          options.ignoreMissing,
-        )
-      : await this.apiClient.conversation.api.postOTRProtobufMessage(
+      ? this.apiClient.broadcast.api.postBroadcastProtobufMessage(sendingClientId, protoMessage, options.ignoreMissing)
+      : this.apiClient.conversation.api.postOTRProtobufMessage(
           sendingClientId,
           options.conversationId,
           protoMessage,

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -21,155 +21,115 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {AxiosError} from 'axios';
 import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
 import Long from 'long';
-import {bytesToUUID, uuidToBytes} from '@wireapp/commons/src/main/util/StringUtil';
+import {uuidToBytes} from '@wireapp/commons/src/main/util/StringUtil';
 import {APIClient} from '@wireapp/api-client';
 import {
   ClientMismatch,
   MessageSendingStatus,
   NewOTRMessage,
+  OTRRecipients,
   QualifiedOTRRecipients,
   QualifiedUserClients,
   UserClients,
 } from '@wireapp/api-client/src/conversation';
-import {Decoder, Encoder} from 'bazinga64';
+import {Encoder} from 'bazinga64';
 
+import {encryptAsset} from '../../cryptography/AssetCryptography.node';
 import {CryptographyService} from '../../cryptography';
 import {QualifiedId, QualifiedUserPreKeyBundleMap, UserPreKeyBundleMap} from '@wireapp/api-client/src/user';
+import {MessageBuilder} from './MessageBuilder';
+import {GenericMessage} from '@wireapp/protocol-messaging';
+import {GenericMessageType} from '..';
+import {flattenUserClients, flattenQualifiedUserClients} from './UserClientsUtil';
 
-type ClientMismatchError = AxiosError<ClientMismatch>;
+type ClientMismatchError = AxiosError<ClientMismatch | MessageSendingStatus>;
 
 export class MessageService {
   constructor(private readonly apiClient: APIClient, private readonly cryptographyService: CryptographyService) {}
 
-  public async sendOTRMessage(
+  /**
+   * Sends a message to a non-federated backend.
+   * @param {string} sendingClientId
+   * @param {UserClients|UserPreKeyBundleMap} recipients
+   * @param {Uint8Array} plainText
+   * @param {any} options:{conversationId?:string;reportMissing?:boolean;sendAsProtobuf?:boolean;onClientMismatch?:(mismatch:ClientMismatch
+   * @returns {any}
+   */
+  public async sendMessage(
     sendingClientId: string,
     recipients: UserClients | UserPreKeyBundleMap,
-    conversationId: string | null,
-    plainTextArray: Uint8Array,
-    base64CipherText?: string,
-  ): Promise<ClientMismatch> {
-    const encryptedPayload = await this.cryptographyService.encrypt(plainTextArray, recipients);
-    const message: NewOTRMessage<string> = {
-      data: base64CipherText,
-      recipients: CryptographyService.convertArrayRecipientsToBase64(encryptedPayload),
-      sender: sendingClientId,
+    plainText: Uint8Array,
+    options: {
+      conversationId?: string;
+      reportMissing?: boolean;
+      sendAsProtobuf?: boolean;
+      onClientMismatch?: (mismatch: ClientMismatch) => Promise<boolean | undefined>;
+    } = {},
+  ) {
+    let plainTextPayload = plainText;
+    let cipherText: Uint8Array;
+    if (this.shouldSendAsExternal(plainText, recipients)) {
+      const externalPayload = await this.generateExternalPayload(plainText);
+      plainTextPayload = externalPayload.text;
+      cipherText = externalPayload.cipherText;
+    }
+
+    const encryptedPayload = await this.cryptographyService.encrypt(plainTextPayload, recipients);
+    const send = (payload: OTRRecipients<Uint8Array>) => {
+      return options.sendAsProtobuf
+        ? this.sendOTRProtobufMessage(sendingClientId, payload, {...options, assetData: cipherText})
+        : this.sendOTRMessage(sendingClientId, payload, {...options, assetData: cipherText});
     };
-
-    /*
-     * When creating the PreKey bundles we already found out to which users we want to send a message, so we can ignore
-     * missing clients. We have to ignore missing clients because there can be the case that there are clients that
-     * don't provide PreKeys (clients from the Pre-E2EE era).
-     */
-    const ignoreMissing = true;
-
     try {
-      if (conversationId === null) {
-        return await this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, ignoreMissing);
-      }
-      return await this.apiClient.conversation.api.postOTRMessage(
-        sendingClientId,
-        conversationId,
-        message,
-        ignoreMissing,
-      );
+      return send(encryptedPayload);
     } catch (error) {
       if (!this.isClientMismatchError(error)) {
         throw error;
       }
-      const mismatch = error.response!.data;
-      const reEncryptedMessage = await this.onClientMismatch(
-        mismatch,
-        {
-          ...message,
-          data: base64CipherText ? Decoder.fromBase64(base64CipherText).asBytes : undefined,
-          recipients: encryptedPayload,
-        },
-        plainTextArray,
-      );
-      return await this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, {
-        data: reEncryptedMessage.data ? Encoder.toBase64(reEncryptedMessage.data).asString : undefined,
-        recipients: CryptographyService.convertArrayRecipientsToBase64(reEncryptedMessage.recipients),
-        sender: reEncryptedMessage.sender,
-      });
+      const mismatch = error.response!.data as ClientMismatch;
+      const reEncryptedMessage = await this.reencryptAfterMismatch(mismatch, encryptedPayload, plainText);
+      return send(reEncryptedMessage);
     }
   }
 
-  private isClientMismatchError(error: any): error is ClientMismatchError {
-    return error.response?.status === HTTP_STATUS.PRECONDITION_FAILED;
-  }
-
-  private checkFederatedClientsMismatch(
-    messageData: ProtobufOTR.QualifiedNewOtrMessage,
-    messageSendingStatus: MessageSendingStatus,
-  ): MessageSendingStatus | null {
-    const updatedMessageSendingStatus = {...messageSendingStatus};
-    const sendingStatusKeys: (keyof Omit<typeof updatedMessageSendingStatus, 'time'>)[] = [
-      'deleted',
-      'failed_to_send',
-      'missing',
-      'redundant',
-    ];
-
-    const allFailed: QualifiedUserClients = {
-      ...messageSendingStatus.deleted,
-      ...messageSendingStatus.failed_to_send,
-      ...messageSendingStatus.missing,
-      ...messageSendingStatus.redundant,
-    };
-    const hasDiffs = Object.keys(allFailed).length;
-    if (!hasDiffs) {
-      return null;
-    }
-
-    if (messageData.ignoreOnly?.userIds?.length) {
-      for (const [domainFailed, userClientsFailed] of Object.entries(allFailed)) {
-        for (const userIdMissing of Object.keys(userClientsFailed)) {
-          const userIsIgnored = messageData.ignoreOnly.userIds.find(({domain: domainIgnore, id: userIdIgnore}) => {
-            return userIdIgnore === userIdMissing && domainIgnore === domainFailed;
-          });
-          if (userIsIgnored) {
-            for (const sendingStatusKey of sendingStatusKeys) {
-              delete updatedMessageSendingStatus[sendingStatusKey][domainFailed][userIdMissing];
-            }
-          }
-        }
-      }
-    } else if (messageData.reportOnly?.userIds?.length) {
-      for (const [reportDomain, reportUserId] of Object.entries(messageData.reportOnly.userIds)) {
-        for (const sendingStatusKey of sendingStatusKeys) {
-          for (const [domainDeleted, userClientsDeleted] of Object.entries(
-            updatedMessageSendingStatus[sendingStatusKey],
-          )) {
-            for (const userIdDeleted of Object.keys(userClientsDeleted)) {
-              if (userIdDeleted !== reportUserId.id && domainDeleted !== reportDomain) {
-                delete updatedMessageSendingStatus[sendingStatusKey][domainDeleted][userIdDeleted];
-              }
-            }
-          }
-        }
-      }
-    } else if (!!messageData.ignoreAll) {
-      // report nothing
-      return null;
-    }
-
-    return updatedMessageSendingStatus;
-  }
-
-  public async sendFederatedOTRMessage(
+  public async sendFederatedMessage(
     sendingClientId: string,
-    {id: conversationId, domain}: QualifiedId,
     recipients: QualifiedUserClients | QualifiedUserPreKeyBundleMap,
-    plainTextArray: Uint8Array,
+    plainText: Uint8Array,
     options: {
       assetData?: Uint8Array;
+      conversationId?: QualifiedId;
       reportMissing?: boolean;
       onClientMismatch?: (mismatch: MessageSendingStatus) => Promise<boolean | undefined>;
-    } = {},
+    },
   ): Promise<MessageSendingStatus> {
-    const otrRecipients = await this.cryptographyService.encryptQualified(plainTextArray, recipients);
+    const send = (payload: QualifiedOTRRecipients) => {
+      return this.sendFederatedOtrMessage(sendingClientId, payload, options);
+    };
+    const encryptedPayload = await this.cryptographyService.encryptQualified(plainText, recipients);
+    try {
+      return send(encryptedPayload);
+    } catch (error) {
+      if (!this.isClientMismatchError(error)) {
+        throw error;
+      }
+      const mismatch = error.response!.data as MessageSendingStatus;
+      const reEncryptedPayload = await this.reencryptAfterFederatedMismatch(mismatch, encryptedPayload, plainText);
+      return send(reEncryptedPayload);
+    }
+  }
 
-    const qualifiedUserEntries = Object.entries(otrRecipients).map<ProtobufOTR.IQualifiedUserEntry>(
+  private async sendFederatedOtrMessage(
+    sendingClientId: string,
+    recipients: QualifiedOTRRecipients,
+    options: {
+      assetData?: Uint8Array;
+      conversationId?: QualifiedId;
+      reportMissing?: boolean;
+      onClientMismatch?: (mismatch: MessageSendingStatus) => Promise<boolean | undefined>;
+    },
+  ): Promise<MessageSendingStatus> {
+    const qualifiedUserEntries = Object.entries(recipients).map<ProtobufOTR.IQualifiedUserEntry>(
       ([domain, otrRecipients]) => {
         const userEntries = Object.entries(otrRecipients).map<ProtobufOTR.IUserEntry>(([userId, otrClientMap]) => {
           const clientEntries = Object.entries(otrClientMap).map<ProtobufOTR.IClientEntry>(([clientId, payload]) => {
@@ -204,52 +164,136 @@ export class MessageService {
       protoMessage.blob = options.assetData;
     }
 
-    /*
-     * When creating the PreKey bundles we already found out to which users we want to send a message, so we can ignore
-     * missing clients. We have to ignore missing clients because there can be the case that there are clients that
-     * don't provide PreKeys (clients from the Pre-E2EE era).
-     */
     if (options.reportMissing) {
       protoMessage.reportAll = {};
     } else {
       protoMessage.ignoreAll = {};
     }
 
-    let sendingStatus: MessageSendingStatus;
-    let sendingFailed: boolean = false;
-    try {
-      sendingStatus = await this.apiClient.conversation.api.postOTRMessageV2(conversationId, domain, protoMessage);
-    } catch (error) {
-      if (!this.isClientMismatchError(error)) {
-        throw error;
-      }
-      sendingStatus = error.response!.data! as unknown as MessageSendingStatus;
-      sendingFailed = true;
+    if (!options.conversationId) {
+      //TODO implement federated broadcast sending
+      throw new Error('Unimplemented federated broadcast');
     }
 
-    const mismatch = this.checkFederatedClientsMismatch(protoMessage, sendingStatus);
+    const {id, domain} = options.conversationId;
 
-    if (mismatch) {
-      const shouldStopSending = options.onClientMismatch && !(await options.onClientMismatch(mismatch));
-      if (shouldStopSending || !sendingFailed) {
-        return sendingStatus;
-      }
-      const reEncryptedMessage = await this.onFederatedMismatch(protoMessage, mismatch, plainTextArray);
-      await this.apiClient.conversation.api.postOTRMessageV2(conversationId, domain, reEncryptedMessage);
-    }
-    return sendingStatus;
+    return await this.apiClient.conversation.api.postOTRMessageV2(id, domain, protoMessage);
   }
 
-  public async sendOTRProtobufMessage(
+  private async sendOTRMessage(
     sendingClientId: string,
-    recipients: UserClients | UserPreKeyBundleMap,
-    conversationId: string | null,
-    plainTextArray: Uint8Array,
-    assetData?: Uint8Array,
+    recipients: OTRRecipients<Uint8Array>,
+    options: {conversationId?: string; assetData?: Uint8Array; ignoreMissing?: boolean},
   ): Promise<ClientMismatch> {
-    const encryptedPayload = await this.cryptographyService.encrypt(plainTextArray, recipients);
+    const message: NewOTRMessage<string> = {
+      data: options.assetData ? Encoder.toBase64(options.assetData).asString : undefined,
+      recipients: CryptographyService.convertArrayRecipientsToBase64(recipients),
+      sender: sendingClientId,
+    };
 
-    const userEntries: ProtobufOTR.IUserEntry[] = Object.entries(encryptedPayload).map(([userId, otrClientMap]) => {
+    return !options.conversationId
+      ? await this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, options.ignoreMissing)
+      : await this.apiClient.conversation.api.postOTRMessage(
+          sendingClientId,
+          options.conversationId,
+          message,
+          options.ignoreMissing,
+        );
+  }
+
+  private async generateExternalPayload(plainText: Uint8Array): Promise<{text: Uint8Array; cipherText: Uint8Array}> {
+    const asset = await encryptAsset({plainText});
+    const {cipherText, keyBytes, sha256} = asset;
+    const messageId = MessageBuilder.createId();
+
+    const externalMessage = {
+      otrKey: new Uint8Array(keyBytes),
+      sha256: new Uint8Array(sha256),
+    };
+
+    const genericMessage = GenericMessage.create({
+      [GenericMessageType.EXTERNAL]: externalMessage,
+      messageId,
+    });
+
+    return {text: GenericMessage.encode(genericMessage).finish(), cipherText};
+  }
+
+  private shouldSendAsExternal(plainText: Uint8Array, preKeyBundles: UserPreKeyBundleMap | UserClients): boolean {
+    const EXTERNAL_MESSAGE_THRESHOLD_BYTES = 200 * 1024;
+
+    let clientCount = 0;
+    for (const user in preKeyBundles) {
+      clientCount += Object.keys(preKeyBundles[user]).length;
+    }
+
+    const messageInBytes = new Uint8Array(plainText).length;
+    const estimatedPayloadInBytes = clientCount * messageInBytes;
+
+    console.log(estimatedPayloadInBytes, EXTERNAL_MESSAGE_THRESHOLD_BYTES);
+    return estimatedPayloadInBytes > EXTERNAL_MESSAGE_THRESHOLD_BYTES;
+  }
+
+  private isClientMismatchError(error: any): error is ClientMismatchError {
+    return error.response?.status === HTTP_STATUS.PRECONDITION_FAILED;
+  }
+
+  private async reencryptAfterMismatch(
+    mismatch: ClientMismatch,
+    recipients: OTRRecipients<Uint8Array>,
+    plainText: Uint8Array,
+  ): Promise<OTRRecipients<Uint8Array>> {
+    const deleted = flattenUserClients(mismatch.deleted);
+    const missing = flattenUserClients(mismatch.missing);
+    // remove deleted clients to the recipients
+    deleted.forEach(({userId, data}) => data.forEach(clientId => delete recipients[userId.id][clientId]));
+    if (missing.length) {
+      const missingPreKeyBundles = await this.apiClient.user.api.postMultiPreKeyBundles(mismatch.missing);
+      const reEncrypted = await this.cryptographyService.encrypt(plainText, missingPreKeyBundles);
+      const reEncryptedPayloads = flattenUserClients<{[client: string]: Uint8Array}>(reEncrypted);
+      // add missing clients to the recipients
+      reEncryptedPayloads.forEach(({data, userId}) => (recipients[userId.id] = {...recipients[userId.id], ...data}));
+    }
+    return recipients;
+  }
+
+  /**
+   * Will re-encrypt a message when there were some missing clients in the initial send (typically when the server replies with a client mismatch error)
+   *
+   * @param {ProtobufOTR.QualifiedNewOtrMessage} messageData The initial message that was sent
+   * @param {MessageSendingStatus} messageSendingStatus Info about the missing/deleted clients
+   * @param {Uint8Array} plainText The text that should be encrypted for the missing clients
+   * @return resolves with a new message payload that can be sent
+   */
+  private async reencryptAfterFederatedMismatch(
+    mismatch: MessageSendingStatus,
+    recipients: QualifiedOTRRecipients,
+    plainText: Uint8Array,
+  ): Promise<QualifiedOTRRecipients> {
+    const deleted = flattenQualifiedUserClients(mismatch.deleted);
+    const missing = flattenQualifiedUserClients(mismatch.missing);
+    // remove deleted clients to the recipients
+    deleted.forEach(({userId, data}) =>
+      data.forEach(clientId => delete recipients[userId.domain][userId.id][clientId]),
+    );
+
+    if (Object.keys(missing).length) {
+      const missingPreKeyBundles = await this.apiClient.user.api.postQualifiedMultiPreKeyBundles(mismatch.missing);
+      const reEncrypted = await this.cryptographyService.encryptQualified(plainText, missingPreKeyBundles);
+      const reEncryptedPayloads = flattenQualifiedUserClients<{[client: string]: Uint8Array}>(reEncrypted);
+      reEncryptedPayloads.forEach(
+        ({data, userId}) => (recipients[userId.domain][userId.id] = {...recipients[userId.domain][userId.id], ...data}),
+      );
+    }
+    return recipients;
+  }
+
+  private async sendOTRProtobufMessage(
+    sendingClientId: string,
+    recipients: OTRRecipients<Uint8Array>,
+    options: {conversationId?: string; assetData?: Uint8Array; ignoreMissing?: boolean},
+  ): Promise<ClientMismatch> {
+    const userEntries: ProtobufOTR.IUserEntry[] = Object.entries(recipients).map(([userId, otrClientMap]) => {
       const clients: ProtobufOTR.IClientEntry[] = Object.entries(otrClientMap).map(([clientId, payload]) => {
         return {
           client: {
@@ -274,239 +318,21 @@ export class MessageService {
       },
     });
 
-    if (assetData) {
-      protoMessage.blob = assetData;
+    if (options.assetData) {
+      protoMessage.blob = options.assetData;
     }
 
-    /*
-     * When creating the PreKey bundles we already found out to which users we want to send a message, so we can ignore
-     * missing clients. We have to ignore missing clients because there can be the case that there are clients that
-     * don't provide PreKeys (clients from the Pre-E2EE era).
-     */
-    const ignoreMissing = true;
-
-    try {
-      if (conversationId === null) {
-        return await this.apiClient.broadcast.api.postBroadcastProtobufMessage(
+    return !options.conversationId
+      ? await this.apiClient.broadcast.api.postBroadcastProtobufMessage(
           sendingClientId,
           protoMessage,
-          ignoreMissing,
+          options.ignoreMissing,
+        )
+      : await this.apiClient.conversation.api.postOTRProtobufMessage(
+          sendingClientId,
+          options.conversationId,
+          protoMessage,
+          options.ignoreMissing,
         );
-      }
-      return await this.apiClient.conversation.api.postOTRProtobufMessage(
-        sendingClientId,
-        conversationId,
-        protoMessage,
-        ignoreMissing,
-      );
-    } catch (error) {
-      if (!this.isClientMismatchError(error)) {
-        throw error;
-      }
-      const mismatch = error.response!.data;
-      const reEncryptedMessage = await this.onClientProtobufMismatch(mismatch, protoMessage, plainTextArray);
-      if (conversationId === null) {
-        return await this.apiClient.broadcast.api.postBroadcastProtobufMessage(sendingClientId, reEncryptedMessage);
-      }
-      return await this.apiClient.conversation.api.postOTRProtobufMessage(
-        sendingClientId,
-        conversationId,
-        reEncryptedMessage,
-        ignoreMissing,
-      );
-    }
-  }
-
-  private async onClientMismatch(
-    clientMismatch: ClientMismatch,
-    message: NewOTRMessage<Uint8Array>,
-    plainTextArray: Uint8Array,
-  ): Promise<NewOTRMessage<Uint8Array>> {
-    const {missing, deleted} = clientMismatch;
-
-    const deletedUserIds = Object.keys(deleted);
-    const missingUserIds = Object.keys(missing);
-
-    if (deletedUserIds.length) {
-      for (const deletedUserId of deletedUserIds) {
-        for (const deletedClientId of deleted[deletedUserId]) {
-          const deletedUser = message.recipients[deletedUserId];
-          if (deletedUser) {
-            delete deletedUser[deletedClientId];
-          }
-        }
-      }
-    }
-
-    if (missingUserIds.length) {
-      const missingPreKeyBundles = await this.apiClient.user.api.postMultiPreKeyBundles(missing);
-      const reEncryptedPayloads = await this.cryptographyService.encrypt(plainTextArray, missingPreKeyBundles);
-      for (const missingUserId of missingUserIds) {
-        for (const missingClientId in reEncryptedPayloads[missingUserId]) {
-          const missingUser = message.recipients[missingUserId];
-          if (!missingUser) {
-            message.recipients[missingUserId] = {};
-          }
-
-          message.recipients[missingUserId][missingClientId] = reEncryptedPayloads[missingUserId][missingClientId];
-        }
-      }
-    }
-
-    return message;
-  }
-
-  private async onClientProtobufMismatch(
-    clientMismatch: {missing: UserClients; deleted: UserClients},
-    message: ProtobufOTR.NewOtrMessage,
-    plainTextArray: Uint8Array,
-  ): Promise<ProtobufOTR.NewOtrMessage> {
-    const {missing, deleted} = clientMismatch;
-
-    const deletedUserIds = Object.keys(deleted);
-    const missingUserIds = Object.keys(missing);
-
-    if (deletedUserIds.length) {
-      for (const deletedUserId of deletedUserIds) {
-        for (const deletedClientId of deleted[deletedUserId]) {
-          const deletedUserIndex = message.recipients.findIndex(({user}) => bytesToUUID(user.uuid) === deletedUserId);
-          if (deletedUserIndex > -1) {
-            const deletedClientIndex = message.recipients[deletedUserIndex].clients?.findIndex(({client}) => {
-              return client.client.toString(16) === deletedClientId;
-            });
-            if (typeof deletedClientIndex !== 'undefined' && deletedClientIndex > -1) {
-              delete message.recipients[deletedUserIndex].clients?.[deletedClientIndex!];
-            }
-          }
-        }
-      }
-    }
-
-    if (missingUserIds.length) {
-      const missingPreKeyBundles = await this.apiClient.user.api.postMultiPreKeyBundles(missing);
-      const reEncryptedPayloads = await this.cryptographyService.encrypt(plainTextArray, missingPreKeyBundles);
-      for (const missingUserId of missingUserIds) {
-        for (const missingClientId in reEncryptedPayloads[missingUserId]) {
-          const missingUserIndex = message.recipients.findIndex(({user}) => bytesToUUID(user.uuid) === missingUserId);
-          if (missingUserIndex === -1) {
-            message.recipients.push({
-              clients: [
-                {
-                  client: {
-                    client: Long.fromString(missingClientId, 16),
-                  },
-                  text: reEncryptedPayloads[missingUserId][missingClientId],
-                },
-              ],
-              user: {
-                uuid: uuidToBytes(missingUserId),
-              },
-            });
-          }
-        }
-      }
-    }
-
-    return message;
-  }
-
-  private deleteExtraQualifiedClients(
-    message: ProtobufOTR.QualifiedNewOtrMessage,
-    deletedClients: MessageSendingStatus['deleted'],
-  ): ProtobufOTR.QualifiedNewOtrMessage {
-    // walk through deleted domain/user map
-    for (const [deletedUserDomain, deletedUserIdClients] of Object.entries(deletedClients)) {
-      if (!message.recipients.find(recipient => recipient.domain === deletedUserDomain)) {
-        // no user from this domain was deleted
-        continue;
-      }
-      // walk through deleted user ids
-      for (const [deletedUserId] of Object.entries(deletedUserIdClients)) {
-        // walk through message recipients
-        for (const recipients of message.recipients) {
-          // check if message recipients' domain is the same as the deleted user's domain
-          if (recipients.domain === deletedUserDomain) {
-            // check if message recipients' id is the same as the deleted user's id
-            for (const recipientEntry of recipients.entries || []) {
-              const uuid = recipientEntry.user?.uuid;
-              if (!!uuid && bytesToUUID(uuid) === deletedUserId) {
-                // delete this user from the message recipients
-                const deleteIndex = recipients.entries!.indexOf(recipientEntry);
-                recipients.entries!.splice(deleteIndex);
-              }
-            }
-          }
-        }
-      }
-    }
-    return message;
-  }
-
-  /**
-   * Will re-encrypt a message when there were some missing clients in the initial send (typically when the server replies with a client mismatch error)
-   *
-   * @param {ProtobufOTR.QualifiedNewOtrMessage} messageData The initial message that was sent
-   * @param {MessageSendingStatus} messageSendingStatus Info about the missing/deleted clients
-   * @param {Uint8Array} plainText The text that should be encrypted for the missing clients
-   * @return resolves with a new message payload that can be sent
-   */
-  private async onFederatedMismatch(
-    message: ProtobufOTR.QualifiedNewOtrMessage,
-    {deleted, missing}: MessageSendingStatus,
-    plainText: Uint8Array,
-  ): Promise<ProtobufOTR.QualifiedNewOtrMessage> {
-    message = this.deleteExtraQualifiedClients(message, deleted);
-    if (Object.keys(missing).length) {
-      const missingPreKeyBundles = await this.apiClient.user.api.postQualifiedMultiPreKeyBundles(missing);
-      const reEncryptedPayloads = await this.cryptographyService.encryptQualified(plainText, missingPreKeyBundles);
-      message = this.addMissingQualifiedClients(message, reEncryptedPayloads);
-    }
-    return message;
-  }
-
-  private addMissingQualifiedClients(
-    messageData: ProtobufOTR.QualifiedNewOtrMessage,
-    reEncryptedPayloads: QualifiedOTRRecipients,
-  ): ProtobufOTR.QualifiedNewOtrMessage {
-    // walk through missing domain/user map
-    for (const [missingDomain, userClients] of Object.entries(reEncryptedPayloads)) {
-      // walk through missing user ids
-      for (const [missingUserId, missingClientIds] of Object.entries(userClients)) {
-        // walk through message recipients
-        for (const domain of messageData.recipients) {
-          // check if message recipients' domain is the same as the missing user's domain
-          if (domain.domain === missingDomain) {
-            // check if there is a recipient with same user id as the missing user's id
-            let userIndex = domain.entries?.findIndex(({user}) => bytesToUUID(user.uuid) === missingUserId);
-
-            if (userIndex === -1) {
-              // no recipient found, let's create it
-              userIndex =
-                domain.entries!.push({
-                  user: {
-                    uuid: uuidToBytes(missingUserId),
-                  },
-                }) - 1;
-            }
-
-            const missingUserUUID = domain.entries![userIndex!].user.uuid;
-
-            if (bytesToUUID(missingUserUUID) === missingUserId) {
-              for (const [missingClientId, missingClientPayload] of Object.entries(missingClientIds)) {
-                domain.entries![userIndex!].clients ||= [];
-                domain.entries![userIndex!].clients?.push({
-                  client: {
-                    client: Long.fromString(missingClientId, 16),
-                  },
-                  text: missingClientPayload,
-                });
-              }
-            }
-          }
-        }
-      }
-    }
-
-    return messageData;
   }
 }

--- a/packages/core/src/main/conversation/message/UserClientsUtil.ts
+++ b/packages/core/src/main/conversation/message/UserClientsUtil.ts
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {QualifiedId} from '@wireapp/api-client/src/user';
+
+type UserClientsContainer<T> = {[userId: string]: T};
+type QualifiedUserClientsContainer<T> = {[domain: string]: UserClientsContainer<T>};
+
+export function flattenUserClients<T>(
+  userClients: UserClientsContainer<T>,
+  domain: string = '',
+): {data: T; userId: QualifiedId}[] {
+  return Object.entries(userClients).map(([id, data]) => ({data, userId: {domain, id}}));
+}
+
+/**
+ * Will flatten a container of users=>clients infos to an array
+ *
+ * @param userClients The UserClients (qualified or not) to flatten
+ * @return An array containing the qualified user Ids and the clients info
+ */
+export function flattenQualifiedUserClients<T = unknown>(
+  userClients: QualifiedUserClientsContainer<T>,
+): {data: T; userId: QualifiedId}[] {
+  return Object.entries(userClients).reduce((ids, [domain, userClients]) => {
+    return [...ids, ...flattenUserClients(userClients, domain)];
+  }, [] as {data: T; userId: QualifiedId}[]);
+}

--- a/packages/core/src/main/conversation/message/UserClientsUtils.test.node.ts
+++ b/packages/core/src/main/conversation/message/UserClientsUtils.test.node.ts
@@ -1,0 +1,44 @@
+/*
+ * Wire
+ * Copyright (C) 2021 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {flattenQualifiedUserClients, flattenUserClients} from './UserClientsUtil';
+
+describe('userClientsUtils', () => {
+  it('extracts user and data info from qualified payload', () => {
+    const payload = {domain1: {user1: ['client1'], user2: ['client11']}, domain2: {user3: ['client1', 'client2']}};
+    const expected = [
+      {data: ['client1'], userId: {domain: 'domain1', id: 'user1'}},
+      {data: ['client11'], userId: {domain: 'domain1', id: 'user2'}},
+      {data: ['client1', 'client2'], userId: {domain: 'domain2', id: 'user3'}},
+    ];
+
+    expect(flattenQualifiedUserClients(payload)).toEqual(expected);
+  });
+
+  it('extracts user and data info from non-qualified payload', () => {
+    const payload = {user1: ['client1'], user2: ['client11'], user3: ['client1', 'client2']};
+    const expected = [
+      {data: ['client1'], userId: {domain: '', id: 'user1'}},
+      {data: ['client11'], userId: {domain: '', id: 'user2'}},
+      {data: ['client1', 'client2'], userId: {domain: '', id: 'user3'}},
+    ];
+
+    expect(flattenUserClients(payload)).toEqual(expected);
+  });
+});

--- a/packages/core/src/main/util/TypePredicateUtil.ts
+++ b/packages/core/src/main/util/TypePredicateUtil.ts
@@ -21,7 +21,7 @@ import type {QualifiedUserClients, UserClients} from '@wireapp/api-client/src/co
 import type {QualifiedId} from '@wireapp/api-client/src/user/';
 
 export function isStringArray(obj: any): obj is string[] {
-  return Array.isArray(obj) && typeof obj[0] === 'string';
+  return Array.isArray(obj) && (obj.length === 0 || typeof obj[0] === 'string');
 }
 
 export function isQualifiedId(obj: any): obj is QualifiedId {
@@ -37,10 +37,7 @@ export function isQualifiedUserClients(obj: any): obj is QualifiedUserClients {
     const firstUserClientObject = Object.values(obj)?.[0];
     if (typeof firstUserClientObject === 'object') {
       const firstClientIdArray = Object.values(firstUserClientObject as object)[0];
-      if (Array.isArray(firstClientIdArray)) {
-        const firstClientId = firstClientIdArray[0];
-        return typeof firstClientId === 'string' || typeof firstClientId === 'undefined';
-      }
+      return isStringArray(firstClientIdArray);
     }
   }
   return false;
@@ -49,10 +46,7 @@ export function isQualifiedUserClients(obj: any): obj is QualifiedUserClients {
 export function isUserClients(obj: any): obj is UserClients {
   if (typeof obj === 'object') {
     const firstUserClientArray = Object.values(obj)?.[0];
-    if (Array.isArray(firstUserClientArray)) {
-      const firstClientId = firstUserClientArray[0];
-      return typeof firstClientId === 'string';
-    }
+    return isStringArray(firstUserClientArray);
   }
   return false;
 }


### PR DESCRIPTION
BREAKING CHANGE
- When calling `account.services.converation.send` with a list of `UserClients`, the core will not try to fetch the latest clients from the backend and will instead only send to the given clients. This might generate a mismatch error is there are missing clients given. 

This PR will:
- Simplify the `MessageService` API to only 2 public methods (`sendMessage`, `sendFederatedMessage`);
- Move all the encryption jobs to the `MessageService`, the `ConversationService` is not even aware encryption exists;
- Harmonize how mismatch are handled and retried in the `MessageService`;
- Cover the main sending scenarios (as external, with mismatch, as protobuf...) with tests;

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
