### PR TITLE
feat(core): Add a mechanism to cancel message sending

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -77,6 +77,25 @@ describe('ConversationService', () => {
         expect(callbacks.onSuccess).toHaveBeenCalledWith(jasmine.any(Object), sentTime);
       });
     });
+
+    it(`cancels message sending if onStart returns false`, async () => {
+      account['apiClient'].context = {
+        clientType: ClientType.NONE,
+        userId: PayloadHelper.getUUID(),
+        clientId: PayloadHelper.getUUID(),
+      };
+      const conversationService = account.service!.conversation;
+      spyOn<any>(conversationService, 'sendGenericMessage');
+      const message: OtrMessage = {...baseMessage, type: PayloadBundleType.TEXT, content: {text: 'test'}};
+      const callbacks = {onStart: () => Promise.resolve(false), onSuccess: jasmine.createSpy()};
+      await conversationService.send({
+        callbacks,
+        payloadBundle: message,
+      });
+
+      expect(callbacks.onSuccess).not.toHaveBeenCalled();
+      expect(conversationService['sendGenericMessage']).not.toHaveBeenCalled();
+    });
   });
 
   describe('"createText"', () => {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->
This adds the possibility for the consumer to cancel a message from being sent. 
This allows the consumer to access the full `genericMessage` (can be used for optimistic event) but still cancel the sending. 

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
