### PR TITLE
feat(core): Add ability to send targeted message to specific users

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -117,16 +117,21 @@ describe('ConversationService', () => {
       });
 
       [
-        {domain1: {user1: ['client1'], user2: ['client11', 'client12']}},
+        {domain1: {user1: ['client1'], user2: ['client11', 'client12']}, domain2: {user3: ['client1']}},
         [
           {id: 'user1', domain: 'domain1'},
           {id: 'user2', domain: 'domain1'},
+          {id: 'user3', domain: 'domain2'},
         ],
       ].forEach(recipients => {
         it(`forwards the list of users to report for federated message (${JSON.stringify(recipients)})`, async () => {
           const conversationService = account.service!.conversation;
-          spyOn<any>(conversationService, 'getQualifiedRecipientsForConversation').and.returnValue(Promise.resolve({} as any));
-          spyOn(conversationService['messageService'], 'sendFederatedMessage').and.returnValue(Promise.resolve({} as any));
+          spyOn<any>(conversationService, 'getQualifiedRecipientsForConversation').and.returnValue(
+            Promise.resolve({} as any),
+          );
+          spyOn(conversationService['messageService'], 'sendFederatedMessage').and.returnValue(
+            Promise.resolve({} as any),
+          );
           await conversationService.send({
             conversationDomain: 'domain1',
             payloadBundle: message,
@@ -138,7 +143,13 @@ describe('ConversationService', () => {
             jasmine.any(String),
             jasmine.any(Object),
             jasmine.any(Uint8Array),
-            jasmine.objectContaining({reportMissing: ['user1', 'user2']}),
+            jasmine.objectContaining({
+              reportMissing: [
+                {id: 'user1', domain: 'domain1'},
+                {id: 'user2', domain: 'domain1'},
+                {id: 'user3', domain: 'domain2'},
+              ],
+            }),
           );
         });
       });

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -37,6 +37,14 @@ describe('ConversationService', () => {
     await account.initServices(new MemoryEngine());
   });
 
+  beforeEach(() => {
+    account['apiClient'].context = {
+      clientType: ClientType.NONE,
+      userId: PayloadHelper.getUUID(),
+      clientId: PayloadHelper.getUUID(),
+    };
+  });
+
   describe('"send"', () => {
     const baseMessage = {
       conversation: PayloadHelper.getUUID(),
@@ -57,11 +65,6 @@ describe('ConversationService', () => {
     ];
     messages.forEach(payloadBundle => {
       it(`calls callbacks when sending '${payloadBundle.type}' message is starting and successful`, async () => {
-        account['apiClient'].context = {
-          clientType: ClientType.NONE,
-          userId: PayloadHelper.getUUID(),
-          clientId: PayloadHelper.getUUID(),
-        };
         const conversationService = account.service!.conversation;
         const sentTime = new Date().toISOString();
         spyOn<any>(conversationService, 'sendGenericMessage').and.returnValue(Promise.resolve({time: sentTime}));
@@ -78,12 +81,70 @@ describe('ConversationService', () => {
       });
     });
 
+    describe('targetted messages', () => {
+      const message: OtrMessage = {...baseMessage, type: PayloadBundleType.TEXT, content: {text: 'test'}};
+      it('fails if no userIds are given', done => {
+        const conversationService = account.service!.conversation;
+        conversationService
+          .send({
+            payloadBundle: message,
+            targettedMessage: true,
+          })
+          .catch(error => {
+            expect(error.message).toContain('no userIds are given');
+            done();
+          });
+      });
+
+      [{user1: ['client1'], user2: ['client11', 'client12']}, ['user1', 'user2']].forEach(recipients => {
+        it(`forwards the list of users to report (${JSON.stringify(recipients)})`, async () => {
+          const conversationService = account.service!.conversation;
+          spyOn<any>(conversationService, 'getRecipientsForConversation').and.returnValue(Promise.resolve({} as any));
+          spyOn(conversationService['messageService'], 'sendMessage').and.returnValue(Promise.resolve({} as any));
+          await conversationService.send({
+            payloadBundle: message,
+            targettedMessage: true,
+            userIds: recipients,
+          });
+
+          expect(conversationService['messageService'].sendMessage).toHaveBeenCalledWith(
+            jasmine.any(String),
+            jasmine.any(Object),
+            jasmine.any(Uint8Array),
+            jasmine.objectContaining({reportMissing: ['user1', 'user2']}),
+          );
+        });
+      });
+
+      [
+        {domain1: {user1: ['client1'], user2: ['client11', 'client12']}},
+        [
+          {id: 'user1', domain: 'domain1'},
+          {id: 'user2', domain: 'domain1'},
+        ],
+      ].forEach(recipients => {
+        it(`forwards the list of users to report for federated message (${JSON.stringify(recipients)})`, async () => {
+          const conversationService = account.service!.conversation;
+          spyOn<any>(conversationService, 'getQualifiedRecipientsForConversation').and.returnValue(Promise.resolve({} as any));
+          spyOn(conversationService['messageService'], 'sendFederatedMessage').and.returnValue(Promise.resolve({} as any));
+          await conversationService.send({
+            conversationDomain: 'domain1',
+            payloadBundle: message,
+            targettedMessage: true,
+            userIds: recipients,
+          });
+
+          expect(conversationService['messageService'].sendFederatedMessage).toHaveBeenCalledWith(
+            jasmine.any(String),
+            jasmine.any(Object),
+            jasmine.any(Uint8Array),
+            jasmine.objectContaining({reportMissing: ['user1', 'user2']}),
+          );
+        });
+      });
+    });
+
     it(`cancels message sending if onStart returns false`, async () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-        clientId: PayloadHelper.getUUID(),
-      };
       const conversationService = account.service!.conversation;
       spyOn<any>(conversationService, 'sendGenericMessage');
       const message: OtrMessage = {...baseMessage, type: PayloadBundleType.TEXT, content: {text: 'test'}};
@@ -98,11 +159,6 @@ describe('ConversationService', () => {
     });
 
     it(`does not call onSuccess when message was canceled`, async () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-        clientId: PayloadHelper.getUUID(),
-      };
       const conversationService = account.service!.conversation;
       spyOn<any>(conversationService, 'sendGenericMessage').and.returnValue(Promise.resolve({time: '', errored: true}));
       const message: OtrMessage = {...baseMessage, type: PayloadBundleType.TEXT, content: {text: 'test'}};
@@ -118,11 +174,6 @@ describe('ConversationService', () => {
 
   describe('"createText"', () => {
     it('adds link previews correctly', async () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const url = 'http://example.com';
 
       const permanentUrl = url;
@@ -165,11 +216,6 @@ describe('ConversationService', () => {
     });
 
     it('does not add link previews', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const text = 'Hello, world!';
       const textMessage = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
 
@@ -177,11 +223,6 @@ describe('ConversationService', () => {
     });
 
     it('uploads link previews', async () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       spyOn(account.service!.asset, 'uploadImageAsset').and.returnValue(
         Promise.resolve({
           cipherText: Buffer.from([]),
@@ -222,11 +263,6 @@ describe('ConversationService', () => {
     });
 
     it('adds mentions correctly', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const text = 'Hello @user!';
 
       const mention: MentionContent = {
@@ -248,11 +284,6 @@ describe('ConversationService', () => {
     });
 
     it('does not add mentions', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const text = 'Hello, world!';
       const textMessage = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
 
@@ -260,11 +291,6 @@ describe('ConversationService', () => {
     });
 
     it('adds a quote correctly', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const quoteId = PayloadHelper.getUUID();
       const text = 'I totally agree.';
 
@@ -283,11 +309,6 @@ describe('ConversationService', () => {
     });
 
     it('does not add a quote', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const text = 'Hello, world!';
       const textMessage = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
 
@@ -295,11 +316,6 @@ describe('ConversationService', () => {
     });
 
     it('adds a read confirmation request correctly', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const text = 'Please read me';
 
       const replyMessage = account
@@ -312,11 +328,6 @@ describe('ConversationService', () => {
     });
 
     it('adds a legal hold status', () => {
-      account['apiClient'].context = {
-        clientType: ClientType.NONE,
-        userId: PayloadHelper.getUUID(),
-      };
-
       const text = 'Please read me';
 
       const firstMessage = account

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -327,17 +327,14 @@ export class ConversationService {
     return Object.keys(userIds);
   }
 
-  private extractQualifiedUserIds(userIds?: QualifiedId[] | QualifiedUserClients): string[] | undefined {
-    if (!userIds) {
+  private extractQualifiedUserIds(userIds?: QualifiedId[] | QualifiedUserClients): QualifiedId[] | undefined {
+    if (!userIds || isQualifiedIdArray(userIds)) {
       return userIds;
     }
-    if (isQualifiedIdArray(userIds)) {
-      return userIds.map(({id}) => id);
-    }
 
-    return Object.entries(userIds).reduce((ids, [domain, userClients]) => {
-      return ids.concat(this.extractUserIds(userClients) as string[]);
-    }, [] as string[]);
+    return Object.entries(userIds).reduce<QualifiedId[]>((ids, [domain, userClients]) => {
+      return ids.concat(Object.keys(userClients).map(userId => ({domain, id: userId})));
+    }, []);
   }
 
   private generateButtonActionGenericMessage(payloadBundle: ButtonActionMessage): GenericMessage {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -116,7 +116,7 @@ interface MessageSendingOptions {
   nativePush?: boolean;
 
   /**
-   * @param options.onClientMismatch? Will be called whenever there is a clientmismatch returned from the server. Needs to be combined with a userIds of type QualifiedUserClients
+   * Will be called whenever there is a clientmismatch returned from the server. Needs to be combined with a userIds of type QualifiedUserClients
    */
   onClientMismatch?: MessageSendingCallbacks['onClientMismatch'];
 
@@ -353,7 +353,7 @@ export class ConversationService {
     const recipients = await this.getRecipientsForConversation(conversationId, userIds);
     let reportMissing;
     if (targetMode === MessageTargetMode.NONE) {
-      reportMissing = isQualifiedUserClients(userIds); // we want to check mismatch in case the consumer gave an exact list of users/devices
+      reportMissing = isUserClients(userIds); // we want to check mismatch in case the consumer gave an exact list of users/devices
     } else if (targetMode === MessageTargetMode.USERS) {
       reportMissing = this.extractUserIds(userIds);
     } else {

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -220,7 +220,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.any(Object),
-        true,
+        undefined,
       );
     });
 
@@ -238,7 +238,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.any(Object),
-        true,
+        undefined,
       );
     });
 
@@ -247,7 +247,11 @@ describe('MessageService', () => {
       spyOn(apiClient.broadcast.api, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
       await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message));
-      expect(apiClient.broadcast.api.postBroadcastMessage).toHaveBeenCalledWith(clientId, jasmine.any(Object), true);
+      expect(apiClient.broadcast.api.postBroadcastMessage).toHaveBeenCalledWith(
+        clientId,
+        jasmine.any(Object),
+        undefined,
+      );
     });
 
     it('should broadcast protobuf message if no conversationId is given', async () => {
@@ -263,7 +267,7 @@ describe('MessageService', () => {
       expect(apiClient.broadcast.api.postBroadcastProtobufMessage).toHaveBeenCalledWith(
         clientId,
         jasmine.any(Object),
-        true,
+        undefined,
       );
     });
 
@@ -278,7 +282,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.objectContaining({data: undefined}),
-        true,
+        undefined,
       );
     });
 
@@ -299,7 +303,7 @@ describe('MessageService', () => {
         clientId,
         conversationId,
         jasmine.objectContaining({data: jasmine.any(String)}),
-        true,
+        undefined,
       );
     });
 

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -41,6 +41,7 @@ import {MessageBuilder} from './MessageBuilder';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 import {GenericMessageType} from '..';
 import {flattenUserClients, flattenQualifiedUserClients} from './UserClientsUtil';
+import {isQualifiedIdArray, isStringArray} from '../../util';
 
 type ClientMismatchError = AxiosError<ClientMismatch | MessageSendingStatus>;
 
@@ -65,8 +66,9 @@ export class MessageService {
     plainText: Uint8Array,
     options: {
       conversationId?: string;
-      reportMissing?: boolean;
+      reportMissing?: boolean | string[];
       sendAsProtobuf?: boolean;
+      nativePush?: boolean;
       onClientMismatch?: (mismatch: ClientMismatch) => void | boolean | Promise<boolean>;
     } = {},
   ): Promise<ClientMismatch & {errored?: boolean}> {
@@ -119,7 +121,8 @@ export class MessageService {
     options: {
       assetData?: Uint8Array;
       conversationId?: QualifiedId;
-      reportMissing?: boolean;
+      reportMissing?: boolean | QualifiedId[];
+      nativePush?: boolean;
       onClientMismatch?: (mismatch: MessageSendingStatus) => void | boolean | Promise<boolean>;
     },
   ): Promise<MessageSendingStatus & {errored?: boolean}> {
@@ -146,7 +149,12 @@ export class MessageService {
   private async sendFederatedOtrMessage(
     sendingClientId: string,
     recipients: QualifiedOTRRecipients,
-    options: {assetData?: Uint8Array; conversationId?: QualifiedId; reportMissing?: boolean},
+    options: {
+      assetData?: Uint8Array;
+      conversationId?: QualifiedId;
+      reportMissing?: boolean | QualifiedId[];
+      nativePush?: boolean;
+    },
   ): Promise<MessageSendingStatus> {
     const qualifiedUserEntries = Object.entries(recipients).map<ProtobufOTR.IQualifiedUserEntry>(
       ([domain, otrRecipients]) => {
@@ -177,6 +185,7 @@ export class MessageService {
       sender: {
         client: Long.fromString(sendingClientId, 16),
       },
+      nativePush: options.nativePush,
     });
 
     if (options.assetData) {
@@ -184,9 +193,13 @@ export class MessageService {
     }
 
     if (options.reportMissing) {
-      protoMessage.reportAll = {};
+      if (isQualifiedIdArray(options.reportMissing)) {
+        protoMessage.reportOnly = {userIds: options.reportMissing};
+      } else {
+        protoMessage.reportAll = true;
+      }
     } else {
-      protoMessage.ignoreAll = {};
+      protoMessage.ignoreAll = true;
     }
 
     if (!options.conversationId) {
@@ -202,22 +215,28 @@ export class MessageService {
   private async sendOTRMessage(
     sendingClientId: string,
     recipients: OTRRecipients<Uint8Array>,
-    options: {conversationId?: string; assetData?: Uint8Array; reportMissing?: boolean},
+    options: {
+      conversationId?: string;
+      assetData?: Uint8Array;
+      reportMissing?: boolean | string[];
+      nativePush?: boolean;
+    },
   ): Promise<ClientMismatch> {
     const message: NewOTRMessage<string> = {
       data: options.assetData ? Encoder.toBase64(options.assetData).asString : undefined,
       recipients: CryptographyService.convertArrayRecipientsToBase64(recipients),
       sender: sendingClientId,
+      native_push: options.nativePush,
     };
 
+    const ignoreMissing = !options.reportMissing;
+    if (isStringArray(options.reportMissing)) {
+      message.report_missing = options.reportMissing;
+    }
+
     return !options.conversationId
-      ? this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, !options.reportMissing)
-      : this.apiClient.conversation.api.postOTRMessage(
-          sendingClientId,
-          options.conversationId,
-          message,
-          !options.reportMissing,
-        );
+      ? this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, ignoreMissing)
+      : this.apiClient.conversation.api.postOTRMessage(sendingClientId, options.conversationId, message, ignoreMissing);
   }
 
   private async generateExternalPayload(plainText: Uint8Array): Promise<{text: Uint8Array; cipherText: Uint8Array}> {
@@ -309,7 +328,7 @@ export class MessageService {
   private async sendOTRProtobufMessage(
     sendingClientId: string,
     recipients: OTRRecipients<Uint8Array>,
-    options: {conversationId?: string; assetData?: Uint8Array; reportMissing?: boolean},
+    options: {conversationId?: string; assetData?: Uint8Array; reportMissing?: boolean | string[]},
   ): Promise<ClientMismatch> {
     const userEntries: ProtobufOTR.IUserEntry[] = Object.entries(recipients).map(([userId, otrClientMap]) => {
       const clients: ProtobufOTR.IClientEntry[] = Object.entries(otrClientMap).map(([clientId, payload]) => {
@@ -336,17 +355,23 @@ export class MessageService {
       },
     });
 
+    const ignoreMissing = !options.reportMissing;
+    if (isStringArray(options.reportMissing)) {
+      const encoder = new TextEncoder();
+      protoMessage.reportMissing = options.reportMissing.map(userId => ({uuid: encoder.encode(userId)}));
+    }
+
     if (options.assetData) {
       protoMessage.blob = options.assetData;
     }
 
     return !options.conversationId
-      ? this.apiClient.broadcast.api.postBroadcastProtobufMessage(sendingClientId, protoMessage, !options.reportMissing)
+      ? this.apiClient.broadcast.api.postBroadcastProtobufMessage(sendingClientId, protoMessage, ignoreMissing)
       : this.apiClient.conversation.api.postOTRProtobufMessage(
           sendingClientId,
           options.conversationId,
           protoMessage,
-          !options.reportMissing,
+          ignoreMissing,
         );
   }
 }

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -229,7 +229,7 @@ export class MessageService {
       native_push: options.nativePush,
     };
 
-    const ignoreMissing = !options.reportMissing;
+    const ignoreMissing = options.reportMissing === true ? false : undefined;
     if (isStringArray(options.reportMissing)) {
       message.report_missing = options.reportMissing;
     }
@@ -355,7 +355,7 @@ export class MessageService {
       },
     });
 
-    const ignoreMissing = !options.reportMissing;
+    const ignoreMissing = options.reportMissing === true ? false : undefined;
     if (isStringArray(options.reportMissing)) {
       const encoder = new TextEncoder();
       protoMessage.reportMissing = options.reportMissing.map(userId => ({uuid: encoder.encode(userId)}));


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

This will allow messages to be send to a particular set of users in the conversation. 
There are three target mode possible:
- NONE (default) will target no user in particular (so will try to send to all the users in the conversation). This will trigger a mismatch error if some user/client pair are missing on backend side ;
- `USERS` Will target some specific users. Only clients missing from those users will trigger a mismatch error. Missing users will not
- `USERS_CLIENTS` will target specific users/clients. Basically the same as forcing the message to be sent and ignores all missing users/clients.

## Use Cases

- confirmation message => only sent to the user from the original message but all his devices (`USERS`) (see https://github.com/wireapp/wire-webapp/pull/12207)
- calling message while in call => only sent to the user **and** the device in the call (`USERS_CLIENTS`)

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
