### PR TITLE
feat(core): Map qualified_conversation and qualified_from in message payloads

### DIFF
--- a/packages/core/src/main/conversation/ConversationMapper.ts
+++ b/packages/core/src/main/conversation/ConversationMapper.ts
@@ -27,6 +27,8 @@ export class ConversationMapper {
     return {
       content: event.data,
       conversation: event.conversation,
+      qualifiedConversation: event.qualified_conversation,
+      qualifiedFrom: event.qualified_from,
       from: event.from,
       id: MessageBuilder.createId(),
       messageTimer: 0,

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -130,7 +130,13 @@ interface MessageSendingOptions {
 }
 
 export interface MessageSendingCallbacks {
+  /**
+   * Will be called before a message is actually sent. Returning 'false' will prevent the message from being sent
+   * @param message The message being sent
+   * @return true or undefined if the message should be sent, false if the message sending should be cancelled
+   */
   onStart?: (message: GenericMessage) => void | boolean | Promise<boolean>;
+
   onSuccess?: (message: GenericMessage, sentTime?: string) => void;
   /**
    * Called whenever there is a clientmismatch returned from the server. Will also indicate the sending status of the message (if it was already sent or not)
@@ -845,8 +851,6 @@ export class ConversationService {
    *    When given a QualifiedUserClients or UserClients the method will only send to the clients listed in the userIds. This could lead to ClientMismatch (since the given list of devices might not be the freshest one and new clients could have been created)
    *    When given a QualifiedId[] or QualifiedUserClients the method will send the message through the federated API endpoint
    *    When given a string[] or UserClients the method will send the message through the old API endpoint
-   * @param callbacks.onStart Will be called before a message is actually sent. Returning 'false' will prevent the message from being sent
-   * @param callbacks.onClientMismatch? Will be called when a mismatch happens. Returning `false` from the callback will stop the sending attempt
    * @return resolves with the sent message
    */
   public async send<T extends OtrMessage = OtrMessage>({

--- a/packages/core/src/main/conversation/message/PayloadBundle.ts
+++ b/packages/core/src/main/conversation/message/PayloadBundle.ts
@@ -18,6 +18,7 @@
  */
 
 import type {ConversationEventData, TeamEventData, UserEventData} from '@wireapp/api-client/src/event/';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 import type {ConversationContent} from '../content';
 import type {Message} from './Message';
@@ -40,7 +41,9 @@ export enum PayloadBundleState {
 export interface BasePayloadBundle {
   content: PayloadBundleContent;
   conversation: string;
+  qualifiedConversation?: QualifiedId;
   from: string;
+  qualifiedFrom?: QualifiedId;
   fromClientId?: string;
   id: string;
   messageTimer?: number;


### PR DESCRIPTION
`PayloadBundle` now gets decorated with `qualifiedConversation` and `qualifiedFrom` and can be read on consumer side
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
