### PR TITLE
fix(core): Use Uint8Array in place of Buffer

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -901,14 +901,14 @@ export class ConversationService {
     return this.apiClient.conversation.api.getConversationsByIds(conversationIds);
   }
 
-  public async getAsset({assetId, assetToken, otrKey, sha256}: RemoteData): Promise<Buffer> {
+  public async getAsset({assetId, assetToken, otrKey, sha256}: RemoteData): Promise<Uint8Array> {
     const request = this.apiClient.asset.api.getAssetV3(assetId, assetToken);
     const encryptedBuffer = (await request.response).buffer;
 
     return decryptAsset({
-      cipherText: Buffer.from(encryptedBuffer),
-      keyBytes: Buffer.from(otrKey),
-      sha256: Buffer.from(sha256),
+      cipherText: new Uint8Array(encryptedBuffer),
+      keyBytes: otrKey,
+      sha256: sha256,
     });
   }
 

--- a/packages/core/src/main/cryptography/AssetCryptography/EncryptedAsset.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/EncryptedAsset.ts
@@ -18,10 +18,10 @@
  */
 
 export interface EncryptedAsset {
-  cipherText: Buffer;
-  keyBytes: Buffer;
+  cipherText: Uint8Array;
+  keyBytes: Uint8Array;
   /** The SHA-256 sum of `cipherText` */
-  sha256: Buffer;
+  sha256: Uint8Array;
 }
 
 export interface EncryptedAssetUploaded extends EncryptedAsset {

--- a/packages/core/src/main/cryptography/AssetCryptography/crypto.browser.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/crypto.browser.ts
@@ -42,7 +42,7 @@ export const crypto: Crypto = {
   },
 
   async encrypt(
-    plainText: Buffer | Uint8Array,
+    plainText: Uint8Array,
     keyBytes: Uint8Array,
     initializationVector: Uint8Array,
   ): Promise<{key: Uint8Array; cipher: Uint8Array}> {

--- a/packages/core/src/main/cryptography/AssetCryptography/crypto.browser.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/crypto.browser.ts
@@ -38,7 +38,7 @@ export const crypto: Crypto = {
   },
 
   getRandomValues(size: number): Uint8Array {
-    return new Uint8Array(cryptoLib.getRandomValues(new Uint8Array(size)));
+    return cryptoLib.getRandomValues(new Uint8Array(size));
   },
 
   async encrypt(

--- a/packages/core/src/main/cryptography/AssetCryptography/crypto.browser.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/crypto.browser.ts
@@ -22,33 +22,33 @@ import {Crypto} from './interfaces';
 const cryptoLib = window.crypto;
 
 export const crypto: Crypto = {
-  async digest(cipherText: Buffer | Uint8Array): Promise<Buffer> {
+  async digest(cipherText: Uint8Array): Promise<Uint8Array> {
     const checksum = await cryptoLib.subtle.digest('SHA-256', cipherText);
-    return Buffer.from(checksum);
+    return new Uint8Array(checksum);
   },
 
-  async decrypt(cipherText: Buffer | Uint8Array, keyBytes: Buffer): Promise<Buffer> {
+  async decrypt(cipherText: Uint8Array, keyBytes: Uint8Array): Promise<Uint8Array> {
     const key = await cryptoLib.subtle.importKey('raw', keyBytes, 'AES-CBC', false, ['decrypt']);
 
     const initializationVector = cipherText.slice(0, 16);
     const assetCipherText = cipherText.slice(16);
     const decipher = await cryptoLib.subtle.decrypt({iv: initializationVector, name: 'AES-CBC'}, key, assetCipherText);
 
-    return Buffer.from(decipher);
+    return new Uint8Array(decipher);
   },
 
-  getRandomValues(size: number): Buffer {
-    return Buffer.from(cryptoLib.getRandomValues(new Uint8Array(size)));
+  getRandomValues(size: number): Uint8Array {
+    return new Uint8Array(cryptoLib.getRandomValues(new Uint8Array(size)));
   },
 
   async encrypt(
     plainText: Buffer | Uint8Array,
-    keyBytes: Buffer,
-    initializationVector: Buffer,
-  ): Promise<{key: Buffer; cipher: Buffer}> {
+    keyBytes: Uint8Array,
+    initializationVector: Uint8Array,
+  ): Promise<{key: Uint8Array; cipher: Uint8Array}> {
     const key = await cryptoLib.subtle.importKey('raw', keyBytes, 'AES-CBC', true, ['encrypt']);
     return {
-      key: Buffer.from(await cryptoLib.subtle.exportKey('raw', key)),
+      key: new Uint8Array(await cryptoLib.subtle.exportKey('raw', key)),
       cipher: await cryptoLib.subtle.encrypt({iv: initializationVector, name: 'AES-CBC'}, key, plainText),
     };
   },

--- a/packages/core/src/main/cryptography/AssetCryptography/crypto.node.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/crypto.node.ts
@@ -21,11 +21,11 @@ import {Crypto} from './interfaces';
 import * as cryptoLib from 'crypto';
 
 export const crypto: Crypto = {
-  async digest(cipherText: Buffer | Uint8Array): Promise<Buffer> {
+  async digest(cipherText: Uint8Array): Promise<Uint8Array> {
     return cryptoLib.createHash('SHA256').update(cipherText).digest();
   },
 
-  async decrypt(cipherText: Buffer | Uint8Array, keyBytes: Buffer): Promise<Buffer> {
+  async decrypt(cipherText: Uint8Array, keyBytes: Uint8Array): Promise<Uint8Array> {
     const initializationVector = cipherText.slice(0, 16);
     const assetCipherText = cipherText.slice(16);
 
@@ -36,16 +36,16 @@ export const crypto: Crypto = {
     return Buffer.concat([decipherUpdated, decipherFinal]);
   },
 
-  getRandomValues(size: number): Buffer {
+  getRandomValues(size: number): Uint8Array {
     return cryptoLib.randomBytes(size);
   },
 
   async encrypt(
-    plainText: Buffer | Uint8Array,
-    keyBytes: Buffer,
-    initializationVector: Buffer,
+    plainText: Uint8Array,
+    keyBytes: Uint8Array,
+    initializationVector: Uint8Array,
     algorithm: string,
-  ): Promise<{key: Buffer; cipher: Buffer}> {
+  ): Promise<{key: Uint8Array; cipher: Uint8Array}> {
     const cipher = cryptoLib.createCipheriv(algorithm, keyBytes, initializationVector);
     const cipherUpdated = cipher.update(plainText);
     const cipherFinal = cipher.final();

--- a/packages/core/src/main/cryptography/AssetCryptography/index.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/index.ts
@@ -21,7 +21,7 @@ import {CipherOptions} from '@wireapp/api-client/src/asset';
 import type {EncryptedAsset} from './EncryptedAsset';
 import {crypto} from './crypto.node';
 
-const isEqual = (a: Buffer, b: Buffer): boolean => {
+const isEqual = (a: Uint8Array, b: Uint8Array): boolean => {
   const arrayA = new Uint32Array(a);
   const arrayB = new Uint32Array(b);
 
@@ -32,14 +32,14 @@ const isEqual = (a: Buffer, b: Buffer): boolean => {
 };
 
 interface EncryptOptions extends CipherOptions {
-  plainText: Buffer | Uint8Array;
+  plainText: Uint8Array;
 }
 
 export const decryptAsset = async ({
   cipherText,
   keyBytes,
   sha256: referenceSha256,
-}: EncryptedAsset): Promise<Buffer> => {
+}: EncryptedAsset): Promise<Uint8Array> => {
   const computedSha256 = await crypto.digest(cipherText);
 
   if (!isEqual(computedSha256, referenceSha256)) {
@@ -62,7 +62,7 @@ export const encryptAsset = async ({plainText, algorithm = 'AES-256-CBC'}: Encry
   const sha256 = await crypto.digest(ivCipherText);
 
   return {
-    cipherText: Buffer.from(ivCipherText.buffer),
+    cipherText: ivCipherText,
     keyBytes: key,
     sha256,
   };

--- a/packages/core/src/main/cryptography/AssetCryptography/interfaces.ts
+++ b/packages/core/src/main/cryptography/AssetCryptography/interfaces.ts
@@ -18,16 +18,16 @@
  */
 
 export interface Crypto {
-  digest(cipherText: Buffer | Uint8Array): Promise<Buffer>;
+  digest(cipherText: Uint8Array): Promise<Uint8Array>;
 
-  decrypt(cipherText: Buffer | Uint8Array, keyBytes: Buffer): Promise<Buffer>;
+  decrypt(cipherText: Uint8Array, keyBytes: Uint8Array): Promise<Uint8Array>;
 
-  getRandomValues(size: number): Buffer;
+  getRandomValues(size: number): Uint8Array;
 
   encrypt(
-    plainText: Buffer | Uint8Array,
-    keyBytes: Buffer,
-    initializationVector: Buffer,
+    plainText: Uint8Array,
+    keyBytes: Uint8Array,
+    initializationVector: Uint8Array,
     algorithm: string,
-  ): Promise<{key: Buffer; cipher: Buffer}>;
+  ): Promise<{key: Uint8Array; cipher: Uint8Array}>;
 }

--- a/packages/core/src/main/cryptography/CryptographyService.test.browser.js
+++ b/packages/core/src/main/cryptography/CryptographyService.test.browser.js
@@ -127,14 +127,12 @@ describe('CryptographyService', () => {
 
   describe('"encryptAsset"', () => {
     it('encrypts and decrypts ArrayBuffer', async () => {
-      const bytes = new Uint8Array(16);
-      window.crypto.getRandomValues(bytes);
-      const byteBuffer = Buffer.from(bytes.buffer);
+      const bytes = window.crypto.getRandomValues(new Uint8Array(16));
 
-      const encryptedAsset = await encryptAsset({plainText: byteBuffer});
+      const encryptedAsset = await encryptAsset({plainText: bytes});
       const decryptedBuffer = await decryptAsset(encryptedAsset);
 
-      expect(decryptedBuffer).toEqual(byteBuffer);
+      expect(decryptedBuffer).toEqual(bytes);
     });
 
     it('does not decrypt when the hash is missing', async () => {

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -184,7 +184,7 @@ describe('CryptographyService', () => {
     it('encrypts and decrypts ArrayBuffer', async () => {
       const bytes = new Uint8Array(16);
       await promisify(crypto.randomFill)(bytes);
-      const byteBuffer = bytes;
+      const byteBuffer = Buffer.from(bytes);
 
       const encryptedAsset = await encryptAsset({plainText: byteBuffer});
       const decryptedBuffer = await decryptAsset(encryptedAsset);

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -184,7 +184,7 @@ describe('CryptographyService', () => {
     it('encrypts and decrypts ArrayBuffer', async () => {
       const bytes = new Uint8Array(16);
       await promisify(crypto.randomFill)(bytes);
-      const byteBuffer = Buffer.from(bytes.buffer);
+      const byteBuffer = bytes;
 
       const encryptedAsset = await encryptAsset({plainText: byteBuffer});
       const decryptedBuffer = await decryptAsset(encryptedAsset);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

Since node `Buffer` is a subclass of `Uint8Array` and that we don't need the specific features of `Buffer` we can just use plain `Uint8Array` everywhere. (see https://nodejs.org/api/buffer.html#buffer)

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
