### PR TITLE
fix(core): Do not try to encrypt for clients without prekeys

### DIFF
--- a/packages/api-client/src/user/UserPreKeyBundleMap.ts
+++ b/packages/api-client/src/user/UserPreKeyBundleMap.ts
@@ -21,7 +21,7 @@ import type {PreKey} from '../auth';
 
 export interface UserPreKeyBundleMap {
   [userId: string]: {
-    [clientId: string]: PreKey;
+    [clientId: string]: PreKey | null;
   };
 }
 

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -127,6 +127,7 @@ describe('CryptographyService', () => {
             id: 72,
             key: 'pQABARn//wKhAFggTWwHUoppQ8aXWhbH95YWnNp6uOYMxo2y4wbarWbF+EEDoQChAFggUiFoPtsiR0WFowIvl0myD+bVnFQJBYarqieI0Gly46QE9g==',
           },
+          ae87218e77d02d30: null,
           [firstClientId]: {
             id: 42,
             key: 'pQABARn//wKhAFggWcbwny0jdqlcnnn0j4QSENIVVq/KgyQ3mmdpunfvGZQDoQChAFggrsQBkQkrVZ8sWhr8wTeaC+dmctuJ3oRqfdHsymTtKmgE9g==',

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -114,6 +114,7 @@ describe('CryptographyService', () => {
     it('generates a set of encrypted data based on PreKeys from multiple clients.', async () => {
       const firstUserID = 'bc0c99f1-49a5-4ad2-889a-62885af37088';
       const secondUserID = '2bde49aa-bdb5-458f-98cf-7d3552b10916';
+      const noPrekeyClient = 'ae87218e77d02d30';
 
       const firstClientId = '2b83ee08d7ac550d';
 
@@ -127,7 +128,7 @@ describe('CryptographyService', () => {
             id: 72,
             key: 'pQABARn//wKhAFggTWwHUoppQ8aXWhbH95YWnNp6uOYMxo2y4wbarWbF+EEDoQChAFggUiFoPtsiR0WFowIvl0myD+bVnFQJBYarqieI0Gly46QE9g==',
           },
-          ae87218e77d02d30: null,
+          [noPrekeyClient]: null,
           [firstClientId]: {
             id: 42,
             key: 'pQABARn//wKhAFggWcbwny0jdqlcnnn0j4QSENIVVq/KgyQ3mmdpunfvGZQDoQChAFggrsQBkQkrVZ8sWhr8wTeaC+dmctuJ3oRqfdHsymTtKmgE9g==',
@@ -150,6 +151,7 @@ describe('CryptographyService', () => {
       expect(Object.keys(encrypted[firstUserID]).length).toBe(3);
       expect(Object.keys(encrypted[secondUserID]).length).toBe(2);
       expect(encrypted[firstUserID][firstClientId]).toEqual(jasmine.any(Uint8Array));
+      expect(encrypted[firstUserID][noPrekeyClient]).not.toBeDefined();
     });
 
     it('does not generate a message counter twice when ran asynchronously multiple times for the same cryptographic session', async () => {

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -149,7 +149,11 @@ export class CryptographyService {
     for (const userId in users) {
       const clientIds = isUserClients(users) ? users[userId] : Object.keys(users[userId]);
       for (const clientId of clientIds) {
-        const base64PreKey = isUserClients(users) ? undefined : users[userId][clientId].key;
+        if (!isUserClients(users) && !users[userId][clientId]) {
+          // In case we are dealing with a PreKeyBundle and there is no prekey for this client, we can just skip the encryption part
+          break;
+        }
+        const base64PreKey = isUserClients(users) ? undefined : users[userId][clientId]?.key;
         const sessionId = CryptographyService.constructSessionId(userId, clientId, domain || null);
         const result = await this.encryptPayloadForSession(sessionId, plainText, base64PreKey);
         if (result) {

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -147,12 +147,12 @@ export class CryptographyService {
     const missing: UserClients = {};
 
     for (const userId in users) {
-      const clientIds = isUserClients(users) ? users[userId] : Object.keys(users[userId]);
+      const clientIds = isUserClients(users)
+        ? users[userId]
+        : Object.keys(users[userId])
+            // We filter out clients that have `null` prekey
+            .filter(clientId => !!users[userId][clientId]);
       for (const clientId of clientIds) {
-        if (!isUserClients(users) && !users[userId][clientId]) {
-          // In case we are dealing with a PreKeyBundle and there is no prekey for this client, we can just skip the encryption part
-          break;
-        }
         const base64PreKey = isUserClients(users) ? undefined : users[userId][clientId]?.key;
         const sessionId = CryptographyService.constructSessionId(userId, clientId, domain || null);
         const result = await this.encryptPayloadForSession(sessionId, plainText, base64PreKey);


### PR DESCRIPTION
Backend response for prekey bundle can eventually be `null`. We need to handle that case in the core to prevent crashes