### PR TITLE
feat(core): Add a method to get all participants/clients of a conversation

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -239,6 +239,43 @@ describe('ConversationService', () => {
     });
   });
 
+  describe('getAllParticipantsClients', () => {
+    it('gives the members and clients of a federated conversation', async () => {
+      const members = {
+        user1: ['client1', 'client2'],
+        user2: ['client1', 'client2'],
+        user3: ['client1', 'client2'],
+      };
+      const conversationService = account.service!.conversation;
+      spyOn(conversationService['messageService'], 'sendMessage').and.callFake(
+        (_client, _recipients, _text, options) => {
+          options?.onClientMismatch?.({missing: members, deleted: {}, redundant: {}, time: ''});
+          return {} as any;
+        },
+      );
+      const fetchedMembers = await conversationService.getAllParticipantsClients('convid');
+
+      expect(fetchedMembers).toEqual(members);
+    });
+
+    it('gives the members and clients of a federated conversation', async () => {
+      const members = {
+        domain1: {user1: ['client1', 'client2']},
+        domain2: {user2: ['client1', 'client2'], user3: ['client1', 'client2']},
+      };
+      const conversationService = account.service!.conversation;
+      spyOn(conversationService['messageService'], 'sendFederatedMessage').and.callFake(
+        (_client, _recipients, _text, options) => {
+          options?.onClientMismatch?.({missing: members, deleted: {}, redundant: {}, failed_to_send: {}, time: ''});
+          return {} as any;
+        },
+      );
+      const fetchedMembers = await conversationService.getAllParticipantsClients('convid', 'domain1');
+
+      expect(fetchedMembers).toEqual(members);
+    });
+  });
+
   describe('"createText"', () => {
     it('adds link previews correctly', async () => {
       const url = 'http://example.com';

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -715,6 +715,7 @@ export class ConversationService {
             resolve(mismatch.missing);
             return false;
           },
+          reportMissing: true,
         });
       } else {
         await this.messageService.sendMessage(sendingClientId, recipients, text, {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -707,24 +707,22 @@ export class ConversationService {
     const recipients = {};
     const text = new Uint8Array();
     return new Promise(async resolve => {
+      const onClientMismatch = (mismatch: ClientMismatch | MessageSendingStatus) => {
+        resolve(mismatch.missing);
+        // When the mismatch happens, we ask the messageService to cancel the sending
+        return false;
+      };
+
       if (conversationDomain) {
         await this.messageService.sendFederatedMessage(sendingClientId, recipients, text, {
           conversationId: {id: conversationId, domain: conversationDomain},
-          // When the mismatch happens, we ask the messageService to cancel the sending
-          onClientMismatch: mismatch => {
-            resolve(mismatch.missing);
-            return false;
-          },
+          onClientMismatch,
           reportMissing: true,
         });
       } else {
         await this.messageService.sendMessage(sendingClientId, recipients, text, {
           conversationId,
-          // When the mismatch happens, we ask the messageService to cancel the sending
-          onClientMismatch: mismatch => {
-            resolve(mismatch.missing);
-            return false;
-          },
+          onClientMismatch,
         });
       }
     });

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -699,16 +699,16 @@ export class ConversationService {
    * @param {string} conversationId
    * @param {string} conversationDomain? - If given will send the message to the new qualified endpoint
    */
-  public async getAllParticipantsClients(
+  public getAllParticipantsClients(
     conversationId: string,
     conversationDomain?: string,
   ): Promise<UserClients | QualifiedUserClients> {
     const sendingClientId = this.apiClient.validatedClientId;
     const recipients = {};
     const text = new Uint8Array();
-    return new Promise(resolve => {
+    return new Promise(async resolve => {
       if (conversationDomain) {
-        this.messageService.sendFederatedMessage(sendingClientId, recipients, text, {
+        await this.messageService.sendFederatedMessage(sendingClientId, recipients, text, {
           conversationId: {id: conversationId, domain: conversationDomain},
           // When the mismatch happens, we ask the messageService to cancel the sending
           onClientMismatch: mismatch => {
@@ -717,7 +717,7 @@ export class ConversationService {
           },
         });
       } else {
-        this.messageService.sendMessage(sendingClientId, recipients, text, {
+        await this.messageService.sendMessage(sendingClientId, recipients, text, {
           conversationId,
           // When the mismatch happens, we ask the messageService to cancel the sending
           onClientMismatch: mismatch => {


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

This enables the consumer to get a fresh list of participants and clients for a given conversation.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
