### PR TITLE
feat(core): Send availability status only to directly connected members

### DIFF
--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -50,7 +50,7 @@ export class BroadcastService {
           .flat()
       : (await this.apiClient.teams.member.api.getAllMembers(teamId)).members.map(({user}) => user);
 
-    let members = teamMembers.map(member => ({id: member}));
+    let members = Array.from(new Set(teamMembers)).map(member => ({id: member}));
 
     if (skipOwnClients) {
       const selfUser = await this.apiClient.self.api.getSelf();

--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -32,10 +32,25 @@ export class BroadcastService {
     this.messageService = new MessageService(this.apiClient, this.cryptographyService);
   }
 
-  public async getPreKeyBundlesFromTeam(teamId: string, skipOwnClients = false): Promise<UserPreKeyBundleMap> {
-    const {members: teamMembers} = await this.apiClient.teams.member.api.getAllMembers(teamId);
+  /**
+   * Will create a key bundle for all the users of the team
+   *
+   * @param teamId
+   * @param skipOwnClients=false
+   * @param onlyDirectConnections=false Will generate a bundle only for directly connected users (users the self user has conversation with). Allows avoiding broadcasting messages to too many people
+   */
+  public async getPreKeyBundlesFromTeam(
+    teamId: string,
+    skipOwnClients = false,
+    onlyDirectConnections = false,
+  ): Promise<UserPreKeyBundleMap> {
+    const teamMembers = onlyDirectConnections
+      ? (await this.apiClient.conversation.api.getConversations()).conversations
+          .map(({members}) => members.others.map(user => user.id).concat(members.self.id))
+          .flat()
+      : (await this.apiClient.teams.member.api.getAllMembers(teamId)).members.map(({user}) => user);
 
-    let members = teamMembers.map(member => ({id: member.user}));
+    let members = teamMembers.map(member => ({id: member}));
 
     if (skipOwnClients) {
       const selfUser = await this.apiClient.self.api.getSelf();

--- a/packages/core/src/main/user/UserService.ts
+++ b/packages/core/src/main/user/UserService.ts
@@ -60,9 +60,20 @@ export class UserService {
       : this.apiClient.user.api.getUsers({ids: userIds});
   }
 
-  public async setAvailability(teamId: string, type: AvailabilityType, sendAsProtobuf?: boolean): Promise<void> {
+  /**
+   * Sends a availability update to members of the same team
+   * @param teamId
+   * @param type
+   * @param options.sendAll=false will broadcast the message to all the members of the team (instead of just direct connections). Should be avoided in a big team
+   * @param options.sendAsProtobuf=false
+   */
+  public async setAvailability(
+    teamId: string,
+    type: AvailabilityType,
+    {sendAll = false, sendAsProtobuf = false}: {sendAll: boolean; sendAsProtobuf?: boolean},
+  ): Promise<void> {
     // Get pre-key bundles for members of your own team
-    const preKeyBundlesFromTeam = await this.broadcastService.getPreKeyBundlesFromTeam(teamId);
+    const preKeyBundlesFromTeam = await this.broadcastService.getPreKeyBundlesFromTeam(teamId, false, !sendAll);
 
     // Get pre-key bundles for all of your other 1:1 connections
     const connections = await this.connectionService.getConnections();


### PR DESCRIPTION
BREAKING CHANGE: the setAvailability of the user service will by default now only send to directly connected users. To send to absolutely all the users in the team call `setAvailability` with the `{sendAll: true}` option

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
