### PR TITLE
refactor(core): Harmonize asset param name

### DIFF
--- a/packages/bot-api/src/MessageHandler.ts
+++ b/packages/bot-api/src/MessageHandler.ts
@@ -287,7 +287,7 @@ export abstract class MessageHandler {
         conversationId,
         from: this.account.userId,
         image,
-        imageAsset: await (await this.account.service!.asset.uploadAsset(image.data)).response,
+        asset: await (await this.account.service!.asset.uploadAsset(image.data)).response,
       });
       await this.account.service.conversation.send({payloadBundle: imagePayload, userIds});
     }

--- a/packages/core/src/demo/echo.ts
+++ b/packages/core/src/demo/echo.ts
@@ -343,12 +343,12 @@ const {WIRE_EMAIL, WIRE_PASSWORD, WIRE_BACKEND = 'staging'} = process.env;
       type: original.mimeType,
       width: original.image.width,
     };
-    const imageAsset = await (await account.service!.asset.uploadAsset(image.data)).response;
+    const asset = await (await account.service!.asset.uploadAsset(image.data)).response;
     const imagePayload = MessageBuilder.createImage({
       conversationId,
       from: account.userId,
       image,
-      imageAsset,
+      asset,
     });
 
     messageIdCache[messageId] = imagePayload.id;

--- a/packages/core/src/demo/sender.ts
+++ b/packages/core/src/demo/sender.ts
@@ -176,7 +176,7 @@ const {
       conversationId: WIRE_CONVERSATION_ID,
       from: account.userId,
       image,
-      imageAsset: await (await account.service!.asset.uploadAsset(image.data)).response,
+      asset: await (await account.service!.asset.uploadAsset(image.data)).response,
     });
     await account.service!.conversation.send({payloadBundle: imagePayload, sendAsProtobuf: useProtobuf});
   }

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import type {CipherOptions} from '@wireapp/api-client/src/asset';
 import {ClientAction, Confirmation} from '@wireapp/protocol-messaging';
 import UUID from 'uuidjs';
 
@@ -59,20 +58,16 @@ interface BaseOptions {
 }
 
 interface CreateImageOptions extends BaseOptions {
-  cipherOptions?: CipherOptions;
   expectsReadConfirmation?: boolean;
-  imageAsset: EncryptedAssetUploaded;
+  asset: EncryptedAssetUploaded;
   image: ImageContent;
   legalHoldStatus?: LegalHoldStatus;
 }
 
-interface CreateFileOptions {
-  cipherOptions?: CipherOptions;
-  conversationId: string;
+interface CreateFileOptions extends BaseOptions {
   expectsReadConfirmation?: boolean;
   asset: EncryptedAssetUploaded;
   file: FileContent;
-  from: string;
   legalHoldStatus?: LegalHoldStatus;
   originalMessageId: string;
 }
@@ -209,14 +204,13 @@ export class MessageBuilder {
   }
 
   public static createImage(payload: CreateImageOptions): ImageAssetMessageOutgoing {
-    const {expectsReadConfirmation, image, imageAsset, legalHoldStatus} = payload;
-
+    const {expectsReadConfirmation, image, asset, legalHoldStatus} = payload;
     return {
       ...createCommonProperties(payload),
       content: {
-        asset: imageAsset,
         expectsReadConfirmation,
         image,
+        asset,
         legalHoldStatus,
       },
       type: PayloadBundleType.ASSET_IMAGE,


### PR DESCRIPTION
BREAKING CHANGE:

Replace `MessageBuilder.createImage({..., imageAsset: asset})` with `MessageBuilder.createImage({..., asset})`

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
