### PR TITLE
feat(core): Make message builder stateless

### DIFF
--- a/packages/bot-api/src/MessageHandler.test.node.ts
+++ b/packages/bot-api/src/MessageHandler.test.node.ts
@@ -25,6 +25,7 @@ import UUID from 'uuidjs';
 import {ClientType} from '@wireapp/api-client/src/client';
 import {TextMessage} from '@wireapp/core/src/main/conversation/message/OtrMessage';
 import {Connection} from '@wireapp/api-client/src/connection';
+import {MessageBuilder} from '@wireapp/core/src/main/conversation/message/MessageBuilder';
 
 describe('MessageHandler', () => {
   let mainHandler: MessageHandler;
@@ -92,12 +93,13 @@ describe('MessageHandler', () => {
         },
       ];
 
-      spyOn(mainHandler.account!.service!.conversation.messageBuilder, 'createText').and.callThrough();
+      spyOn(MessageBuilder, 'createText').and.callThrough();
 
       await mainHandler.sendText(conversationId, messageText, mentionData);
 
-      expect(mainHandler.account!.service!.conversation.messageBuilder.createText).toHaveBeenCalledWith({
+      expect(MessageBuilder.createText).toHaveBeenCalledWith({
         conversationId,
+        from: '',
         text: messageText,
       });
       expect(mainHandler.account!.service!.conversation.send).toHaveBeenCalledWith(
@@ -113,12 +115,13 @@ describe('MessageHandler', () => {
       const conversationId = UUID.genV4().toString();
       const message = UUID.genV4().toString();
 
-      spyOn(mainHandler.account!.service!.conversation.messageBuilder, 'createText').and.callThrough();
+      spyOn(MessageBuilder, 'createText').and.callThrough();
 
       await mainHandler.sendText(conversationId, message);
 
-      expect(mainHandler.account!.service!.conversation.messageBuilder.createText).toHaveBeenCalledWith({
+      expect(MessageBuilder.createText).toHaveBeenCalledWith({
         conversationId,
+        from: '',
         text: message,
       });
       expect(mainHandler.account!.service!.conversation.send).toHaveBeenCalledWith(
@@ -133,13 +136,14 @@ describe('MessageHandler', () => {
       const message = UUID.genV4().toString();
       const userIds = [UUID.genV4().toString(), UUID.genV4().toString()];
 
-      spyOn(mainHandler.account!.service!.conversation.messageBuilder, 'createText').and.callThrough();
+      spyOn(MessageBuilder, 'createText').and.callThrough();
 
       await mainHandler.sendText(conversationId, message, undefined, undefined, userIds);
 
-      expect(mainHandler.account!.service!.conversation.messageBuilder.createText).toHaveBeenCalledWith({
+      expect(MessageBuilder.createText).toHaveBeenCalledWith({
         conversationId,
         text: message,
+        from: 'sender',
       });
       expect(mainHandler.account!.service!.conversation.send).toHaveBeenCalledWith(
         jasmine.objectContaining({

--- a/packages/bot-api/src/MessageHandler.test.node.ts
+++ b/packages/bot-api/src/MessageHandler.test.node.ts
@@ -99,7 +99,7 @@ describe('MessageHandler', () => {
 
       expect(MessageBuilder.createText).toHaveBeenCalledWith({
         conversationId,
-        from: '',
+        from: 'user-id',
         text: messageText,
       });
       expect(mainHandler.account!.service!.conversation.send).toHaveBeenCalledWith(
@@ -121,7 +121,7 @@ describe('MessageHandler', () => {
 
       expect(MessageBuilder.createText).toHaveBeenCalledWith({
         conversationId,
-        from: '',
+        from: 'user-id',
         text: message,
       });
       expect(mainHandler.account!.service!.conversation.send).toHaveBeenCalledWith(
@@ -143,7 +143,7 @@ describe('MessageHandler', () => {
       expect(MessageBuilder.createText).toHaveBeenCalledWith({
         conversationId,
         text: message,
-        from: 'sender',
+        from: 'user-id',
       });
       expect(mainHandler.account!.service!.conversation.send).toHaveBeenCalledWith(
         jasmine.objectContaining({

--- a/packages/bot-api/src/MessageHandler.ts
+++ b/packages/bot-api/src/MessageHandler.ts
@@ -111,7 +111,7 @@ export abstract class MessageHandler {
 
       const buttonActionConfirmationMessage = MessageBuilder.createButtonActionConfirmationMessage({
         conversationId,
-        from: this.account.clientId,
+        from: this.account.userId,
         content: buttonActionConfirmationContent,
       });
 
@@ -124,7 +124,7 @@ export abstract class MessageHandler {
    */
   async sendCall(conversationId: string, content: CallingContent, userIds?: string[] | UserClients): Promise<void> {
     if (this.account?.service) {
-      const callPayload = MessageBuilder.createCall({conversationId, from: this.account.clientId, content});
+      const callPayload = MessageBuilder.createCall({conversationId, from: this.account.userId, content});
       await this.account.service.conversation.send({payloadBundle: callPayload, userIds});
     }
   }
@@ -139,7 +139,7 @@ export abstract class MessageHandler {
     userIds?: string[] | UserClients,
   ): Promise<void> {
     if (this.account?.service) {
-      const message = MessageBuilder.createComposite({conversationId, from: this.account.clientId}).addText(
+      const message = MessageBuilder.createComposite({conversationId, from: this.account.userId}).addText(
         Text.create({content: text}),
       );
       buttons.forEach(button => message.addButton(button));
@@ -158,7 +158,7 @@ export abstract class MessageHandler {
     if (this.account?.service) {
       const confirmationPayload = MessageBuilder.createConfirmation({
         conversationId,
-        from: this.account.clientId,
+        from: this.account.userId,
         firstMessageId,
         type: Confirmation.Type.DELIVERED,
       });
@@ -196,7 +196,7 @@ export abstract class MessageHandler {
     if (this.account?.service) {
       const editedPayload = MessageBuilder.createEditedText({
         conversationId,
-        from: this.account.clientId,
+        from: this.account.userId,
         newMessageText,
         originalMessageId,
       })
@@ -207,7 +207,7 @@ export abstract class MessageHandler {
 
       if (newLinkPreview) {
         const editedWithPreviewPayload = MessageBuilder.createEditedText({
-          from: this.account.clientId,
+          from: this.account.userId,
           conversationId,
           newMessageText,
           originalMessageId,
@@ -253,14 +253,14 @@ export abstract class MessageHandler {
       const metadataPayload = MessageBuilder.createFileMetadata({
         conversationId,
         metaData: metadata,
-        from: this.account.clientId,
+        from: this.account.userId,
       });
       await this.account.service.conversation.send({payloadBundle: metadataPayload, userIds});
 
       try {
         const filePayload = MessageBuilder.createFileData({
           conversationId,
-          from: this.account.clientId,
+          from: this.account.userId,
           file,
           asset: await this.account.service!.asset.uploadFileAsset(file),
           originalMessageId: metadataPayload.id,
@@ -269,7 +269,7 @@ export abstract class MessageHandler {
       } catch (error) {
         const abortPayload = await MessageBuilder.createFileAbort({
           conversationId,
-          from: this.account.clientId,
+          from: this.account.userId,
           reason: Asset.NotUploaded.FAILED,
           originalMessageId: metadataPayload.id,
         });
@@ -285,7 +285,7 @@ export abstract class MessageHandler {
     if (this.account?.service) {
       const imagePayload = MessageBuilder.createImage({
         conversationId,
-        from: this.account.clientId,
+        from: this.account.userId,
         image,
         imageAsset: await this.account.service!.asset.uploadImageAsset(image),
       });
@@ -304,7 +304,7 @@ export abstract class MessageHandler {
     if (this.account?.service) {
       const locationPayload = MessageBuilder.createLocation({
         conversationId,
-        from: this.account.clientId,
+        from: this.account.userId,
         location,
       });
       await this.account.service.conversation.send({payloadBundle: locationPayload, userIds});
@@ -316,7 +316,7 @@ export abstract class MessageHandler {
    */
   async sendPing(conversationId: string, userIds?: string[] | UserClients): Promise<void> {
     if (this.account?.service) {
-      const pingPayload = MessageBuilder.createPing({conversationId, from: this.account.clientId});
+      const pingPayload = MessageBuilder.createPing({conversationId, from: this.account.userId});
       await this.account.service.conversation.send({payloadBundle: pingPayload, userIds});
     }
   }
@@ -333,7 +333,7 @@ export abstract class MessageHandler {
     if (this.account?.service) {
       const reactionPayload = MessageBuilder.createReaction({
         conversationId,
-        from: this.account.clientId,
+        from: this.account.userId,
         reaction: {
           originalMessageId,
           type,
@@ -350,7 +350,7 @@ export abstract class MessageHandler {
     userIds?: string[] | UserClients,
   ): Promise<void> {
     if (this.account?.service) {
-      const replyPayload = MessageBuilder.createText({conversationId, text, from: this.account.clientId})
+      const replyPayload = MessageBuilder.createText({conversationId, text, from: this.account.userId})
         .withQuote(quotedMessage)
         .build();
       await this.account.service.conversation.send({payloadBundle: replyPayload, userIds});
@@ -380,7 +380,7 @@ export abstract class MessageHandler {
     userIds?: string[] | UserClients,
   ): Promise<void> {
     if (this.account?.service) {
-      const payload = MessageBuilder.createText({conversationId, text, from: this.account.clientId})
+      const payload = MessageBuilder.createText({conversationId, text, from: this.account.userId})
         .withMentions(mentions)
         .build();
       const sentMessage = await this.account.service.conversation.send({payloadBundle: payload, userIds});
@@ -389,7 +389,7 @@ export abstract class MessageHandler {
         const editedWithPreviewPayload = MessageBuilder.createText({
           conversationId,
           text,
-          from: this.account.clientId,
+          from: this.account.userId,
           messageId: sentMessage.id,
         })
           .withLinkPreviews([await this.account.service!.linkPreview.uploadLinkPreviewImage(linkPreview)])

--- a/packages/changelog-bot/src/main/ChangelogBot.ts
+++ b/packages/changelog-bot/src/main/ChangelogBot.ts
@@ -26,6 +26,7 @@ import * as Changelog from 'generate-changelog';
 import logdown from 'logdown';
 
 import type {ChangelogData, LoginDataBackend} from './Interfaces';
+import {MessageBuilder} from '@wireapp/core/src/main/conversation/message/MessageBuilder';
 
 const logger = logdown('@wireapp/changelog-bot/ChangelogBot', {
   logger: console,
@@ -76,9 +77,11 @@ export class ChangelogBot {
     for (const conversationId of conversationIds) {
       if (conversationId) {
         logger.log(`Sending message to conversation "${conversationId}" ...`);
-        const textPayload = account.service.conversation.messageBuilder
-          .createText({conversationId, text: this.message})
-          .build();
+        const textPayload = MessageBuilder.createText({
+          conversationId,
+          from: account.clientId,
+          text: this.message,
+        }).build();
         await account.service.conversation.send({payloadBundle: textPayload});
       }
     }

--- a/packages/changelog-bot/src/main/ChangelogBot.ts
+++ b/packages/changelog-bot/src/main/ChangelogBot.ts
@@ -79,7 +79,7 @@ export class ChangelogBot {
         logger.log(`Sending message to conversation "${conversationId}" ...`);
         const textPayload = MessageBuilder.createText({
           conversationId,
-          from: account.clientId,
+          from: account.userId,
           text: this.message,
         }).build();
         await account.service.conversation.send({payloadBundle: textPayload});

--- a/packages/cli-client/src/index.ts
+++ b/packages/cli-client/src/index.ts
@@ -112,7 +112,7 @@ account.on(PayloadBundleType.TEXT, textMessage => {
   stdin.addListener('data', async data => {
     const message = data.toString().trim();
     if (account.service) {
-      const payload = MessageBuilder.createText({conversationId, text: message}).build();
+      const payload = MessageBuilder.createText({conversationId, from: userId, text: message}).build();
       await account.service.conversation.send({payloadBundle: payload});
     }
   });

--- a/packages/cli-client/src/index.ts
+++ b/packages/cli-client/src/index.ts
@@ -29,6 +29,7 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 import type {AxiosError} from 'axios';
+import {MessageBuilder} from '@wireapp/core/src/main/conversation/message/MessageBuilder';
 
 dotenv.config();
 
@@ -111,7 +112,7 @@ account.on(PayloadBundleType.TEXT, textMessage => {
   stdin.addListener('data', async data => {
     const message = data.toString().trim();
     if (account.service) {
-      const payload = account.service.conversation.messageBuilder.createText({conversationId, text: message}).build();
+      const payload = MessageBuilder.createText({conversationId, text: message}).build();
       await account.service.conversation.send({payloadBundle: payload});
     }
   });

--- a/packages/core/src/demo/composite.ts
+++ b/packages/core/src/demo/composite.ts
@@ -27,6 +27,7 @@ import {PayloadBundleType} from '../main/conversation';
 import type {ButtonActionContent, ButtonActionConfirmationContent} from '../main/conversation/content';
 
 import 'dotenv-defaults/config';
+import {MessageBuilder} from '../main/conversation/message/MessageBuilder';
 
 const args = process.argv.slice(2);
 const conversationId = args[0] || process.env.WIRE_CONVERSATION;
@@ -66,11 +67,11 @@ const login: LoginData = {
       buttonId,
       referenceMessageId,
     };
-    const buttonActionConfirmationMessage =
-      account.service!.conversation.messageBuilder.createButtonActionConfirmationMessage({
-        conversationId: conversation,
-        content: buttonActionConfirmationContent,
-      });
+    const buttonActionConfirmationMessage = MessageBuilder.createButtonActionConfirmationMessage({
+      conversationId: conversation,
+      from: clientId,
+      content: buttonActionConfirmationContent,
+    });
     await account.service!.conversation.send({payloadBundle: buttonActionConfirmationMessage, userIds: [from]});
 
     console.info(
@@ -80,8 +81,7 @@ const login: LoginData = {
 
   if (account.service) {
     // Send poll
-    const pollMessage = account.service.conversation.messageBuilder
-      .createComposite({conversationId})
+    const pollMessage = MessageBuilder.createComposite({conversationId, from: ''})
       .addText(Text.create({content: 'Are you a robot?'}))
       .addButton('Yes')
       .addButton('No')
@@ -96,8 +96,9 @@ const login: LoginData = {
       buttonId: lastButton!.id,
       referenceMessageId: pollMessage.id,
     };
-    const buttonActionMessage = account.service.conversation.messageBuilder.createButtonActionMessage({
+    const buttonActionMessage = MessageBuilder.createButtonActionMessage({
       conversationId,
+      from: clientId,
       content: buttonActionContent,
     });
     await account.service.conversation.send({payloadBundle: buttonActionMessage});

--- a/packages/core/src/demo/echo.ts
+++ b/packages/core/src/demo/echo.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'path';
 import * as logdown from 'logdown';
-import {Account, MessageBuilder} from '@wireapp/core';
+import {Account} from '@wireapp/core';
 import {PayloadBundleType} from '@wireapp/core/src/main/conversation/';
 import {APIClient} from '@wireapp/api-client';
 import {WebSocketClient} from '@wireapp/api-client/src/tcp/';
@@ -29,6 +29,7 @@ import {CONVERSATION_TYPING} from '@wireapp/api-client/src/conversation/data/';
 import {LegalHoldStatus, Confirmation} from '@wireapp/protocol-messaging';
 import {AssetContent} from '../main/conversation/content/AssetContent';
 import {LinkPreviewUploadedContent} from '../main/conversation/content';
+import {MessageBuilder} from '../main/conversation/message/MessageBuilder';
 
 const logger = logdown('@wireapp/core/demo/echo.js', {
   logger: console,

--- a/packages/core/src/demo/echo.ts
+++ b/packages/core/src/demo/echo.ts
@@ -110,7 +110,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
     if (CONFIRM_TYPES.includes(type)) {
       const deliveredPayload = MessageBuilder.createConfirmation({
         conversationId,
-        from: account.clientId,
+        from: account.userId,
         firstMessageId: messageId,
         type: Confirmation.Type.DELIVERED,
       });
@@ -123,7 +123,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       if (content.expectsReadConfirmation) {
         const readPayload = MessageBuilder.createConfirmation({
           conversationId,
-          from: account.clientId,
+          from: account.userId,
           firstMessageId: messageId,
           type: Confirmation.Type.READ,
         });
@@ -206,7 +206,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       textPayload = MessageBuilder.createText({
         conversationId,
         text,
-        from: account.clientId,
+        from: account.userId,
         messageId: cachedMessageId,
       })
         .withLinkPreviews(newLinkPreviews)
@@ -217,7 +217,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
         .build();
     } else {
       await handleIncomingMessage(data);
-      textPayload = MessageBuilder.createText({conversationId, from: account.clientId, text})
+      textPayload = MessageBuilder.createText({conversationId, from: account.userId, text})
         .withMentions(mentions)
         .withQuote(quote)
         .withReadConfirmation(expectsReadConfirmation)
@@ -247,7 +247,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
 
     const fileMetaDataPayload = MessageBuilder.createFileMetadata({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       metaData: {
         length: fileBuffer.length,
         name: cacheOriginal.name,
@@ -262,7 +262,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       const asset = await account.service!.asset.uploadFileAsset(file);
       const filePayload = MessageBuilder.createFileData({
         conversationId,
-        from: account.clientId,
+        from: account.userId,
         asset,
         file,
         originalMessageId: fileMetaDataPayload.id,
@@ -273,7 +273,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       logger.warn(`Error while sending asset: "${error.stack}"`);
       const fileAbortPayload = MessageBuilder.createFileAbort({
         conversationId,
-        from: account.clientId,
+        from: account.userId,
         reason: 0,
         originalMessageId: fileMetaDataPayload.id,
       });
@@ -305,7 +305,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
 
     const fileMetaDataPayload = MessageBuilder.createFileMetadata({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       metaData: {
         length: 0,
         name: cacheOriginal.name,
@@ -318,7 +318,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
 
     const fileAbortPayload = MessageBuilder.createFileAbort({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       reason: 0,
       originalMessageId: fileMetaDataPayload.id,
     });
@@ -346,7 +346,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
     const imageAsset = await account.service!.asset.uploadImageAsset(image);
     const imagePayload = MessageBuilder.createImage({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       image,
       imageAsset,
     });
@@ -367,7 +367,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
     const {content, conversation: conversationId} = data;
     const locationPayload = MessageBuilder.createLocation({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       location: content,
     });
 
@@ -384,7 +384,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
 
     const pingPayload = MessageBuilder.createPing({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       ping: {
         expectsReadConfirmation,
         hotKnock: false,
@@ -405,7 +405,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
 
     const reactionPayload = MessageBuilder.createReaction({
       conversationId,
-      from: account.clientId,
+      from: account.userId,
       reaction: {
         legalHoldStatus,
         originalMessageId,
@@ -474,7 +474,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       }
       editedPayload = MessageBuilder.createEditedText({
         conversationId,
-        from: account.clientId,
+        from: account.userId,
         newMessageText: text,
         originalMessageId: cachedOriginalMessageId,
         messageId: cachedMessageId,
@@ -489,7 +489,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       await handleIncomingMessage(data);
       editedPayload = MessageBuilder.createEditedText({
         conversationId,
-        from: account.clientId,
+        from: account.userId,
         newMessageText: text,
         originalMessageId: cachedOriginalMessageId,
       })

--- a/packages/core/src/demo/echo.ts
+++ b/packages/core/src/demo/echo.ts
@@ -19,7 +19,7 @@
 
 import * as path from 'path';
 import * as logdown from 'logdown';
-import {Account} from '@wireapp/core';
+import {Account, MessageBuilder} from '@wireapp/core';
 import {PayloadBundleType} from '@wireapp/core/src/main/conversation/';
 import {APIClient} from '@wireapp/api-client';
 import {WebSocketClient} from '@wireapp/api-client/src/tcp/';
@@ -28,7 +28,6 @@ import {ConnectionStatus} from '@wireapp/api-client/src/connection/';
 import {CONVERSATION_TYPING} from '@wireapp/api-client/src/conversation/data/';
 import {LegalHoldStatus, Confirmation} from '@wireapp/protocol-messaging';
 import {AssetContent} from '../main/conversation/content/AssetContent';
-import {MessageBuilder} from '../main/conversation/message/MessageBuilder';
 import {LinkPreviewUploadedContent} from '../main/conversation/content';
 
 const logger = logdown('@wireapp/core/demo/echo.js', {

--- a/packages/core/src/demo/echo.ts
+++ b/packages/core/src/demo/echo.ts
@@ -29,6 +29,7 @@ import {CONVERSATION_TYPING} from '@wireapp/api-client/src/conversation/data/';
 import {LegalHoldStatus, Confirmation} from '@wireapp/protocol-messaging';
 import {AssetContent} from '../main/conversation/content/AssetContent';
 import {MessageBuilder} from '../main/conversation/message/MessageBuilder';
+import {LinkPreviewUploadedContent} from '../main/conversation/content';
 
 const logger = logdown('@wireapp/core/demo/echo.js', {
   logger: console,
@@ -155,7 +156,7 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
   };
 
   const buildLinkPreviews = async originalLinkPreviews => {
-    const newLinkPreviews = [];
+    const newLinkPreviews: LinkPreviewUploadedContent[] = [];
     for (const originalLinkPreview of originalLinkPreviews) {
       const originalLinkPreviewImage =
         originalLinkPreview.article && originalLinkPreview.article.image
@@ -172,14 +173,10 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
           type: originalLinkPreviewImage.original.mimeType,
           width: originalLinkPreviewImage.original.image.width,
         };
+        linkPreviewImage = await account.service.asset.uploadImageAsset(linkPreviewImage);
       }
 
-      const newLinkPreview = await MessageBuilder.createLinkPreview({
-        ...originalLinkPreview,
-        image: linkPreviewImage,
-      });
-
-      newLinkPreviews.push(newLinkPreview);
+      newLinkPreviews.push({...originalLinkPreview, imageUploaded: linkPreviewImage});
     }
     return newLinkPreviews;
   };

--- a/packages/core/src/demo/sender.ts
+++ b/packages/core/src/demo/sender.ts
@@ -36,6 +36,7 @@ import {Account} from '@wireapp/core';
 import {APIClient} from '@wireapp/api-client';
 import {ClientType} from '@wireapp/api-client/src/client/';
 import {FileEngine} from '@wireapp/store-engine-fs';
+import {MessageBuilder} from '../main/conversation/message/MessageBuilder';
 
 const readFileAsync = promisify(fs.readFile);
 
@@ -93,9 +94,11 @@ const {
   logger.log('Client ID', account['apiClient'].context!.clientId);
 
   async function sendAndDeleteMessage(): Promise<void> {
-    const deleteTextPayload = account
-      .service!.conversation.messageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, text: 'Delete me!'})
-      .build();
+    const deleteTextPayload = MessageBuilder.createText({
+      conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
+      text: 'Delete me!',
+    }).build();
     const {id: messageId} = await account.service!.conversation.send({
       payloadBundle: deleteTextPayload,
       sendAsProtobuf: useProtobuf,
@@ -115,46 +118,48 @@ const {
 
   async function sendEphemeralText(expiry = MESSAGE_TIMER): Promise<void> {
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, expiry);
-    const payload = account
-      .service!.conversation.messageBuilder.createText({
-        conversationId: WIRE_CONVERSATION_ID,
-        text: `Expires after ${expiry}ms ...`,
-      })
-      .build();
+    const payload = MessageBuilder.createText({
+      conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
+      text: `Expires after ${expiry}ms ...`,
+    }).build();
     await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, 0);
   }
 
   async function sendPing(expiry = MESSAGE_TIMER): Promise<void> {
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, expiry);
-    const payload = account.service!.conversation.messageBuilder.createPing(WIRE_CONVERSATION_ID);
+    const payload = MessageBuilder.createPing(WIRE_CONVERSATION_ID);
     await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, 0);
   }
 
   async function sendText(): Promise<void> {
-    const payload = account
-      .service!.conversation.messageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, text: 'Hello, World!'})
-      .build();
+    const payload = MessageBuilder.createText({
+      conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
+      text: 'Hello, World!',
+    }).build();
     await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
   }
 
   async function sendAndEdit(): Promise<void> {
-    const payload = account
-      .service!.conversation.messageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, text: 'Hello, Wolrd!'})
-      .build();
+    const payload = MessageBuilder.createText({
+      conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
+      text: 'Hello, Wolrd!',
+    }).build();
     const {id: originalMessageId} = await account.service!.conversation.send({
       payloadBundle: payload,
       sendAsProtobuf: useProtobuf,
     });
     setInterval(async () => {
-      const editedPayload = account
-        .service!.conversation.messageBuilder.createEditedText({
-          conversationId: WIRE_CONVERSATION_ID,
-          newMessageText: 'Hello, World!',
-          originalMessageId,
-        })
-        .build();
+      const editedPayload = MessageBuilder.createEditedText({
+        conversationId: WIRE_CONVERSATION_ID,
+        from: account.clientId,
+        newMessageText: 'Hello, World!',
+        originalMessageId,
+      }).build();
       await account.service!.conversation.send({payloadBundle: editedPayload, sendAsProtobuf: useProtobuf});
     }, TimeUtil.TimeInMillis.SECOND * 2);
   }
@@ -167,9 +172,11 @@ const {
       type: 'image/png',
       width: 500,
     };
-    const imagePayload = await account.service!.conversation.messageBuilder.createImage({
+    const imagePayload = MessageBuilder.createImage({
       conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
       image,
+      imageAsset: await account.service!.asset.uploadImageAsset(image),
     });
     await account.service!.conversation.send({payloadBundle: imagePayload, sendAsProtobuf: useProtobuf});
   }
@@ -177,8 +184,9 @@ const {
   async function sendFile(): Promise<void> {
     const filename = 'wire_logo.png';
     const data = await readFileAsync(path.join(__dirname, filename));
-    const metadataPayload = account.service!.conversation.messageBuilder.createFileMetadata({
+    const metadataPayload = MessageBuilder.createFileMetadata({
       conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
       metaData: {
         length: data.length,
         name: filename,
@@ -187,9 +195,12 @@ const {
     });
     await account.service!.conversation.send({payloadBundle: metadataPayload, sendAsProtobuf: useProtobuf});
 
-    const filePayload = await account.service!.conversation.messageBuilder.createFileData({
+    const file = {data};
+    const filePayload = await MessageBuilder.createFileData({
+      from: account.clientId,
       conversationId: WIRE_CONVERSATION_ID,
-      file: {data},
+      file,
+      asset: await account.service.asset.uploadFileAsset(file),
       originalMessageId: metadataPayload.id,
     });
     await account.service!.conversation.send({payloadBundle: filePayload, sendAsProtobuf: useProtobuf});
@@ -218,8 +229,7 @@ const {
       return mention;
     });
 
-    const payload = account
-      .service!.conversation.messageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, text})
+    const payload = MessageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, from: account.clientId, text})
       .withMentions(mentions)
       .build();
 
@@ -229,9 +239,11 @@ const {
   async function sendQuote(): Promise<void> {
     const text = 'Hello';
 
-    const textPayload = account
-      .service!.conversation.messageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, text})
-      .build();
+    const textPayload = MessageBuilder.createText({
+      conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
+      text,
+    }).build();
 
     const {id: messageId} = await account.service!.conversation.send({
       payloadBundle: textPayload,
@@ -245,8 +257,11 @@ const {
       quotedMessageId: messageId,
     };
 
-    const quotePayload = account
-      .service!.conversation.messageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, text: quoteText})
+    const quotePayload = MessageBuilder.createText({
+      conversationId: WIRE_CONVERSATION_ID,
+      from: account.clientId,
+      text: quoteText,
+    })
       .withQuote(quote)
       .build();
 

--- a/packages/core/src/demo/sender.ts
+++ b/packages/core/src/demo/sender.ts
@@ -96,7 +96,7 @@ const {
   async function sendAndDeleteMessage(): Promise<void> {
     const deleteTextPayload = MessageBuilder.createText({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       text: 'Delete me!',
     }).build();
     const {id: messageId} = await account.service!.conversation.send({
@@ -120,7 +120,7 @@ const {
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, expiry);
     const payload = MessageBuilder.createText({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       text: `Expires after ${expiry}ms ...`,
     }).build();
     await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
@@ -137,7 +137,7 @@ const {
   async function sendText(): Promise<void> {
     const payload = MessageBuilder.createText({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       text: 'Hello, World!',
     }).build();
     await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
@@ -146,7 +146,7 @@ const {
   async function sendAndEdit(): Promise<void> {
     const payload = MessageBuilder.createText({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       text: 'Hello, Wolrd!',
     }).build();
     const {id: originalMessageId} = await account.service!.conversation.send({
@@ -156,7 +156,7 @@ const {
     setInterval(async () => {
       const editedPayload = MessageBuilder.createEditedText({
         conversationId: WIRE_CONVERSATION_ID,
-        from: account.clientId,
+        from: account.userId,
         newMessageText: 'Hello, World!',
         originalMessageId,
       }).build();
@@ -174,7 +174,7 @@ const {
     };
     const imagePayload = MessageBuilder.createImage({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       image,
       imageAsset: await account.service!.asset.uploadImageAsset(image),
     });
@@ -186,7 +186,7 @@ const {
     const data = await readFileAsync(path.join(__dirname, filename));
     const metadataPayload = MessageBuilder.createFileMetadata({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       metaData: {
         length: data.length,
         name: filename,
@@ -197,7 +197,7 @@ const {
 
     const file = {data};
     const filePayload = await MessageBuilder.createFileData({
-      from: account.clientId,
+      from: account.userId,
       conversationId: WIRE_CONVERSATION_ID,
       file,
       asset: await account.service.asset.uploadFileAsset(file),
@@ -229,7 +229,7 @@ const {
       return mention;
     });
 
-    const payload = MessageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, from: account.clientId, text})
+    const payload = MessageBuilder.createText({conversationId: WIRE_CONVERSATION_ID, from: account.userId, text})
       .withMentions(mentions)
       .build();
 
@@ -241,7 +241,7 @@ const {
 
     const textPayload = MessageBuilder.createText({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       text,
     }).build();
 
@@ -259,7 +259,7 @@ const {
 
     const quotePayload = MessageBuilder.createText({
       conversationId: WIRE_CONVERSATION_ID,
-      from: account.clientId,
+      from: account.userId,
       text: quoteText,
     })
       .withQuote(quote)

--- a/packages/core/src/demo/status-bot.ts
+++ b/packages/core/src/demo/status-bot.ts
@@ -19,7 +19,7 @@
 
 import {APIClient} from '@wireapp/api-client';
 import {ClientType} from '@wireapp/api-client/src/client/';
-import {Account} from '@wireapp/core';
+import {Account, MessageBuilder} from '@wireapp/core';
 import {MemoryEngine} from '@wireapp/store-engine';
 import * as logdown from 'logdown';
 
@@ -68,7 +68,7 @@ if (!message) {
 
   const text = message || `I am posting from ${name} v${version}. 🌞`;
   for (const conversationId of conversationIds) {
-    const payload = account.service.conversation.messageBuilder.createText({conversationId, text}).build();
+    const payload = MessageBuilder.createText({conversationId, from: apiClient.userId, text}).build();
     await account.service.conversation.send({payloadBundle: payload});
   }
 })().catch(error => logger.error(error));

--- a/packages/core/src/main/Account.test.node.ts
+++ b/packages/core/src/main/Account.test.node.ts
@@ -32,6 +32,7 @@ import {MemoryEngine} from '@wireapp/store-engine';
 import nock = require('nock');
 import {Account} from './Account';
 import {PayloadBundleSource, PayloadBundleType} from './conversation';
+import {MessageBuilder} from './conversation/message/MessageBuilder';
 
 const BASE_URL = 'mock-backend.wire.com';
 const MOCK_BACKEND = {
@@ -142,7 +143,7 @@ describe('Account', () => {
       expect(account['apiClient'].context!.userId).toBeDefined();
 
       const text = 'FIFA World Cup';
-      const payload = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
+      const payload = MessageBuilder.createText({conversationId: '', from: '', text}).build();
 
       expect(payload.timestamp).toBeGreaterThan(0);
     });

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -205,7 +205,7 @@ export class Account extends EventEmitter {
     const clientService = new ClientService(this.apiClient, storeEngine, cryptographyService);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
-    const conversationService = new ConversationService(this.apiClient, cryptographyService, assetService);
+    const conversationService = new ConversationService(this.apiClient, cryptographyService);
     const notificationService = new NotificationService(this.apiClient, cryptographyService, storeEngine);
     const selfService = new SelfService(this.apiClient);
     const teamService = new TeamService(this.apiClient);

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -51,6 +51,7 @@ import {SelfService} from './self/';
 import {TeamService} from './team/';
 import {UserService} from './user/';
 import {AccountService} from './account/';
+import {LinkPreviewService} from './linkPreview';
 
 enum TOPIC {
   ERROR = 'Account.TOPIC.ERROR',
@@ -116,6 +117,7 @@ export class Account extends EventEmitter {
     conversation: ConversationService;
     cryptography: CryptographyService;
     giphy: GiphyService;
+    linkPreview: LinkPreviewService;
     notification: NotificationService;
     self: SelfService;
     team: TeamService;
@@ -205,6 +207,7 @@ export class Account extends EventEmitter {
     const clientService = new ClientService(this.apiClient, storeEngine, cryptographyService);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
+    const linkPreviewService = new LinkPreviewService(assetService);
     const conversationService = new ConversationService(this.apiClient, cryptographyService);
     const notificationService = new NotificationService(this.apiClient, cryptographyService, storeEngine);
     const selfService = new SelfService(this.apiClient);
@@ -222,6 +225,7 @@ export class Account extends EventEmitter {
       conversation: conversationService,
       cryptography: cryptographyService,
       giphy: giphyService,
+      linkPreview: linkPreviewService,
       notification: notificationService,
       self: selfService,
       team: teamService,

--- a/packages/core/src/main/conversation/AssetService.test.node.ts
+++ b/packages/core/src/main/conversation/AssetService.test.node.ts
@@ -18,21 +18,15 @@
  */
 
 import {APIClient} from '@wireapp/api-client';
-import {MemoryEngine} from '@wireapp/store-engine';
 import UUID from 'uuidjs';
-import {Account} from '../Account';
+import {AssetService} from './AssetService';
 
 describe('AssetService', () => {
-  let account: Account;
-
-  beforeAll(async () => {
-    const client = new APIClient({urls: APIClient.BACKEND.STAGING});
-    account = new Account(client);
-    await account.initServices(new MemoryEngine());
-  });
-
   describe('"uploadImageAsset"', () => {
     it('builds an encrypted asset payload', async () => {
+      const apiClient = new APIClient();
+      const assetService = new AssetService(apiClient);
+
       const assetServerData = {
         key: `3-2-${UUID.genV4().toString()}`,
         keyBytes: Buffer.from(UUID.genV4().toString()),
@@ -40,7 +34,6 @@ describe('AssetService', () => {
         token: UUID.genV4().toString(),
       };
 
-      const assetService = account.service!.conversation['assetService'];
       const image = {
         data: Buffer.from([1, 2, 3]),
         height: 600,
@@ -48,7 +41,7 @@ describe('AssetService', () => {
         width: 600,
       };
 
-      spyOn<any>(assetService, 'postAsset').and.returnValue(Promise.resolve(assetServerData));
+      spyOn<any>(apiClient.asset.api, 'postAsset').and.returnValue(Promise.resolve(assetServerData));
 
       const asset = await assetService.uploadImageAsset(image);
 

--- a/packages/core/src/main/conversation/AssetService.test.node.ts
+++ b/packages/core/src/main/conversation/AssetService.test.node.ts
@@ -29,9 +29,8 @@ describe('AssetService', () => {
 
       const assetServerData = {
         key: `3-2-${UUID.genV4().toString()}`,
-        keyBytes: Buffer.from(UUID.genV4().toString()),
-        sha256: UUID.genV4().toString(),
         token: UUID.genV4().toString(),
+        expires: '',
       };
 
       const image = {
@@ -41,15 +40,20 @@ describe('AssetService', () => {
         width: 600,
       };
 
-      spyOn<any>(apiClient.asset.api, 'postAsset').and.returnValue(Promise.resolve(assetServerData));
+      spyOn(apiClient.asset.api, 'postAsset').and.returnValue(
+        Promise.resolve({
+          cancel: () => {},
+          response: Promise.resolve(assetServerData),
+        }),
+      );
 
       const asset = await assetService.uploadImageAsset(image);
 
       expect(asset).toEqual(
         jasmine.objectContaining({
           key: assetServerData.key,
-          keyBytes: assetServerData.keyBytes,
-          sha256: assetServerData.sha256,
+          keyBytes: jasmine.any(Buffer),
+          sha256: jasmine.any(Buffer),
           token: assetServerData.token,
         }),
       );

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -26,6 +26,7 @@ import {MessageTargetMode, PayloadBundleSource, PayloadBundleState, PayloadBundl
 import {Account} from '../Account';
 import * as PayloadHelper from '../test/PayloadHelper';
 import {MentionContent, QuoteContent} from './content';
+import {MessageBuilder} from './message/MessageBuilder';
 import {OtrMessage} from './message/OtrMessage';
 
 describe('ConversationService', () => {
@@ -290,16 +291,15 @@ describe('ConversationService', () => {
       };
       const urlOffset = 0;
 
-      const linkPreview = await account.service!.conversation.messageBuilder.createLinkPreview({
+      const linkPreview = {
         permanentUrl,
         summary,
         title,
         tweet,
         url,
         urlOffset,
-      });
-      const textMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
+      };
+      const textMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withLinkPreviews([linkPreview])
         .build();
 
@@ -321,7 +321,7 @@ describe('ConversationService', () => {
 
     it('does not add link previews', () => {
       const text = 'Hello, world!';
-      const textMessage = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
+      const textMessage = MessageBuilder.createText({conversationId: '', from: '', text}).build();
 
       expect(textMessage.content.linkPreviews).toBeUndefined();
     });
@@ -347,9 +347,8 @@ describe('ConversationService', () => {
       const text = url;
       const urlOffset = 0;
 
-      const linkPreview = await account.service!.conversation.messageBuilder.createLinkPreview({image, url, urlOffset});
-      const textMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
+      const linkPreview = {image, url, urlOffset};
+      const textMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withLinkPreviews([linkPreview])
         .build();
 
@@ -375,8 +374,7 @@ describe('ConversationService', () => {
         userId: PayloadHelper.getUUID(),
       };
 
-      const textMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
+      const textMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withMentions([mention])
         .build();
 
@@ -389,7 +387,7 @@ describe('ConversationService', () => {
 
     it('does not add mentions', () => {
       const text = 'Hello, world!';
-      const textMessage = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
+      const textMessage = MessageBuilder.createText({conversationId: '', from: '', text}).build();
 
       expect(textMessage.content.mentions).toBeUndefined();
     });
@@ -402,10 +400,7 @@ describe('ConversationService', () => {
         quotedMessageId: quoteId,
       };
 
-      const replyMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
-        .withQuote(quote)
-        .build();
+      const replyMessage = MessageBuilder.createText({conversationId: '', from: '', text}).withQuote(quote).build();
 
       expect(replyMessage.content.text).toEqual(text);
       expect(replyMessage.content.quote).toEqual(jasmine.objectContaining({quotedMessageId: quoteId}));
@@ -414,7 +409,7 @@ describe('ConversationService', () => {
 
     it('does not add a quote', () => {
       const text = 'Hello, world!';
-      const textMessage = account.service!.conversation.messageBuilder.createText({conversationId: '', text}).build();
+      const textMessage = MessageBuilder.createText({conversationId: '', from: '', text}).build();
 
       expect(textMessage.content.quote).toBeUndefined();
     });
@@ -422,8 +417,7 @@ describe('ConversationService', () => {
     it('adds a read confirmation request correctly', () => {
       const text = 'Please read me';
 
-      const replyMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
+      const replyMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withReadConfirmation(true)
         .build();
 
@@ -434,15 +428,13 @@ describe('ConversationService', () => {
     it('adds a legal hold status', () => {
       const text = 'Please read me';
 
-      const firstMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
+      const firstMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withLegalHoldStatus()
         .build();
 
       expect(firstMessage.content.legalHoldStatus).toEqual(LegalHoldStatus.UNKNOWN);
 
-      const replyMessage = account
-        .service!.conversation.messageBuilder.createText({conversationId: '', text})
+      const replyMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withLegalHoldStatus(LegalHoldStatus.ENABLED)
         .build();
 

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -25,7 +25,7 @@ import {MessageTargetMode, PayloadBundleSource, PayloadBundleState, PayloadBundl
 
 import {Account} from '../Account';
 import * as PayloadHelper from '../test/PayloadHelper';
-import {MentionContent, QuoteContent} from './content';
+import {LinkPreviewUploadedContent, MentionContent, QuoteContent} from './content';
 import {MessageBuilder} from './message/MessageBuilder';
 import {OtrMessage} from './message/OtrMessage';
 
@@ -327,16 +327,6 @@ describe('ConversationService', () => {
     });
 
     it('uploads link previews', async () => {
-      spyOn(account.service!.asset, 'uploadImageAsset').and.returnValue(
-        Promise.resolve({
-          cipherText: Buffer.from([]),
-          key: '',
-          keyBytes: Buffer.from([]),
-          sha256: Buffer.from([]),
-          token: '',
-        }),
-      );
-
       const url = 'http://example.com';
       const image = {
         data: Buffer.from([]),
@@ -347,12 +337,23 @@ describe('ConversationService', () => {
       const text = url;
       const urlOffset = 0;
 
-      const linkPreview = {image, url, urlOffset};
+      const linkPreview: LinkPreviewUploadedContent = {
+        url,
+        urlOffset,
+        imageUploaded: {
+          image,
+          asset: {
+            cipherText: Buffer.from([]),
+            key: '',
+            keyBytes: Buffer.from([]),
+            sha256: Buffer.from([]),
+            token: '',
+          },
+        },
+      };
       const textMessage = MessageBuilder.createText({conversationId: '', from: '', text})
         .withLinkPreviews([linkPreview])
         .build();
-
-      expect(account.service!.asset.uploadImageAsset).toHaveBeenCalledTimes(1);
 
       expect(textMessage.content.linkPreviews).toEqual(jasmine.any(Array));
       expect(textMessage.content.linkPreviews!.length).toBe(1);

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -52,7 +52,6 @@ import {
 } from '@wireapp/protocol-messaging';
 
 import {
-  AssetService,
   AssetTransferState,
   GenericMessageType,
   MessageTimer,
@@ -153,16 +152,10 @@ export interface MessageSendingCallbacks {
 
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
-  public readonly messageBuilder: MessageBuilder;
   private readonly messageService: MessageService;
 
-  constructor(
-    private readonly apiClient: APIClient,
-    cryptographyService: CryptographyService,
-    private readonly assetService: AssetService,
-  ) {
+  constructor(private readonly apiClient: APIClient, cryptographyService: CryptographyService) {
     this.messageTimer = new MessageTimer();
-    this.messageBuilder = new MessageBuilder(this.apiClient, this.assetService);
     this.messageService = new MessageService(this.apiClient, cryptographyService);
   }
 

--- a/packages/core/src/main/conversation/content/LinkPreviewContent.ts
+++ b/packages/core/src/main/conversation/content/LinkPreviewContent.ts
@@ -18,14 +18,14 @@
  */
 
 import type {ILinkPreview} from '@wireapp/protocol-messaging';
-import { EncryptedAssetUploaded } from '../../cryptography';
+import {EncryptedAssetUploaded} from '../../cryptography';
 
 import type {ImageAssetContent, ImageContent, LegalHoldStatus} from '../content/';
 
 export interface LinkPreviewContent extends Omit<ILinkPreview, 'image'> {
   expectsReadConfirmation?: boolean;
   image?: ImageContent;
-  imageAsset?: EncryptedAssetUploaded,
+  imageAsset?: EncryptedAssetUploaded;
   legalHoldStatus?: LegalHoldStatus;
 }
 

--- a/packages/core/src/main/conversation/content/LinkPreviewContent.ts
+++ b/packages/core/src/main/conversation/content/LinkPreviewContent.ts
@@ -18,14 +18,11 @@
  */
 
 import type {ILinkPreview} from '@wireapp/protocol-messaging';
-import {EncryptedAssetUploaded} from '../../cryptography';
 
-import type {ImageAssetContent, ImageContent, LegalHoldStatus} from '../content/';
+import type {ImageAssetContent, LegalHoldStatus} from '../content/';
 
 export interface LinkPreviewContent extends Omit<ILinkPreview, 'image'> {
   expectsReadConfirmation?: boolean;
-  image?: ImageContent;
-  imageAsset?: EncryptedAssetUploaded;
   legalHoldStatus?: LegalHoldStatus;
 }
 

--- a/packages/core/src/main/conversation/content/LinkPreviewContent.ts
+++ b/packages/core/src/main/conversation/content/LinkPreviewContent.ts
@@ -18,12 +18,14 @@
  */
 
 import type {ILinkPreview} from '@wireapp/protocol-messaging';
+import { EncryptedAssetUploaded } from '../../cryptography';
 
 import type {ImageAssetContent, ImageContent, LegalHoldStatus} from '../content/';
 
 export interface LinkPreviewContent extends Omit<ILinkPreview, 'image'> {
   expectsReadConfirmation?: boolean;
   image?: ImageContent;
+  imageAsset?: EncryptedAssetUploaded,
   legalHoldStatus?: LegalHoldStatus;
 }
 

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -163,7 +163,7 @@ export class MessageBuilder {
     });
   }
 
-  public createFileData(payload: CreateFileOptions): FileAssetMessage {
+  public static createFileData(payload: CreateFileOptions): FileAssetMessage {
     const {asset, expectsReadConfirmation, file, legalHoldStatus, originalMessageId} = payload;
 
     return {
@@ -193,7 +193,7 @@ export class MessageBuilder {
     };
   }
 
-  public async createFileAbort(payload: CreateFileAbortOptions): Promise<FileAssetAbortMessage> {
+  public static createFileAbort(payload: CreateFileAbortOptions): FileAssetAbortMessage {
     const {expectsReadConfirmation, legalHoldStatus, reason} = payload;
 
     return {

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -32,8 +32,6 @@ import type {
   ImageContent,
   KnockContent,
   LegalHoldStatus,
-  LinkPreviewContent,
-  LinkPreviewUploadedContent,
   LocationContent,
   ReactionContent,
 } from '../content';
@@ -266,7 +264,7 @@ export class MessageBuilder {
     };
   }
 
-  createButtonActionMessage(payload: CreateActionMessageOptions): ButtonActionMessage {
+  public static createButtonActionMessage(payload: CreateActionMessageOptions): ButtonActionMessage {
     return {
       ...createCommonProperties(payload),
       content: payload.content,
@@ -274,7 +272,7 @@ export class MessageBuilder {
     };
   }
 
-  createButtonActionConfirmationMessage(
+  public static createButtonActionConfirmationMessage(
     payload: CreateButtonActionConfirmationOptions,
   ): ButtonActionConfirmationMessage {
     return {
@@ -284,7 +282,7 @@ export class MessageBuilder {
     };
   }
 
-  createComposite(payload: BaseOptions): CompositeContentBuilder {
+  public static createComposite(payload: BaseOptions): CompositeContentBuilder {
     return new CompositeContentBuilder({
       ...createCommonProperties(payload),
       content: {},
@@ -308,20 +306,6 @@ export class MessageBuilder {
       },
       type: PayloadBundleType.CLIENT_ACTION,
     };
-  }
-
-  public static createLinkPreview(linkPreview: LinkPreviewContent): LinkPreviewUploadedContent {
-    if (linkPreview.image && linkPreview.imageAsset) {
-      return {
-        ...linkPreview,
-        imageUploaded: {
-          asset: linkPreview.imageAsset,
-          image: linkPreview.image,
-        },
-      };
-    }
-
-    return linkPreview;
   }
 
   public static createId(): string {

--- a/packages/core/src/main/index.ts
+++ b/packages/core/src/main/index.ts
@@ -23,9 +23,11 @@ import * as conversation from './conversation/';
 import {CoreError} from './CoreError';
 import * as cryptography from './cryptography/';
 import * as util from './util';
+import {MessageBuilder} from './conversation/message/MessageBuilder';
 
 export = {
   Account,
+  MessageBuilder,
   CoreError,
   auth,
   conversation,

--- a/packages/core/src/main/linkPreview/LinkPreviewService.ts
+++ b/packages/core/src/main/linkPreview/LinkPreviewService.ts
@@ -17,16 +17,24 @@
  *
  */
 
-import type {ILinkPreview} from '@wireapp/protocol-messaging';
+import {AssetService} from '../conversation';
+import {LinkPreviewContent, LinkPreviewUploadedContent} from '../conversation/content';
 
-import type {ImageAssetContent, ImageContent, LegalHoldStatus} from '../content/';
+export class LinkPreviewService {
+  constructor(private readonly assetService: AssetService) {}
 
-export interface LinkPreviewContent extends Omit<ILinkPreview, 'image'> {
-  expectsReadConfirmation?: boolean;
-  legalHoldStatus?: LegalHoldStatus;
-  image: ImageContent;
-}
+  public async uploadLinkPreviewImage(linkPreview: LinkPreviewContent): Promise<LinkPreviewUploadedContent> {
+    const {image, ...preview} = linkPreview;
+    if (!image) {
+      return preview;
+    }
 
-export interface LinkPreviewUploadedContent extends Omit<LinkPreviewContent, 'image'> {
-  imageUploaded?: ImageAssetContent;
+    const uploadedLinkPreview: LinkPreviewUploadedContent = preview;
+    const asset = await this.assetService.uploadImageAsset(linkPreview.image);
+    uploadedLinkPreview.imageUploaded = {
+      asset,
+      image,
+    };
+    return uploadedLinkPreview;
+  }
 }

--- a/packages/core/src/main/linkPreview/index.ts
+++ b/packages/core/src/main/linkPreview/index.ts
@@ -17,16 +17,4 @@
  *
  */
 
-import type {ILinkPreview} from '@wireapp/protocol-messaging';
-
-import type {ImageAssetContent, ImageContent, LegalHoldStatus} from '../content/';
-
-export interface LinkPreviewContent extends Omit<ILinkPreview, 'image'> {
-  expectsReadConfirmation?: boolean;
-  legalHoldStatus?: LegalHoldStatus;
-  image: ImageContent;
-}
-
-export interface LinkPreviewUploadedContent extends Omit<LinkPreviewContent, 'image'> {
-  imageUploaded?: ImageAssetContent;
-}
+export * from './LinkPreviewService';


### PR DESCRIPTION
BREAKING CHANGE:

- `MessageBuilder` has been moved from `account.services.conversation.messageBuilder` to an own stateless class.
- All method of the `MessageBuilder` now take a required `from` parameter
- `MessageBuilder` is not uploading files under the hood. Upload must be done in a separate function call

Replace

```
const textPayload = account.service.conversation.messageBuilder.createText(...);
```

With

```
import {MessageBuilder} from '@wireapp/core/src/main/conversation/message/MessageBuilder';
//...
const textPayload = MessageBuilder.createText(...);
```

Replace

```
const linkPreview = await account.service.conversation.messageBuilder.createLinkPreview(...);
cons textPayload = account.service.conversation.messageBuilder.createText(...).withLinkPreview([linkPreview]);
```

With

```
cons textPayload = account.service.conversation.messageBuilder
    .createText(...)
    .withLinkPreview([await this.account.service.linkPreview.uploadLinkPreviewImage(newLinkPreview)]);
```


<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
