### PR TITLE
feat(api-client): Allow setting a backend version

### DIFF
--- a/packages/api-client/src/APIClient.test.node.ts
+++ b/packages/api-client/src/APIClient.test.node.ts
@@ -81,7 +81,7 @@ describe('APIClient', () => {
     });
   });
 
-  fdescribe('useVersion', () => {
+  describe('useVersion', () => {
     it('fails if backend versions and accepted version have no common version', async () => {
       nock(baseUrl)
         .get('/api-version')

--- a/packages/api-client/src/APIClient.test.node.ts
+++ b/packages/api-client/src/APIClient.test.node.ts
@@ -81,6 +81,36 @@ describe('APIClient', () => {
     });
   });
 
+  fdescribe('useVersion', () => {
+    it('fails if backend versions and accepted version have no common version', async () => {
+      nock(baseUrl)
+        .get('/api-version')
+        .reply(200, {supported: [0, 1]});
+      const client = new APIClient();
+      try {
+        await client.useVersion([2, 3]);
+      } catch (error) {
+        expect((error as any).message).toContain('does not support');
+      }
+    });
+
+    it("uses version 0 if backend doesn't support /api-version endpoint", async () => {
+      nock(baseUrl).get('/api-version').reply(404);
+      const client = new APIClient();
+      const version = await client.useVersion([0, 1, 2, 3]);
+      expect(version).toBe(0);
+    });
+
+    it('uses highest common version', async () => {
+      nock(baseUrl)
+        .get('/api-version')
+        .reply(200, {supported: [0, 1]});
+      const client = new APIClient();
+      const version = await client.useVersion([0, 1, 2]);
+      expect(version).toBe(1);
+    });
+  });
+
   describe('login', () => {
     accessTokenData = {
       access_token:

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -203,6 +203,30 @@ export class APIClient extends EventEmitter {
     };
   }
 
+  public async useVersion(acceptedVersions: number[]): Promise<number> {
+    let backendVersions = [];
+    try {
+      backendVersions = await (
+        await this.transport.http.sendRequest<{supported: number[]}>({url: '/api-version'})
+      ).data.supported;
+    } catch (error) {
+      backendVersions = [0];
+    }
+    const highestCommonVersion = backendVersions
+      .sort()
+      .reverse()
+      .find(version => acceptedVersions.includes(version));
+
+    if (highestCommonVersion === undefined) {
+      throw new Error(
+        `Backend does not support requested versions [${acceptedVersions.join(
+          ',',
+        )}] (supported versions ${backendVersions.join(',')})`,
+      );
+    }
+    return highestCommonVersion;
+  }
+
   public async init(clientType: ClientType = ClientType.NONE, cookie?: Cookie): Promise<Context> {
     CookieStore.setCookie(cookie);
 

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -240,7 +240,8 @@ export class APIClient extends EventEmitter {
         )}] (supported versions ${backendVersions.join(',')})`,
       );
     }
-    this.api = this.configureApis(highestCommonVersion);
+    this.backendFeatures = this.computeBackendFeatures(0);
+    this.api = this.configureApis(this.backendFeatures);
     return highestCommonVersion;
   }
 

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -251,8 +251,8 @@ export class APIClient extends EventEmitter {
     if (highestCommonVersion === undefined) {
       throw new Error(
         `Backend does not support requested versions [${acceptedVersions.join(
-          ',',
-        )}] (supported versions ${backendVersions.supported.join(',')})`,
+          ', ',
+        )}] (supported versions ${backendVersions.supported.join(', ')})`,
       );
     }
     this.backendFeatures = this.computeBackendFeatures(0, backendVersions);

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -171,7 +171,7 @@ export class APIClient extends EventEmitter {
     this.api = this.configureApis(0);
   }
 
-  private configureApis(_: number): Apis {
+  private configureApis(backendVersion: number): Apis {
     return {
       account: new AccountAPI(this.transport.http),
       asset: new AssetAPI(this.transport.http),
@@ -179,8 +179,8 @@ export class APIClient extends EventEmitter {
       services: new ServicesAPI(this.transport.http),
       broadcast: new BroadcastAPI(this.transport.http),
       client: new ClientAPI(this.transport.http),
-      connection: new ConnectionAPI(this.transport.http),
-      conversation: new ConversationAPI(this.transport.http),
+      connection: new ConnectionAPI(this.transport.http, backendVersion),
+      conversation: new ConversationAPI(this.transport.http, backendVersion),
       giphy: new GiphyAPI(this.transport.http),
       notification: new NotificationAPI(this.transport.http),
       self: new SelfAPI(this.transport.http),
@@ -199,11 +199,15 @@ export class APIClient extends EventEmitter {
         service: new ServiceAPI(this.transport.http),
         team: new TeamAPI(this.transport.http),
       },
-      user: new UserAPI(this.transport.http),
+      user: new UserAPI(this.transport.http, backendVersion),
     };
   }
 
-  public async useVersion(acceptedVersions: number[]): Promise<number> {
+  async useVersion(acceptedVersions: number[]): Promise<number> {
+    if (acceptedVersions.length === 1 && acceptedVersions[0] === 0) {
+      // Nothing to do since version 0 is the default one
+      return 0;
+    }
     let backendVersions = [];
     try {
       backendVersions = await (
@@ -224,6 +228,7 @@ export class APIClient extends EventEmitter {
         )}] (supported versions ${backendVersions.join(',')})`,
       );
     }
+    this.api = this.configureApis(highestCommonVersion);
     return highestCommonVersion;
   }
 

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -119,7 +119,7 @@ type Apis = {
 /** map of all the features that the backend supports (depending on the backend api version number) */
 export type BackendFeatures = {
   /** Does the backend API support federated endpoints */
-  federation: boolean;
+  federationEndpoints: boolean;
   /** Is the backend actually talking to other federated domains */
   isFederated: boolean;
 };
@@ -221,7 +221,7 @@ export class APIClient extends EventEmitter {
    */
   private computeBackendFeatures(backendVersion: number, responsePayload?: BackendVersionResponse): BackendFeatures {
     return {
-      federation: backendVersion > 0,
+      federationEndpoints: backendVersion > 0,
       isFederated: responsePayload?.federated || false,
     };
   }

--- a/packages/api-client/src/connection/ConnectionAPI.ts
+++ b/packages/api-client/src/connection/ConnectionAPI.ts
@@ -39,7 +39,7 @@ export class ConnectionAPI {
    */
   public async getConnection(userId: string | QualifiedId): Promise<Connection> {
     const url =
-      typeof userId !== 'string' && this.backendFeatures.federation
+      typeof userId !== 'string' && this.backendFeatures.federationEndpoints
         ? `${ConnectionAPI.URL.CONNECTIONS}/${userId.domain}/${userId}`
         : `${ConnectionAPI.URL.CONNECTIONS}/${userId}`;
     const config: AxiosRequestConfig = {
@@ -77,7 +77,7 @@ export class ConnectionAPI {
    * @see https://nginz-https.anta.wire.link/api/swagger-ui/#/default/post_list_connections
    */
   public getConnectionList(): Promise<Connection[]> {
-    if (!this.backendFeatures.federation) {
+    if (!this.backendFeatures.federationEndpoints) {
       return this.getAllConnections();
     }
     let allConnections: Connection[] = [];
@@ -144,7 +144,7 @@ export class ConnectionAPI {
   }
 
   public async postConnection(userId: QualifiedId, name?: string): Promise<Connection> {
-    if (this.backendFeatures.federation) {
+    if (this.backendFeatures.federationEndpoints) {
       return this.postConnection_v2(userId as QualifiedId);
     }
     return this.postConnection_v1({user: userId.id, name} as ConnectionRequest);
@@ -211,7 +211,7 @@ export class ConnectionAPI {
    */
   public async putConnection(userId: string | QualifiedId, updatedConnection: ConnectionUpdate): Promise<Connection> {
     const url =
-      this.backendFeatures.federation && typeof userId !== 'string'
+      this.backendFeatures.federationEndpoints && typeof userId !== 'string'
         ? `${ConnectionAPI.URL.CONNECTIONS}/${userId.domain}/${userId.id}`
         : `${ConnectionAPI.URL.CONNECTIONS}/${userId}`;
 

--- a/packages/api-client/src/connection/ConnectionAPI.ts
+++ b/packages/api-client/src/connection/ConnectionAPI.ts
@@ -142,11 +142,11 @@ export class ConnectionAPI {
     return getConnectionChunks();
   }
 
-  public async postConnection(data: ConnectionRequest | QualifiedId): Promise<Connection> {
+  public async postConnection(userId: QualifiedId, name?: string): Promise<Connection> {
     if (this.supportsFederation) {
-      return this.postConnection_v2(data as QualifiedId);
+      return this.postConnection_v2(userId as QualifiedId);
     }
-    return this.postConnection_v1(data as ConnectionRequest);
+    return this.postConnection_v1({user: userId.id, name} as ConnectionRequest);
   }
 
   /**

--- a/packages/api-client/src/conversation/ConversationAPI.test.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.test.ts
@@ -23,7 +23,10 @@ import {ConversationAPI} from './ConversationAPI';
 const httpClientMock = jasmine.createSpyObj('httpClient', {sendJSON: () => ({data: ''})});
 
 describe('ConversationAPI', () => {
-  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {federationEndpoints: false, isFederated: false});
+  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {
+    federationEndpoints: false,
+    isFederated: false,
+  });
   describe('postORTMessage', () => {
     it('add ignore_missing and report_missing parameters', async () => {
       await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, false);

--- a/packages/api-client/src/conversation/ConversationAPI.test.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.test.ts
@@ -23,7 +23,7 @@ import {ConversationAPI} from './ConversationAPI';
 const httpClientMock = jasmine.createSpyObj('httpClient', {sendJSON: () => ({data: ''})});
 
 describe('ConversationAPI', () => {
-  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {federation: false});
+  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {federation: false, isFederated: false});
   describe('postORTMessage', () => {
     it('add ignore_missing and report_missing parameters', async () => {
       await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, false);

--- a/packages/api-client/src/conversation/ConversationAPI.test.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.test.ts
@@ -23,7 +23,7 @@ import {ConversationAPI} from './ConversationAPI';
 const httpClientMock = jasmine.createSpyObj('httpClient', {sendJSON: () => ({data: ''})});
 
 describe('ConversationAPI', () => {
-  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {federation: false, isFederated: false});
+  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {federationEndpoints: false, isFederated: false});
   describe('postORTMessage', () => {
     it('add ignore_missing and report_missing parameters', async () => {
       await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, false);

--- a/packages/api-client/src/conversation/ConversationAPI.test.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.test.ts
@@ -23,7 +23,7 @@ import {ConversationAPI} from './ConversationAPI';
 const httpClientMock = jasmine.createSpyObj('httpClient', {sendJSON: () => ({data: ''})});
 
 describe('ConversationAPI', () => {
-  const conversationApi = new ConversationAPI(httpClientMock as HttpClient);
+  const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {federation: false});
   describe('postORTMessage', () => {
     it('add ignore_missing and report_missing parameters', async () => {
       await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, false);

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -145,7 +145,7 @@ export class ConversationAPI {
     const convId = typeof conversationId === 'string' ? {id: conversationId, domain: ''} : conversationId;
     const uId = typeof userId === 'string' ? {id: userId, domain: ''} : userId;
 
-    const isFederated = this.backendFeatures.federation && convId.domain && uId.domain;
+    const isFederated = this.backendFeatures.federationEndpoints && convId.domain && uId.domain;
 
     const url = isFederated
       ? `${ConversationAPI.URL.CONVERSATIONS}/${convId.id}/${ConversationAPI.URL.MEMBERS}/${uId.id}`
@@ -201,7 +201,7 @@ export class ConversationAPI {
   }
 
   public async getConversation(conversationId: string | QualifiedId): Promise<Conversation> {
-    return this.backendFeatures.federation && typeof conversationId !== 'string'
+    return this.backendFeatures.federationEndpoints && typeof conversationId !== 'string'
       ? this.getConversation_v2(conversationId)
       : this.getConversation_v1(typeof conversationId === 'string' ? conversationId : conversationId.id);
   }
@@ -324,7 +324,7 @@ export class ConversationAPI {
    * Get all local & remote conversations from a federated backend.
    */
   public async getConversationList(): Promise<Conversation[]> {
-    if (!this.backendFeatures.federation) {
+    if (!this.backendFeatures.federationEndpoints) {
       return this.getAllConversations();
     }
     const allConversationIds = await this.getQualifiedConversationIds();
@@ -925,7 +925,7 @@ export class ConversationAPI {
    * @param users List of users to add to a conversation
    */
   public async postMembers(conversationId: string, users: QualifiedId[]): Promise<ConversationMemberJoinEvent> {
-    if (!this.backendFeatures.federation) {
+    if (!this.backendFeatures.federationEndpoints) {
       return this.postMembersV0(
         conversationId,
         users.map(user => user.id),

--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -212,13 +212,9 @@ export class ConversationAPI {
   }
 
   public async getConversation(conversationId: string | QualifiedId): Promise<Conversation> {
-    if (typeof conversationId === 'string') {
-      return this.getConversation_v1(conversationId);
-    }
-    if (!this.supportsFederation) {
-      return this.getConversation_v1(conversationId.id);
-    }
-    return this.getConversation_v2(conversationId);
+    return this.supportsFederation && typeof conversationId !== 'string'
+      ? this.getConversation_v2(conversationId)
+      : this.getConversation_v1(typeof conversationId === 'string' ? conversationId : conversationId.id);
   }
 
   /**

--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -44,6 +44,7 @@ import type {RichInfo} from './RichInfo';
 import type {UserClients, QualifiedUserClients} from '../conversation/';
 import type {QualifiedUserPreKeyBundleMap} from './UserPreKeyBundleMap';
 import {VerificationActionType} from '../auth/VerificationActionType';
+import {BackendFeatures} from '../APIClient';
 
 export class UserAPI {
   public static readonly DEFAULT_USERS_CHUNK_SIZE = 50;
@@ -71,11 +72,8 @@ export class UserAPI {
     V2: 'v2',
     VERIFICATION: '/verification-code',
   };
-  private readonly supportsFederation: boolean;
 
-  constructor(private readonly client: HttpClient, backendVersion: number) {
-    this.supportsFederation = backendVersion > 0;
-  }
+  constructor(private readonly client: HttpClient, private readonly backendFeatures: BackendFeatures) {}
 
   /**
    * Clear all properties.
@@ -146,7 +144,7 @@ export class UserAPI {
    */
   public async getClient(userId: string | QualifiedId, clientId: string): Promise<PublicClient> {
     const url =
-      this.supportsFederation && typeof userId !== 'string'
+      this.backendFeatures.federation && typeof userId !== 'string'
         ? `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`
         : `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.CLIENTS}/${clientId}`;
 
@@ -166,7 +164,7 @@ export class UserAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getPrekey
    */
   public async getClientPreKey(userId: string | QualifiedId, clientId: string): Promise<ClientPreKey> {
-    if (this.supportsFederation && typeof userId !== 'string') {
+    if (this.backendFeatures.federation && typeof userId !== 'string') {
       return this.getClientPreKey_v2(userId, clientId);
     }
     return this.getClientPreKey_v1(userId as string, clientId);
@@ -202,7 +200,7 @@ export class UserAPI {
    */
   public async getClients(userId: string | QualifiedId): Promise<PublicClient[]> {
     const url =
-      this.supportsFederation && typeof userId !== 'string'
+      this.backendFeatures.federation && typeof userId !== 'string'
         ? `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`
         : `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.CLIENTS}`;
 

--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -144,7 +144,7 @@ export class UserAPI {
    */
   public async getClient(userId: string | QualifiedId, clientId: string): Promise<PublicClient> {
     const url =
-      this.backendFeatures.federation && typeof userId !== 'string'
+      this.backendFeatures.federationEndpoints && typeof userId !== 'string'
         ? `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`
         : `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.CLIENTS}/${clientId}`;
 
@@ -164,7 +164,7 @@ export class UserAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getPrekey
    */
   public async getClientPreKey(userId: string | QualifiedId, clientId: string): Promise<ClientPreKey> {
-    if (this.backendFeatures.federation && typeof userId !== 'string') {
+    if (this.backendFeatures.federationEndpoints && typeof userId !== 'string') {
       return this.getClientPreKey_v2(userId, clientId);
     }
     return this.getClientPreKey_v1(userId as string, clientId);
@@ -200,7 +200,7 @@ export class UserAPI {
    */
   public async getClients(userId: string | QualifiedId): Promise<PublicClient[]> {
     const url =
-      this.backendFeatures.federation && typeof userId !== 'string'
+      this.backendFeatures.federationEndpoints && typeof userId !== 'string'
         ? `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`
         : `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.CLIENTS}`;
 

--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -71,8 +71,11 @@ export class UserAPI {
     V2: 'v2',
     VERIFICATION: '/verification-code',
   };
+  private readonly supportsFederation: boolean;
 
-  constructor(private readonly client: HttpClient) {}
+  constructor(private readonly client: HttpClient, backendVersion: number) {
+    this.supportsFederation = backendVersion > 0;
+  }
 
   /**
    * Clear all properties.
@@ -141,15 +144,9 @@ export class UserAPI {
    * @param clientId The client ID
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getUserClient
    */
-  public async getClient(userId: string, clientId: string, useFederation?: false): Promise<PublicClient>;
-  public async getClient(userId: QualifiedId, clientId: string, useFederation: true): Promise<PublicClient>;
-  public async getClient(
-    userId: string | QualifiedId,
-    clientId: string,
-    useFederation: boolean = false,
-  ): Promise<PublicClient> {
+  public async getClient(userId: string | QualifiedId, clientId: string): Promise<PublicClient> {
     const url =
-      useFederation && typeof userId !== 'string'
+      this.supportsFederation && typeof userId !== 'string'
         ? `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`
         : `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.CLIENTS}/${clientId}`;
 
@@ -166,17 +163,10 @@ export class UserAPI {
    * Get a prekey for a specific client of a user.
    * @param userId The user ID
    * @param clientId The client ID
-   * @param useFederation Whether the backend supports federation (in which case userId must be a QualifiedId)
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getPrekey
    */
-  public async getClientPreKey(userId: string, clientId: string, useFederation?: false): Promise<ClientPreKey>;
-  public async getClientPreKey(userId: QualifiedId, clientId: string, useFederation: true): Promise<ClientPreKey>;
-  public async getClientPreKey(
-    userId: string | QualifiedId,
-    clientId: string,
-    useFederation: boolean = false,
-  ): Promise<ClientPreKey> {
-    if (useFederation && typeof userId !== 'string') {
+  public async getClientPreKey(userId: string | QualifiedId, clientId: string): Promise<ClientPreKey> {
+    if (this.supportsFederation && typeof userId !== 'string') {
       return this.getClientPreKey_v2(userId, clientId);
     }
     return this.getClientPreKey_v1(userId as string, clientId);
@@ -210,11 +200,9 @@ export class UserAPI {
    * @param userId The user ID
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getUserClients
    */
-  public async getClients(userId: string, useFederation?: false): Promise<PublicClient[]>;
-  public async getClients(userId: QualifiedId, useFederation: true): Promise<PublicClient[]>;
-  public async getClients(userId: string | QualifiedId, useFederation: boolean = false): Promise<PublicClient[]> {
+  public async getClients(userId: string | QualifiedId): Promise<PublicClient[]> {
     const url =
-      useFederation && typeof userId !== 'string'
+      this.supportsFederation && typeof userId !== 'string'
         ? `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`
         : `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.CLIENTS}`;
 

--- a/packages/bot-api/src/MessageHandler.ts
+++ b/packages/bot-api/src/MessageHandler.ts
@@ -168,7 +168,7 @@ export abstract class MessageHandler {
 
   async sendConnectionRequest(userId: string): Promise<void> {
     if (this.account?.service) {
-      await this.account.service.connection.createConnection(userId);
+      await this.account.service.connection.createConnection({id: userId, domain: ''});
     }
   }
 

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -193,7 +193,7 @@ export class Account extends EventEmitter {
   }
 
   public async initServices(storeEngine: CRUDEngine): Promise<void> {
-    const config = {useQualifiedIds: this.apiClient.backendFeatures.federation};
+    const config = {useQualifiedIds: this.apiClient.backendFeatures.federationEndpoints};
     const accountService = new AccountService(this.apiClient);
     const assetService = new AssetService(this.apiClient);
     const cryptographyService = new CryptographyService(this.apiClient, storeEngine, config);

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -19,7 +19,7 @@
 
 import type {AxiosError} from 'axios';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
-import {APIClient} from '@wireapp/api-client';
+import {APIClient, BackendFeatures} from '@wireapp/api-client';
 import type {RegisterData} from '@wireapp/api-client/src/auth';
 import {AUTH_COOKIE_KEY, AUTH_TABLE_NAME, Context, Cookie, CookieStore, LoginData} from '@wireapp/api-client/src/auth/';
 import {ClientType, RegisteredClient} from '@wireapp/api-client/src/client/';
@@ -97,11 +97,6 @@ export interface Account {
 
 export type StoreEngineProvider = (storeName: string) => Promise<CRUDEngine>;
 
-type AccountConfig = {
-  /** If set to true, will use fully qualified ids and federated endpoints */
-  useQualifiedIds?: boolean;
-};
-
 export class Account extends EventEmitter {
   private readonly apiClient: APIClient;
   private readonly logger: logdown.Logger;
@@ -124,18 +119,16 @@ export class Account extends EventEmitter {
     team: TeamService;
     user: UserService;
   };
+  public backendFeatures: BackendFeatures;
 
   /**
    * @param apiClient The apiClient instance to use in the core (will create a new new one if undefined)
    * @param storeEngineProvider Used to store info in the database (will create a inMemory engine if undefined)
    */
-  constructor(
-    apiClient: APIClient = new APIClient(),
-    storeEngineProvider?: StoreEngineProvider,
-    private readonly config: AccountConfig = {},
-  ) {
+  constructor(apiClient: APIClient = new APIClient(), storeEngineProvider?: StoreEngineProvider) {
     super();
     this.apiClient = apiClient;
+    this.backendFeatures = this.apiClient.backendFeatures;
     if (storeEngineProvider) {
       this.storeEngineProvider = storeEngineProvider;
     } else {
@@ -200,15 +193,16 @@ export class Account extends EventEmitter {
   }
 
   public async initServices(storeEngine: CRUDEngine): Promise<void> {
+    const config = {useQualifiedIds: this.apiClient.backendFeatures.federation};
     const accountService = new AccountService(this.apiClient);
     const assetService = new AssetService(this.apiClient);
-    const cryptographyService = new CryptographyService(this.apiClient, storeEngine, this.config);
+    const cryptographyService = new CryptographyService(this.apiClient, storeEngine, config);
 
     const clientService = new ClientService(this.apiClient, storeEngine, cryptographyService);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);
-    const conversationService = new ConversationService(this.apiClient, cryptographyService, this.config);
+    const conversationService = new ConversationService(this.apiClient, cryptographyService, config);
     const notificationService = new NotificationService(this.apiClient, cryptographyService, storeEngine);
     const selfService = new SelfService(this.apiClient);
     const teamService = new TeamService(this.apiClient);

--- a/packages/core/src/main/client/ClientService.ts
+++ b/packages/core/src/main/client/ClientService.ts
@@ -26,7 +26,7 @@ import type {CryptographyService} from '../cryptography/';
 import {ClientInfo, ClientBackendRepository, ClientDatabaseRepository} from './';
 
 export interface MetaClient extends RegisteredClient {
-  domain: string | null;
+  domain?: string;
   meta: {
     is_verified?: boolean;
     primary_key: string;
@@ -42,7 +42,7 @@ export class ClientService {
     private readonly storeEngine: CRUDEngine,
     private readonly cryptographyService: CryptographyService,
   ) {
-    this.database = new ClientDatabaseRepository(this.storeEngine);
+    this.database = new ClientDatabaseRepository(this.storeEngine, this.cryptographyService);
     this.backend = new ClientBackendRepository(this.apiClient);
   }
 
@@ -58,7 +58,7 @@ export class ClientService {
     return this.database.getLocalClient();
   }
 
-  public createLocalClient(client: RegisteredClient, domain: string | null): Promise<MetaClient> {
+  public createLocalClient(client: RegisteredClient, domain?: string): Promise<MetaClient> {
     return this.database.createLocalClient(client, domain);
   }
 
@@ -68,7 +68,7 @@ export class ClientService {
     return this.database.createClientList(
       this.apiClient.context!.userId,
       filteredClients,
-      this.apiClient.context!.domain || null,
+      this.apiClient.context?.domain,
     );
   }
 
@@ -108,7 +108,7 @@ export class ClientService {
     };
 
     const client = await this.backend.postClient(newClient);
-    await this.createLocalClient(client, this.apiClient.context.domain || null);
+    await this.createLocalClient(client, this.apiClient.context.domain);
     await this.cryptographyService.initCryptobox();
 
     return client;

--- a/packages/core/src/main/connection/ConnectionService.ts
+++ b/packages/core/src/main/connection/ConnectionService.ts
@@ -19,6 +19,7 @@
 
 import type {APIClient} from '@wireapp/api-client';
 import {Connection, ConnectionStatus} from '@wireapp/api-client/src/connection/';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 export class ConnectionService {
   constructor(private readonly apiClient: APIClient) {}
@@ -39,11 +40,7 @@ export class ConnectionService {
     });
   }
 
-  public createConnection(userId: string): Promise<Connection> {
-    return this.apiClient.api.connection.postConnection({
-      message: ' ',
-      name: ' ',
-      user: userId,
-    });
+  public createConnection(userId: QualifiedId): Promise<Connection> {
+    return this.apiClient.api.connection.postConnection(userId, '');
   }
 }

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -181,7 +181,7 @@ export class ConversationService {
   }
 
   private async getConversationQualifiedMembers(conversationId: QualifiedId): Promise<QualifiedId[]> {
-    const conversation = await this.apiClient.api.conversation.getConversation(conversationId, true);
+    const conversation = await this.apiClient.api.conversation.getConversation(conversationId);
     /*
      * If you are sending a message to a conversation, you have to include
      * yourself in the list of users if you want to sync a message also to your
@@ -922,18 +922,15 @@ export class ConversationService {
     return (await request.response).buffer;
   }
 
-  public async addUser<T extends string | string[] | QualifiedId | QualifiedId[]>(
+  public async addUser(
     conversationId: string,
-    userIds: T,
-  ): Promise<T> {
+    userIds: string | string[] | QualifiedId | QualifiedId[],
+  ): Promise<QualifiedId[]> {
     const ids = Array.isArray(userIds) ? userIds : [userIds];
-    if (isStringArray(ids)) {
-      await this.apiClient.api.conversation.postMembers(conversationId, ids);
-    } else if (isQualifiedIdArray(ids)) {
-      await this.apiClient.api.conversation.postMembersV2(conversationId, ids);
-    }
+    const qualifiedIds = isStringArray(ids) ? ids.map(id => ({id, domain: ''} as QualifiedId)) : (ids as QualifiedId[]);
+    await this.apiClient.api.conversation.postMembers(conversationId, qualifiedIds);
 
-    return userIds;
+    return qualifiedIds;
   }
 
   public async removeUser(conversationId: string, userId: string): Promise<string> {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -333,7 +333,7 @@ export class ConversationService {
     if (targetMode !== MessageTargetMode.NONE && !userIds) {
       throw new Error('Cannot send targetted message when no userIds are given');
     }
-    if (conversationDomain) {
+    if (conversationDomain && this.config.useQualifiedIds) {
       if (isStringArray(userIds) || isUserClients(userIds)) {
         throw new Error('Invalid userIds option for sending to federated backend');
       }
@@ -774,7 +774,7 @@ export class ConversationService {
         return false;
       };
 
-      if (conversationDomain) {
+      if (conversationDomain && this.config.useQualifiedIds) {
         await this.messageService.sendFederatedMessage(sendingClientId, recipients, text, {
           conversationId: {id: conversationId, domain: conversationDomain},
           onClientMismatch,

--- a/packages/core/src/main/cryptography/CryptographyService.test.browser.js
+++ b/packages/core/src/main/cryptography/CryptographyService.test.browser.js
@@ -56,10 +56,11 @@ describe('CryptographyService', () => {
   });
 
   describe('"constructSessionId"', () => {
-    it('constructs a Session ID by a given User ID and Client ID.', () => {
+    it('constructs a Session ID by a given User ID and Client ID.', async () => {
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
-      const actual = CryptographyService.constructSessionId(userId, clientId);
+      cryptography = new CryptographyService(undefined, await createEngine('wire'), undefined);
+      const actual = cryptography.constructSessionId(userId, clientId);
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);
     });

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -77,6 +77,18 @@ describe('CryptographyService', () => {
       expect(actual).toContain(userId);
       expect(actual).toContain('test.wire.link');
     });
+
+    it('constructs a qualified Session ID by a given qualified User ID and Client ID.', async () => {
+      const cryptographyService = new CryptographyService(new APIClient(), await createEngine('wire'), {
+        useQualifiedIds: true,
+      });
+      const clientId = '1ceb9063fced26d3';
+      const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
+      const actual = cryptographyService.constructSessionId({id: userId, domain: 'test.wire.link'}, clientId);
+      expect(actual).toContain(clientId);
+      expect(actual).toContain(userId);
+      expect(actual).toContain('test.wire.link');
+    });
   });
 
   describe('"decrypt"', () => {

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -64,7 +64,7 @@ describe('CryptographyService', () => {
     it('constructs a Session ID by a given User ID and Client ID.', () => {
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
-      const actual = CryptographyService.constructSessionId(userId, clientId, null);
+      const actual = cryptographyService.constructSessionId(userId, clientId);
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);
     });
@@ -72,7 +72,7 @@ describe('CryptographyService', () => {
     it('constructs a Session ID by a given User ID and Client ID and domain.', () => {
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
-      const actual = CryptographyService.constructSessionId(userId, clientId, 'test.wire.link');
+      const actual = cryptographyService.constructSessionId(userId, clientId, 'test.wire.link');
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);
       expect(actual).toContain('test.wire.link');

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -69,7 +69,10 @@ describe('CryptographyService', () => {
       expect(actual).toContain(userId);
     });
 
-    it('constructs a Session ID by a given User ID and Client ID and domain.', () => {
+    it('constructs a Session ID by a given User ID and Client ID and domain.', async () => {
+      const cryptographyService = new CryptographyService(new APIClient(), await createEngine('wire'), {
+        useQualifiedIds: true,
+      });
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
       const actual = cryptographyService.constructSessionId(userId, clientId, 'test.wire.link');


### PR DESCRIPTION
Allow the API to be fixed to a specific backend version

## Usage

By default, the APIClient will use version 0. If you want to use a different version, you should use the `useVersion` method of the APIClient

```js
const version = await apiClient.useVersion([1,2]);
// Will resolve with the version that will be used
// Will reject if no version in common is found with the backend
```

## Breaking Changes

All the methods that were using `useFederation` do not need this parameter anymore (since the federation state is guessed from the api version number)