### PR TITLE
feat(core): Add lastRead and Countly message to the core

### DIFF
--- a/packages/core/src/main/conversation/GenericMessageType.ts
+++ b/packages/core/src/main/conversation/GenericMessageType.ts
@@ -30,6 +30,7 @@ export enum GenericMessageType {
   CLIENT_ACTION = 'clientAction',
   COMPOSITE = 'composite',
   CONFIRMATION = 'confirmation',
+  DATA_TRANSFER = 'dataTransfer',
   DELETED = 'deleted',
   EDITED = 'edited',
   EPHEMERAL = 'ephemeral',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->
This PR adds:
- caching of the self conversation getter (since the self conversation never changes, there is no need to fetch multiple times)
- ability to sync the last read timestamp across devices
- ability to sync the countly id across devices

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
