### PR TITLE
feat(core): Remove the need to give a domain to use qualified Ids

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -98,7 +98,7 @@ export interface Account {
 export type StoreEngineProvider = (storeName: string) => Promise<CRUDEngine>;
 
 type AccountConfig = {
-  /** If set to true (default), will use fully qualified ids and federated endpoints */
+  /** If set to true, will use fully qualified ids and federated endpoints */
   useQualifiedIds?: boolean;
 };
 
@@ -132,7 +132,7 @@ export class Account extends EventEmitter {
   constructor(
     apiClient: APIClient = new APIClient(),
     storeEngineProvider?: StoreEngineProvider,
-    private readonly config: AccountConfig = {useQualifiedIds: true},
+    private readonly config: AccountConfig = {},
   ) {
     super();
     this.apiClient = apiClient;

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -98,7 +98,7 @@ export interface Account {
 export type StoreEngineProvider = (storeName: string) => Promise<CRUDEngine>;
 
 type AccountConfig = {
-  federationDomain?: string;
+  legacyBackend?: boolean;
 };
 
 export class Account extends EventEmitter {
@@ -127,7 +127,7 @@ export class Account extends EventEmitter {
   /**
    * @param apiClient The apiClient instance to use in the core (will create a new new one if undefined)
    * @param storeEngineProvider Used to store info in the database (will create a inMemory engine if undefined)
-   * @param config.federationDomain If using a federated backend this will set the default domain for qualified ids. Do not set if using a regular backend
+   * @param config.legacyBackend Set to true if the current backend you are connecting to doesn't support qualifiedIds. Decryption issues can happen if the flag is not in sync with the backend's config
    */
   constructor(
     apiClient: APIClient = new APIClient(),
@@ -202,7 +202,7 @@ export class Account extends EventEmitter {
   public async initServices(storeEngine: CRUDEngine): Promise<void> {
     const accountService = new AccountService(this.apiClient);
     const assetService = new AssetService(this.apiClient);
-    const cryptographyService = new CryptographyService(this.apiClient, storeEngine, this.config);
+    const cryptographyService = new CryptographyService(this.apiClient, storeEngine, !this.config?.legacyBackend);
 
     const clientService = new ClientService(this.apiClient, storeEngine, cryptographyService);
     const connectionService = new ConnectionService(this.apiClient);

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -157,7 +157,11 @@ export class ConversationService {
   private readonly messageService: MessageService;
   private selfConversationId?: QualifiedId;
 
-  constructor(private readonly apiClient: APIClient, cryptographyService: CryptographyService) {
+  constructor(
+    private readonly apiClient: APIClient,
+    cryptographyService: CryptographyService,
+    private readonly config: {useQualifiedIds?: boolean},
+  ) {
     this.messageTimer = new MessageTimer();
     this.messageService = new MessageService(this.apiClient, cryptographyService);
   }
@@ -277,7 +281,8 @@ export class ConversationService {
     if (!this.selfConversationId) {
       const {userId} = this.apiClient.context!;
       const {qualified_id, id} = await this.apiClient.conversation.api.getConversation(userId);
-      this.selfConversationId = qualified_id || {id, domain: ''};
+      const domain = this.config.useQualifiedIds ? qualified_id.domain : '';
+      this.selfConversationId = {id, domain};
     }
     return this.selfConversationId;
   }

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -49,10 +49,6 @@ export interface MetaClient extends RegisteredClient {
   };
 }
 
-type CryptographyServiceOptions = {
-  federationDomain?: string;
-};
-
 export class CryptographyService {
   private readonly logger: logdown.Logger;
 
@@ -62,7 +58,7 @@ export class CryptographyService {
   constructor(
     readonly apiClient: APIClient,
     private readonly storeEngine: CRUDEngine,
-    private readonly options?: CryptographyServiceOptions,
+    private readonly useQualifiedIds?: boolean,
   ) {
     this.cryptobox = new Cryptobox(this.storeEngine);
     this.database = new CryptographyDatabaseRepository(this.storeEngine);
@@ -70,7 +66,6 @@ export class CryptographyService {
       logger: console,
       markdown: false,
     });
-    this.options = options;
   }
 
   public static constructSessionId(userId: string, clientId: string, domain: string | null): string {
@@ -221,7 +216,7 @@ export class CryptographyService {
       data: {sender, text: cipherText},
     } = otrMessage;
 
-    const domain = this.options?.federationDomain ? qualified_from?.domain || this.options.federationDomain : null;
+    const domain = this.useQualifiedIds ? qualified_from!.domain : null;
     const sessionId = CryptographyService.constructSessionId(from, sender, domain);
     const decryptedMessage = await this.decrypt(sessionId, cipherText);
     const genericMessage = GenericMessage.decode(decryptedMessage);

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -58,7 +58,7 @@ export class CryptographyService {
   constructor(
     readonly apiClient: APIClient,
     private readonly storeEngine: CRUDEngine,
-    private readonly useQualifiedIds?: boolean,
+    private readonly config: {useQualifiedIds?: boolean} = {},
   ) {
     this.cryptobox = new Cryptobox(this.storeEngine);
     this.database = new CryptographyDatabaseRepository(this.storeEngine);
@@ -216,7 +216,7 @@ export class CryptographyService {
       data: {sender, text: cipherText},
     } = otrMessage;
 
-    const domain = this.useQualifiedIds ? qualified_from!.domain : null;
+    const domain = this.config.useQualifiedIds ? qualified_from!.domain : null;
     const sessionId = CryptographyService.constructSessionId(from, sender, domain);
     const decryptedMessage = await this.decrypt(sessionId, cipherText);
     const genericMessage = GenericMessage.decode(decryptedMessage);


### PR DESCRIPTION
BREAKING CHANGE: If you were using the `Account` with a federationDomain, you need to replace `federationDomain: 'the.domain'` to `useQualifiedIds: true`. The domain will be found automatically by the core