### PR TITLE
feat(core): Add cancelled flag when message sending was cancelled

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -214,13 +214,14 @@ describe('ConversationService', () => {
       spyOn<any>(conversationService, 'sendGenericMessage');
       const message: OtrMessage = {...baseMessage, type: PayloadBundleType.TEXT, content: {text: 'test'}};
       const callbacks = {onStart: () => Promise.resolve(false), onSuccess: jasmine.createSpy()};
-      await conversationService.send({
+      const payloadBundle = await conversationService.send({
         callbacks,
         payloadBundle: message,
       });
 
       expect(callbacks.onSuccess).not.toHaveBeenCalled();
       expect(conversationService['sendGenericMessage']).not.toHaveBeenCalled();
+      expect(payloadBundle.state).toBe(PayloadBundleState.CANCELLED);
     });
 
     it(`does not call onSuccess when message was canceled`, async () => {
@@ -228,12 +229,13 @@ describe('ConversationService', () => {
       spyOn<any>(conversationService, 'sendGenericMessage').and.returnValue(Promise.resolve({time: '', errored: true}));
       const message: OtrMessage = {...baseMessage, type: PayloadBundleType.TEXT, content: {text: 'test'}};
       const callbacks = {onSuccess: jasmine.createSpy()};
-      await conversationService.send({
+      const payloadBundle = await conversationService.send({
         callbacks,
         payloadBundle: message,
       });
 
       expect(callbacks.onSuccess).not.toHaveBeenCalled();
+      expect(payloadBundle.state).toBe(PayloadBundleState.CANCELLED);
     });
   });
 

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -954,7 +954,7 @@ export class ConversationService {
       ...payloadBundle,
       content: processedContent || payloadBundle.content,
       messageTimer: genericMessage.ephemeral?.expireAfterMillis || 0,
-      state: PayloadBundleState.OUTGOING_SENT,
+      state: response.errored ? PayloadBundleState.CANCELLED : PayloadBundleState.OUTGOING_SENT,
     };
   }
 

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -925,7 +925,7 @@ export class ConversationService {
 
     if ((await callbacks?.onStart?.(genericMessage)) === false) {
       // If the onStart call returns false, it means the consumer wants to cancel the message sending
-      return payloadBundle;
+      return {...payloadBundle, state: PayloadBundleState.CANCELLED};
     }
 
     const response = await this.sendGenericMessage(

--- a/packages/core/src/main/conversation/message/PayloadBundle.ts
+++ b/packages/core/src/main/conversation/message/PayloadBundle.ts
@@ -34,6 +34,7 @@ export enum PayloadBundleState {
   INCOMING = 'PayloadBundleState.INCOMING',
   OUTGOING_SENT = 'PayloadBundleState.OUTGOING_SENT',
   OUTGOING_UNSENT = 'PayloadBundleState.OUTGOING_UNSENT',
+  CANCELLED = 'PayloadBundleState.CANCELLED'
 }
 
 export interface BasePayloadBundle {

--- a/packages/core/src/main/conversation/message/PayloadBundle.ts
+++ b/packages/core/src/main/conversation/message/PayloadBundle.ts
@@ -34,7 +34,7 @@ export enum PayloadBundleState {
   INCOMING = 'PayloadBundleState.INCOMING',
   OUTGOING_SENT = 'PayloadBundleState.OUTGOING_SENT',
   OUTGOING_UNSENT = 'PayloadBundleState.OUTGOING_UNSENT',
-  CANCELLED = 'PayloadBundleState.CANCELLED'
+  CANCELLED = 'PayloadBundleState.CANCELLED',
 }
 
 export interface BasePayloadBundle {


### PR DESCRIPTION
When sending a message and the consumer decided to cancel message sending because of a mismatch error, then the returned payload has the `state: PayloadBundleState.CANCELLED` property set

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
