### PR TITLE
refactor(api-client): Move all the specific apis to an `api` namespace of the ApiClient

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -86,37 +86,41 @@ export interface APIClient {
   on(event: TOPIC.ACCESS_TOKEN_REFRESH, listener: (accessToken: AccessTokenData) => void): this;
 }
 
+type Apis = {
+  account: AccountAPI;
+  asset: AssetAPI;
+  auth: AuthAPI;
+  broadcast: BroadcastAPI;
+  client: ClientAPI;
+  connection: ConnectionAPI;
+  conversation: ConversationAPI;
+  giphy: GiphyAPI;
+  notification: NotificationAPI;
+  self: SelfAPI;
+  services: ServicesAPI;
+  serviceProvider: ServiceProviderAPI;
+  teams: {
+    conversation: TeamConversationAPI;
+    feature: FeatureAPI;
+    identityProvider: IdentityProviderAPI;
+    invitation: TeamInvitationAPI;
+    legalhold: LegalHoldAPI;
+    member: MemberAPI;
+    payment: PaymentAPI;
+    billing: BillingAPI;
+    scim: ScimAPI;
+    search: TeamSearchAPI;
+    service: ServiceAPI;
+    team: TeamAPI;
+  };
+  user: UserAPI;
+};
+
 export class APIClient extends EventEmitter {
   private readonly logger: logdown.Logger;
 
   // APIs
-  public account: {api: AccountAPI};
-  public asset: {api: AssetAPI};
-  public auth: {api: AuthAPI};
-  public broadcast: {api: BroadcastAPI};
-  public client: {api: ClientAPI};
-  public connection: {api: ConnectionAPI};
-  public conversation: {api: ConversationAPI};
-  public giphy: {api: GiphyAPI};
-  public notification: {api: NotificationAPI};
-  public self: {api: SelfAPI};
-  public services: {api: ServicesAPI};
-  public serviceProvider: {api: ServiceProviderAPI};
-  public teams: {
-    conversation: {api: TeamConversationAPI};
-    feature: {api: FeatureAPI};
-    identityProvider: {api: IdentityProviderAPI};
-    invitation: {api: TeamInvitationAPI};
-    legalhold: {api: LegalHoldAPI};
-    member: {api: MemberAPI};
-    payment: {api: PaymentAPI};
-    billing: {api: BillingAPI};
-    scim: {api: ScimAPI};
-    search: {api: TeamSearchAPI};
-    service: {api: ServiceAPI};
-    team: {api: TeamAPI};
-  };
-  public user: {api: UserAPI};
+  public api: Apis;
 
   // Configuration
   private readonly accessTokenStore: AccessTokenStore;
@@ -164,82 +168,38 @@ export class APIClient extends EventEmitter {
       http: httpClient,
       ws: webSocket,
     };
-    this.account = {
-      api: new AccountAPI(this.transport.http),
-    };
-    this.asset = {
-      api: new AssetAPI(this.transport.http),
-    };
-    this.auth = {
-      api: new AuthAPI(this.transport.http),
-    };
-    this.services = {
-      api: new ServicesAPI(this.transport.http),
-    };
-    this.broadcast = {
-      api: new BroadcastAPI(this.transport.http),
-    };
-    this.client = {
-      api: new ClientAPI(this.transport.http),
-    };
-    this.connection = {
-      api: new ConnectionAPI(this.transport.http),
-    };
-    this.conversation = {
-      api: new ConversationAPI(this.transport.http),
-    };
-    this.giphy = {
-      api: new GiphyAPI(this.transport.http),
-    };
-    this.notification = {
-      api: new NotificationAPI(this.transport.http),
-    };
-    this.self = {
-      api: new SelfAPI(this.transport.http),
-    };
-    this.serviceProvider = {
-      api: new ServiceProviderAPI(this.transport.http),
-    };
-    this.teams = {
-      conversation: {
-        api: new TeamConversationAPI(this.transport.http),
+    this.api = this.configureApis(0);
+  }
+
+  private configureApis(backendVersion: number): Apis {
+    return {
+      account: new AccountAPI(this.transport.http),
+      asset: new AssetAPI(this.transport.http),
+      auth: new AuthAPI(this.transport.http),
+      services: new ServicesAPI(this.transport.http),
+      broadcast: new BroadcastAPI(this.transport.http),
+      client: new ClientAPI(this.transport.http),
+      connection: new ConnectionAPI(this.transport.http, backendVersion),
+      conversation: new ConversationAPI(this.transport.http, backendVersion),
+      giphy: new GiphyAPI(this.transport.http),
+      notification: new NotificationAPI(this.transport.http),
+      self: new SelfAPI(this.transport.http),
+      serviceProvider: new ServiceProviderAPI(this.transport.http),
+      teams: {
+        conversation: new TeamConversationAPI(this.transport.http),
+        feature: new FeatureAPI(this.transport.http),
+        identityProvider: new IdentityProviderAPI(this.transport.http),
+        invitation: new TeamInvitationAPI(this.transport.http),
+        legalhold: new LegalHoldAPI(this.transport.http),
+        member: new MemberAPI(this.transport.http),
+        payment: new PaymentAPI(this.transport.http),
+        billing: new BillingAPI(this.transport.http),
+        scim: new ScimAPI(this.transport.http),
+        search: new TeamSearchAPI(this.transport.http),
+        service: new ServiceAPI(this.transport.http),
+        team: new TeamAPI(this.transport.http),
       },
-      feature: {
-        api: new FeatureAPI(this.transport.http),
-      },
-      identityProvider: {
-        api: new IdentityProviderAPI(this.transport.http),
-      },
-      invitation: {
-        api: new TeamInvitationAPI(this.transport.http),
-      },
-      legalhold: {
-        api: new LegalHoldAPI(this.transport.http),
-      },
-      member: {
-        api: new MemberAPI(this.transport.http),
-      },
-      payment: {
-        api: new PaymentAPI(this.transport.http),
-      },
-      billing: {
-        api: new BillingAPI(this.transport.http),
-      },
-      scim: {
-        api: new ScimAPI(this.transport.http),
-      },
-      search: {
-        api: new TeamSearchAPI(this.transport.http),
-      },
-      service: {
-        api: new ServiceAPI(this.transport.http),
-      },
-      team: {
-        api: new TeamAPI(this.transport.http),
-      },
-    };
-    this.user = {
-      api: new UserAPI(this.transport.http),
+      user: new UserAPI(this.transport.http, backendVersion),
     };
   }
 
@@ -259,7 +219,7 @@ export class APIClient extends EventEmitter {
       await this.logout();
     }
 
-    const accessToken = await this.auth.api.postLogin(loginData);
+    const accessToken = await this.api.auth.postLogin(loginData);
 
     this.logger.info(
       `Saved initial access token. It will expire in "${accessToken.expires_in}" seconds.`,
@@ -291,7 +251,7 @@ export class APIClient extends EventEmitter {
       await this.logout();
     }
 
-    const user = await this.auth.api.postRegister(userAccount);
+    const user = await this.api.auth.postRegister(userAccount);
 
     await this.createContext(user.id, clientType);
 
@@ -302,7 +262,7 @@ export class APIClient extends EventEmitter {
     try {
       this.disconnect('Closed by client logout');
       if (!options.skipLogoutRequest) {
-        await this.auth.api.postLogout();
+        await this.api.auth.postLogout();
       }
     } catch (error) {
       this.logger.warn(error);
@@ -320,7 +280,7 @@ export class APIClient extends EventEmitter {
   private async createContext(userId: string, clientType: ClientType): Promise<Context> {
     let selfDomain = undefined;
     try {
-      const self = await this.self.api.getSelf();
+      const self = await this.api.self.getSelf();
       selfDomain = self.qualified_id?.domain;
       this.logger.info(`Got self domain "${selfDomain}"`);
     } catch (error) {

--- a/packages/api-client/src/asset/AssetAPI.test.node.ts
+++ b/packages/api-client/src/asset/AssetAPI.test.node.ts
@@ -36,7 +36,7 @@ describe('"AssetAPI"', () => {
     const assetId = 'my-asset-id';
     const assetToken = 'my-asset-token';
 
-    await apiClient.asset.api.getAssetV3(assetId, assetToken);
+    await this.apiClient.api.asset.getAssetV3(assetId, assetToken);
 
     expect(apiClient.transport.http.sendRequest).toHaveBeenCalledWith(
       jasmine.objectContaining({
@@ -61,7 +61,7 @@ describe('"AssetAPI"', () => {
     );
     const assetId = 'my-asset-id';
 
-    await apiClient.asset.api.getAssetV3(assetId);
+    await this.apiClient.api.asset.getAssetV3(assetId);
 
     expect(apiClient.transport.http.sendRequest).toHaveBeenCalledWith(
       jasmine.objectContaining({

--- a/packages/api-client/src/auth/AuthAPI.test.node.ts
+++ b/packages/api-client/src/auth/AuthAPI.test.node.ts
@@ -41,7 +41,7 @@ describe('AuthAPI', () => {
       }),
     );
 
-    await apiClient.auth.api.postLogin(data);
+    await this.apiClient.api.auth.postLogin(data);
 
     expect(apiClient.transport.http.sendJSON).toHaveBeenCalledWith(
       jasmine.objectContaining({
@@ -74,7 +74,7 @@ describe('AuthAPI', () => {
       }),
     );
 
-    await apiClient.auth.api.postLogin(data);
+    await this.apiClient.api.auth.postLogin(data);
 
     expect(apiClient.transport.http.sendJSON).toHaveBeenCalledWith(
       jasmine.objectContaining({

--- a/packages/api-client/src/demo/http401.ts
+++ b/packages/api-client/src/demo/http401.ts
@@ -22,7 +22,7 @@ import {initClient} from './initClient';
 (async () => {
   const apiClient = await initClient();
   apiClient['accessTokenStore'].accessToken!.access_token = 'invalid';
-  await apiClient.conversation.api.getAllConversations();
+  await apiClient.api.conversation.getAllConversations();
 })().catch(error => {
   console.error(error);
   process.exit(1);

--- a/packages/api-client/src/demo/self.ts
+++ b/packages/api-client/src/demo/self.ts
@@ -21,7 +21,7 @@ import {initClient} from './initClient';
 
 (async () => {
   const apiClient = await initClient();
-  const self = await apiClient.self.api.getSelf();
+  const self = await apiClient.api.self.getSelf();
   console.info(`Logged in with handle "${self.handle}".`);
 })().catch(error => {
   console.error(error);

--- a/packages/cli-client/src/index.ts
+++ b/packages/cli-client/src/index.ts
@@ -90,9 +90,9 @@ account.on(PayloadBundleType.TEXT, textMessage => {
     // TODO: The following is just a quick hack to continue if too many clients are registered!
     // We should expose this fail-safe method as an emergency function
     if (errorLabel === BackendErrorLabel.TOO_MANY_CLIENTS) {
-      const clients = await apiClient.client.api.getClients();
+      const clients = await apiClient.api.client.getClients();
       const client: RegisteredClient = clients[0];
-      await apiClient.client.api.deleteClient(client.id, loginData.password);
+      await apiClient.api.client.deleteClient(client.id, loginData.password);
       await account.logout();
 
       // TODO: Completely removing the Wire Cryptobox directoy isn't a good idea! The "logout" method should

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -312,7 +312,7 @@ export class Account extends EventEmitter {
     await this.service!.cryptography.initCryptobox();
 
     const loadedClient = await this.service!.client.getLocalClient();
-    await this.apiClient.client.api.getClient(loadedClient.id);
+    await this.apiClient.api.client.getClient(loadedClient.id);
     this.apiClient.context!.clientId = loadedClient.id;
 
     return loadedClient;

--- a/packages/core/src/main/account/AccountService.ts
+++ b/packages/core/src/main/account/AccountService.ts
@@ -26,6 +26,6 @@ export class AccountService {
 
   getCallConfig(): Promise<CallConfigData> {
     const iceCandidateLimit = Runtime.isFirefox() ? 3 : undefined;
-    return this.apiClient.account.api.getCallConfig(iceCandidateLimit);
+    return this.apiClient.api.account.getCallConfig(iceCandidateLimit);
   }
 }

--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -45,7 +45,7 @@ export class BroadcastService {
     onlyDirectConnections = false,
   ): Promise<UserPreKeyBundleMap> {
     const teamMembers = onlyDirectConnections
-      ? (await this.apiClient.conversation.api.getConversations()).conversations
+      ? (await this.apiClient.api.conversation.getConversations()).conversations
           .map(({members}) => members.others.map(user => user.id).concat(members.self.id))
           .flat()
       : (await this.apiClient.teams.member.api.getAllMembers(teamId)).members.map(({user}) => user);
@@ -53,11 +53,11 @@ export class BroadcastService {
     let members = Array.from(new Set(teamMembers)).map(member => ({id: member}));
 
     if (skipOwnClients) {
-      const selfUser = await this.apiClient.self.api.getSelf();
+      const selfUser = await this.apiClient.api.self.getSelf();
       members = members.filter(member => member.id !== selfUser.id);
     }
 
-    const preKeys = await Promise.all(members.map(member => this.apiClient.user.api.getUserPreKeys(member.id)));
+    const preKeys = await Promise.all(members.map(member => this.apiClient.api.user.getUserPreKeys(member.id)));
 
     return preKeys.reduce<UserPreKeyBundleMap>((bundleMap, bundle) => {
       bundleMap[bundle.user] = {};

--- a/packages/core/src/main/client/ClientBackendRepository.ts
+++ b/packages/core/src/main/client/ClientBackendRepository.ts
@@ -24,10 +24,10 @@ export class ClientBackendRepository {
   constructor(private readonly apiClient: APIClient) {}
 
   public getClients(): Promise<RegisteredClient[]> {
-    return this.apiClient.client.api.getClients();
+    return this.apiClient.api.client.getClients();
   }
 
   public postClient(client: NewClient): Promise<RegisteredClient> {
-    return this.apiClient.client.api.postClient(client);
+    return this.apiClient.api.client.postClient(client);
   }
 }

--- a/packages/core/src/main/connection/ConnectionService.ts
+++ b/packages/core/src/main/connection/ConnectionService.ts
@@ -24,23 +24,23 @@ export class ConnectionService {
   constructor(private readonly apiClient: APIClient) {}
 
   public getConnections(): Promise<Connection[]> {
-    return this.apiClient.connection.api.getAllConnections();
+    return this.apiClient.api.connection.getAllConnections();
   }
 
   public acceptConnection(userId: string): Promise<Connection> {
-    return this.apiClient.connection.api.putConnection(userId, {
+    return this.apiClient.api.connection.putConnection(userId, {
       status: ConnectionStatus.ACCEPTED,
     });
   }
 
   public ignoreConnection(userId: string): Promise<Connection> {
-    return this.apiClient.connection.api.putConnection(userId, {
+    return this.apiClient.api.connection.putConnection(userId, {
       status: ConnectionStatus.IGNORED,
     });
   }
 
   public createConnection(userId: string): Promise<Connection> {
-    return this.apiClient.connection.api.postConnection({
+    return this.apiClient.api.connection.postConnection({
       message: ' ',
       name: ' ',
       user: userId,

--- a/packages/core/src/main/conversation/AssetService.test.node.ts
+++ b/packages/core/src/main/conversation/AssetService.test.node.ts
@@ -33,7 +33,7 @@ describe('AssetService', () => {
         expires: '',
       };
 
-      spyOn(apiClient.asset.api, 'postAsset').and.returnValue({
+      spyOn(apiClient.api.asset, 'postAsset').and.returnValue({
         cancel: () => {},
         response: Promise.resolve(assetServerData),
       });
@@ -59,7 +59,7 @@ describe('AssetService', () => {
         response: Promise.resolve({} as any),
       };
 
-      spyOn(apiClient.asset.api, 'postAsset').and.returnValue(apiUpload);
+      spyOn(apiClient.api.asset, 'postAsset').and.returnValue(apiUpload);
 
       const asset = await assetService.uploadAsset(Buffer.from([1, 2, 3]));
       asset.cancel();
@@ -75,7 +75,7 @@ describe('AssetService', () => {
         response: Promise.resolve({} as any),
       };
 
-      spyOn(apiClient.asset.api, 'postAsset').and.callFake((_asset, _options, progressCallback) => {
+      spyOn(apiClient.api.asset, 'postAsset').and.callFake((_asset, _options, progressCallback) => {
         progressCallback?.(1);
         return apiUpload;
       });

--- a/packages/core/src/main/conversation/AssetService.ts
+++ b/packages/core/src/main/conversation/AssetService.ts
@@ -70,28 +70,28 @@ export class AssetService {
 
     switch (assetData.version) {
       case 1:
-        return this.apiClient.asset.api.getAssetV1(
+        return this.apiClient.api.asset.getAssetV1(
           assetData.assetId,
           assetData.conversationId,
           forceCaching,
           progressCallback,
         );
       case 2:
-        return this.apiClient.asset.api.getAssetV2(
+        return this.apiClient.api.asset.getAssetV2(
           assetData.assetId,
           assetData.conversationId,
           forceCaching,
           progressCallback,
         );
       case 3:
-        return this.apiClient.asset.api.getAssetV3(
+        return this.apiClient.api.asset.getAssetV3(
           assetData.assetKey,
           assetData.assetToken,
           forceCaching,
           progressCallback,
         );
       case 4:
-        return this.apiClient.asset.api.getAssetV4(
+        return this.apiClient.api.asset.getAssetV4(
           assetData.assetKey,
           assetData.assetDomain,
           assetData.assetToken,
@@ -110,7 +110,7 @@ export class AssetService {
    * @return cancellable request that resolves with the uploaded image
    */
   public uploadRawAsset(asset: Buffer | Uint8Array, options?: AssetOptions, progressCallback?: ProgressCallback) {
-    return this.apiClient.asset.api.postAsset(new Uint8Array(asset), options, progressCallback);
+    return this.apiClient.api.asset.postAsset(new Uint8Array(asset), options, progressCallback);
   }
 
   /**

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -181,7 +181,7 @@ export class ConversationService {
   }
 
   private async getConversationQualifiedMembers(conversationId: QualifiedId): Promise<QualifiedId[]> {
-    const conversation = await this.apiClient.conversation.api.getConversation(conversationId, true);
+    const conversation = await this.apiClient.api.conversation.getConversation(conversationId, true);
     /*
      * If you are sending a message to a conversation, you have to include
      * yourself in the list of users if you want to sync a message also to your
@@ -225,7 +225,7 @@ export class ConversationService {
 
     const preKeys = await Promise.all(
       targets.map(async ({id: userId, clients}) => {
-        const prekeyBundle = await this.apiClient.user.api.getUserPreKeys(userId);
+        const prekeyBundle = await this.apiClient.api.user.getUserPreKeys(userId);
         // We filter the clients that should not receive the message (if a QualifiedUserClients was given as parameter)
         const userClients = clients
           ? prekeyBundle.clients.filter(client => clients.includes(client.client))
@@ -256,7 +256,7 @@ export class ConversationService {
     }
 
     if (!members.length) {
-      const conversation = await this.apiClient.conversation.api.getConversation(conversationId);
+      const conversation = await this.apiClient.api.conversation.getConversation(conversationId);
       /*
        * If you are sending a message to a conversation, you have to include
        * yourself in the list of users if you want to sync a message also to your
@@ -265,7 +265,7 @@ export class ConversationService {
       members = conversation.members.others.map(member => member.id).concat(conversation.members.self.id);
     }
 
-    const preKeys = await Promise.all(members.map(member => this.apiClient.user.api.getUserPreKeys(member)));
+    const preKeys = await Promise.all(members.map(member => this.apiClient.api.user.getUserPreKeys(member)));
 
     return preKeys.reduce((bundleMap: UserPreKeyBundleMap, bundle) => {
       const userId = bundle.user;
@@ -280,7 +280,7 @@ export class ConversationService {
   private async getSelfConversationId(): Promise<QualifiedId> {
     if (!this.selfConversationId) {
       const {userId} = this.apiClient.context!;
-      const {qualified_id, id} = await this.apiClient.conversation.api.getConversation(userId);
+      const {qualified_id, id} = await this.apiClient.api.conversation.getConversation(userId);
       const domain = this.config.useQualifiedIds ? qualified_id.domain : '';
       this.selfConversationId = {id, domain};
     }
@@ -868,7 +868,7 @@ export class ConversationService {
   }
 
   public leaveConversation(conversationId: string): Promise<ConversationMemberLeaveEvent> {
-    return this.apiClient.conversation.api.deleteMember(conversationId, this.apiClient.context!.userId);
+    return this.apiClient.api.conversation.deleteMember(conversationId, this.apiClient.context!.userId);
   }
 
   public async leaveConversations(conversationIds?: string[]): Promise<ConversationMemberLeaveEvent[]> {
@@ -891,23 +891,23 @@ export class ConversationService {
       users: ids,
     };
 
-    return this.apiClient.conversation.api.postConversation(newConversation);
+    return this.apiClient.api.conversation.postConversation(newConversation);
   }
 
   public async getConversations(conversationId: string): Promise<Conversation>;
   public async getConversations(conversationIds?: string[]): Promise<Conversation[]>;
   public async getConversations(conversationIds?: string | string[]): Promise<Conversation[] | Conversation> {
     if (!conversationIds || !conversationIds.length) {
-      return this.apiClient.conversation.api.getAllConversations();
+      return this.apiClient.api.conversation.getAllConversations();
     }
     if (typeof conversationIds === 'string') {
-      return this.apiClient.conversation.api.getConversation(conversationIds);
+      return this.apiClient.api.conversation.getConversation(conversationIds);
     }
-    return this.apiClient.conversation.api.getConversationsByIds(conversationIds);
+    return this.apiClient.api.conversation.getConversationsByIds(conversationIds);
   }
 
   public async getAsset({assetId, assetToken, otrKey, sha256}: RemoteData): Promise<Uint8Array> {
-    const request = this.apiClient.asset.api.getAssetV3(assetId, assetToken);
+    const request = this.apiClient.api.asset.getAssetV3(assetId, assetToken);
     const encryptedBuffer = (await request.response).buffer;
 
     return decryptAsset({
@@ -918,7 +918,7 @@ export class ConversationService {
   }
 
   public async getUnencryptedAsset(assetId: string, assetToken?: string): Promise<ArrayBuffer> {
-    const request = await this.apiClient.asset.api.getAssetV3(assetId, assetToken);
+    const request = await this.apiClient.api.asset.getAssetV3(assetId, assetToken);
     return (await request.response).buffer;
   }
 
@@ -928,16 +928,16 @@ export class ConversationService {
   ): Promise<T> {
     const ids = Array.isArray(userIds) ? userIds : [userIds];
     if (isStringArray(ids)) {
-      await this.apiClient.conversation.api.postMembers(conversationId, ids);
+      await this.apiClient.api.conversation.postMembers(conversationId, ids);
     } else if (isQualifiedIdArray(ids)) {
-      await this.apiClient.conversation.api.postMembersV2(conversationId, ids);
+      await this.apiClient.api.conversation.postMembersV2(conversationId, ids);
     }
 
     return userIds;
   }
 
   public async removeUser(conversationId: string, userId: string): Promise<string> {
-    await this.apiClient.conversation.api.deleteMember(conversationId, userId);
+    await this.apiClient.api.conversation.deleteMember(conversationId, userId);
     return userId;
   }
 
@@ -1062,11 +1062,11 @@ export class ConversationService {
   }
 
   public sendTypingStart(conversationId: string): Promise<void> {
-    return this.apiClient.conversation.api.postTyping(conversationId, {status: CONVERSATION_TYPING.STARTED});
+    return this.apiClient.api.conversation.postTyping(conversationId, {status: CONVERSATION_TYPING.STARTED});
   }
 
   public sendTypingStop(conversationId: string): Promise<void> {
-    return this.apiClient.conversation.api.postTyping(conversationId, {status: CONVERSATION_TYPING.STOPPED});
+    return this.apiClient.api.conversation.postTyping(conversationId, {status: CONVERSATION_TYPING.STOPPED});
   }
 
   public setConversationMutedStatus(
@@ -1083,7 +1083,7 @@ export class ConversationService {
       otr_muted_status: status,
     };
 
-    return this.apiClient.conversation.api.putMembershipProperties(conversationId, payload);
+    return this.apiClient.api.conversation.putMembershipProperties(conversationId, payload);
   }
 
   public toggleArchiveConversation(
@@ -1100,7 +1100,7 @@ export class ConversationService {
       otr_archived_ref: archiveTimestamp.toISOString(),
     };
 
-    return this.apiClient.conversation.api.putMembershipProperties(conversationId, payload);
+    return this.apiClient.api.conversation.putMembershipProperties(conversationId, payload);
   }
 
   public setMemberConversationRole(
@@ -1108,7 +1108,7 @@ export class ConversationService {
     userId: string,
     conversationRole: DefaultConversationRoleName | string,
   ): Promise<void> {
-    return this.apiClient.conversation.api.putOtherMember(userId, conversationId, {
+    return this.apiClient.api.conversation.putOtherMember(userId, conversationId, {
       conversation_role: conversationRole,
     });
   }

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -97,13 +97,13 @@ describe('MessageService', () => {
 
   describe('sendFederatedMessage', () => {
     it('sends a message', async () => {
-      spyOn(apiClient.conversation.api, 'postOTRMessageV2').and.returnValue(Promise.resolve(baseMessageSendingStatus));
+      spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.returnValue(Promise.resolve(baseMessageSendingStatus));
       const recipients = generateQualifiedRecipients([user1, user2]);
 
       await messageService.sendFederatedMessage('senderclientid', recipients, new Uint8Array(), {
         conversationId: {id: 'convid', domain: ''},
       });
-      expect(apiClient.conversation.api.postOTRMessageV2).toHaveBeenCalled();
+      expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalled();
     });
 
     describe('client mismatch', () => {
@@ -114,7 +114,7 @@ describe('MessageService', () => {
           deleted: {[user1.domain]: {[user1.id]: [user1.clients[0]]}},
           missing: {'2.wire.test': {[user2.id]: ['client22']}},
         };
-        spyOn(apiClient.conversation.api, 'postOTRMessageV2').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.callFake(() => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -126,7 +126,7 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseMessageSendingStatus);
         });
-        spyOn(apiClient.user.api, 'postQualifiedMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
+        spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -134,14 +134,14 @@ describe('MessageService', () => {
           reportMissing: true,
           conversationId: {id: 'convid', domain: ''},
         });
-        expect(apiClient.conversation.api.postOTRMessageV2).toHaveBeenCalledTimes(2);
+        expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalledTimes(2);
       });
 
       it('continues message sending if onClientMismatch returns true', async () => {
         const onClientMismatch = jasmine.createSpy('onClientMismatch').and.returnValue(true);
         const clientMismatch = {...baseMessageSendingStatus, missing: {'2.wire.test': {[user2.id]: ['client22']}}};
         let spyCounter = 0;
-        spyOn(apiClient.conversation.api, 'postOTRMessageV2').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.callFake(() => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -153,7 +153,7 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseMessageSendingStatus);
         });
-        spyOn(apiClient.user.api, 'postQualifiedMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
+        spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -162,14 +162,14 @@ describe('MessageService', () => {
           onClientMismatch,
           conversationId: {id: 'convid', domain: ''},
         });
-        expect(apiClient.conversation.api.postOTRMessageV2).toHaveBeenCalledTimes(2);
+        expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalledTimes(2);
         expect(onClientMismatch).toHaveBeenCalledWith(clientMismatch);
       });
 
       it('stops message sending if onClientMismatch returns false', async () => {
         const onClientMismatch = jasmine.createSpy('onClientMismatch').and.returnValue(false);
         const clientMismatch = {...baseMessageSendingStatus, missing: {'2.wire.test': {[user2.id]: ['client22']}}};
-        spyOn(apiClient.conversation.api, 'postOTRMessageV2').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.callFake(() => {
           const error = new Error();
           (error as any).response = {
             status: StatusCodes.PRECONDITION_FAILED,
@@ -177,7 +177,7 @@ describe('MessageService', () => {
           };
           return Promise.reject(error);
         });
-        spyOn(apiClient.user.api, 'postQualifiedMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
+        spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -186,7 +186,7 @@ describe('MessageService', () => {
           onClientMismatch,
           conversationId: {id: 'convid', domain: ''},
         });
-        expect(apiClient.conversation.api.postOTRMessageV2).toHaveBeenCalledTimes(1);
+        expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalledTimes(1);
         expect(onClientMismatch).toHaveBeenCalledWith(clientMismatch);
       });
     });
@@ -214,12 +214,12 @@ describe('MessageService', () => {
 
     it('should send regular to conversation', async () => {
       const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.conversation.api, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
+      spyOn(apiClient.api.conversation, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
       await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
         conversationId,
       });
-      expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledWith(
+      expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledWith(
         clientId,
         conversationId,
         jasmine.any(Object),
@@ -229,7 +229,7 @@ describe('MessageService', () => {
 
     it('should send protobuf message to conversation', async () => {
       const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.conversation.api, 'postOTRProtobufMessage').and.returnValue(
+      spyOn(apiClient.api.conversation, 'postOTRProtobufMessage').and.returnValue(
         Promise.resolve({} as ClientMismatch),
       );
 
@@ -237,7 +237,7 @@ describe('MessageService', () => {
         conversationId,
         sendAsProtobuf: true,
       });
-      expect(apiClient.conversation.api.postOTRProtobufMessage).toHaveBeenCalledWith(
+      expect(apiClient.api.conversation.postOTRProtobufMessage).toHaveBeenCalledWith(
         clientId,
         conversationId,
         jasmine.any(Object),
@@ -247,15 +247,15 @@ describe('MessageService', () => {
 
     it('should broadcast regular message if no conversationId is given', async () => {
       const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.broadcast.api, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
+      spyOn(apiClient.api.broadcast, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
       await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message));
-      expect(apiClient.broadcast.api.postBroadcastMessage).toHaveBeenCalledWith(clientId, jasmine.any(Object), false);
+      expect(apiClient.api.broadcast.postBroadcastMessage).toHaveBeenCalledWith(clientId, jasmine.any(Object), false);
     });
 
     it('should broadcast protobuf message if no conversationId is given', async () => {
       const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.broadcast.api, 'postBroadcastProtobufMessage').and.returnValue(
+      spyOn(apiClient.api.broadcast, 'postBroadcastProtobufMessage').and.returnValue(
         Promise.resolve({} as ClientMismatch),
       );
 
@@ -263,7 +263,7 @@ describe('MessageService', () => {
         sendAsProtobuf: true,
       });
 
-      expect(apiClient.broadcast.api.postBroadcastProtobufMessage).toHaveBeenCalledWith(
+      expect(apiClient.api.broadcast.postBroadcastProtobufMessage).toHaveBeenCalledWith(
         clientId,
         jasmine.any(Object),
         false,
@@ -272,12 +272,12 @@ describe('MessageService', () => {
 
     it('should not send as external if payload small', async () => {
       const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.conversation.api, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
+      spyOn(apiClient.api.conversation, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
       await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
         conversationId,
       });
-      expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledWith(
+      expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledWith(
         clientId,
         conversationId,
         jasmine.objectContaining({data: undefined}),
@@ -288,7 +288,7 @@ describe('MessageService', () => {
     it('should send as external if payload is big', async () => {
       const longMessage =
         'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem';
-      spyOn(apiClient.conversation.api, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
+      spyOn(apiClient.api.conversation, 'postOTRMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
       await messageService.sendMessage(
         clientId,
@@ -298,7 +298,7 @@ describe('MessageService', () => {
           conversationId,
         },
       );
-      expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledWith(
+      expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledWith(
         clientId,
         conversationId,
         jasmine.objectContaining({data: jasmine.any(String)}),
@@ -321,7 +321,7 @@ describe('MessageService', () => {
           deleted: {[user1.id]: [user1.clients[0]]},
           missing: {[user2.id]: ['client22']},
         };
-        spyOn(apiClient.conversation.api, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -333,7 +333,7 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseClientMismatch);
         });
-        spyOn(apiClient.user.api, 'postMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
+        spyOn(apiClient.api.user, 'postMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
 
         const recipients = generateRecipients([user1, user2]);
 
@@ -341,14 +341,14 @@ describe('MessageService', () => {
           reportMissing: true,
           conversationId: 'convid',
         });
-        expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledTimes(2);
+        expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledTimes(2);
       });
 
       it('continues message sending if onClientMismatch returns true', async () => {
         const onClientMismatch = jasmine.createSpy().and.returnValue(Promise.resolve(true));
         const clientMismatch = {...baseClientMismatch, missing: {[user2.id]: ['client22']}};
         let spyCounter = 0;
-        spyOn(apiClient.conversation.api, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -360,7 +360,7 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseClientMismatch);
         });
-        spyOn(apiClient.user.api, 'postMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
+        spyOn(apiClient.api.user, 'postMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
 
         const recipients = generateRecipients([user1, user2]);
 
@@ -369,14 +369,14 @@ describe('MessageService', () => {
           onClientMismatch,
           conversationId: 'convid',
         });
-        expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledTimes(2);
+        expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledTimes(2);
         expect(onClientMismatch).toHaveBeenCalledWith(clientMismatch);
       });
 
       it('stops message sending if onClientMismatch returns false', async () => {
         const onClientMismatch = jasmine.createSpy().and.returnValue(Promise.resolve(false));
         const clientMismatch = {...baseMessageSendingStatus, missing: {[user2.id]: ['client22']}};
-        spyOn(apiClient.conversation.api, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
           const error = new Error();
           (error as any).response = {
             status: StatusCodes.PRECONDITION_FAILED,
@@ -384,7 +384,7 @@ describe('MessageService', () => {
           };
           return Promise.reject(error);
         });
-        spyOn(apiClient.user.api, 'postMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
+        spyOn(apiClient.api.user, 'postMultiPreKeyBundles').and.returnValue(Promise.resolve({}));
 
         const recipients = generateRecipients([user1, user2]);
 
@@ -393,7 +393,7 @@ describe('MessageService', () => {
           onClientMismatch,
           conversationId: 'convid',
         });
-        expect(apiClient.conversation.api.postOTRMessage).toHaveBeenCalledTimes(1);
+        expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledTimes(1);
         expect(onClientMismatch).toHaveBeenCalledWith(clientMismatch);
       });
     });

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -217,7 +217,7 @@ export class MessageService {
 
     const {id, domain} = options.conversationId;
 
-    return this.apiClient.conversation.api.postOTRMessageV2(id, domain, protoMessage);
+    return this.apiClient.api.conversation.postOTRMessageV2(id, domain, protoMessage);
   }
 
   private async sendOTRMessage(
@@ -246,8 +246,8 @@ export class MessageService {
     }
 
     return !options.conversationId
-      ? this.apiClient.broadcast.api.postBroadcastMessage(sendingClientId, message, ignoreMissing)
-      : this.apiClient.conversation.api.postOTRMessage(sendingClientId, options.conversationId, message, ignoreMissing);
+      ? this.apiClient.api.broadcast.postBroadcastMessage(sendingClientId, message, ignoreMissing)
+      : this.apiClient.api.conversation.postOTRMessage(sendingClientId, options.conversationId, message, ignoreMissing);
   }
 
   private async generateExternalPayload(plainText: Uint8Array): Promise<{text: Uint8Array; cipherText: Uint8Array}> {
@@ -296,7 +296,7 @@ export class MessageService {
     // remove deleted clients to the recipients
     deleted.forEach(({userId, data}) => data.forEach(clientId => delete recipients[userId.id][clientId]));
     if (missing.length) {
-      const missingPreKeyBundles = await this.apiClient.user.api.postMultiPreKeyBundles(mismatch.missing);
+      const missingPreKeyBundles = await this.apiClient.api.user.postMultiPreKeyBundles(mismatch.missing);
       const {encrypted} = await this.cryptographyService.encrypt(plainText, missingPreKeyBundles);
       const reEncryptedPayloads = flattenUserClients<{[client: string]: Uint8Array}>(encrypted);
       // add missing clients to the recipients
@@ -326,7 +326,7 @@ export class MessageService {
     );
 
     if (Object.keys(missing).length) {
-      const missingPreKeyBundles = await this.apiClient.user.api.postQualifiedMultiPreKeyBundles(mismatch.missing);
+      const missingPreKeyBundles = await this.apiClient.api.user.postQualifiedMultiPreKeyBundles(mismatch.missing);
       const {encrypted} = await this.cryptographyService.encryptQualified(plainText, missingPreKeyBundles);
       const reEncryptedPayloads = flattenQualifiedUserClients<{[client: string]: Uint8Array}>(encrypted);
       reEncryptedPayloads.forEach(
@@ -380,8 +380,8 @@ export class MessageService {
     }
 
     return !options.conversationId
-      ? this.apiClient.broadcast.api.postBroadcastProtobufMessage(sendingClientId, protoMessage, ignoreMissing)
-      : this.apiClient.conversation.api.postOTRProtobufMessage(
+      ? this.apiClient.api.broadcast.postBroadcastProtobufMessage(sendingClientId, protoMessage, ignoreMissing)
+      : this.apiClient.api.conversation.postOTRProtobufMessage(
           sendingClientId,
           options.conversationId,
           protoMessage,

--- a/packages/core/src/main/giphy/GiphyService.ts
+++ b/packages/core/src/main/giphy/GiphyService.ts
@@ -24,14 +24,14 @@ export class GiphyService {
   constructor(private readonly apiClient: APIClient) {}
 
   public getRandomGif(tag?: string, rating?: GIPHY_RATING): Promise<GiphyResult> {
-    return this.apiClient.giphy.api.getGiphyRandom({rating, tag});
+    return this.apiClient.api.giphy.getGiphyRandom({rating, tag});
   }
 
   public getTrendingGif(rating?: GIPHY_RATING): Promise<GiphyMultipleResult> {
-    return this.apiClient.giphy.api.getGiphyTrending({rating});
+    return this.apiClient.api.giphy.getGiphyTrending({rating});
   }
 
   public searchGif(options: GiphySearchOptions): Promise<GiphyMultipleResult> {
-    return this.apiClient.giphy.api.getGiphySearch(options);
+    return this.apiClient.api.giphy.getGiphySearch(options);
   }
 }

--- a/packages/core/src/main/notification/NotificationBackendRepository.ts
+++ b/packages/core/src/main/notification/NotificationBackendRepository.ts
@@ -24,10 +24,10 @@ export class NotificationBackendRepository {
   constructor(private readonly apiClient: APIClient) {}
 
   public async getAllNotifications(clientId?: string, lastNotificationId?: string): Promise<Notification[]> {
-    return this.apiClient.notification.api.getAllNotifications(clientId, lastNotificationId);
+    return this.apiClient.api.notification.getAllNotifications(clientId, lastNotificationId);
   }
 
   public getLastNotification(clientId?: string): Promise<Notification> {
-    return this.apiClient.notification.api.getLastNotification(clientId);
+    return this.apiClient.api.notification.getLastNotification(clientId);
   }
 }

--- a/packages/core/src/main/self/SelfService.ts
+++ b/packages/core/src/main/self/SelfService.ts
@@ -29,18 +29,18 @@ export class SelfService {
   }
 
   public checkUsernames(usernames: string[]): Promise<string[]> {
-    return this.apiClient.user.api.postHandles({
+    return this.apiClient.api.user.postHandles({
       handles: usernames,
     });
   }
 
   public async getName(): Promise<string> {
-    const {name} = await this.apiClient.self.api.getName();
+    const {name} = await this.apiClient.api.self.getName();
     return name;
   }
 
   public async getSelf(): Promise<Self> {
-    const selfData = await this.apiClient.self.api.getSelf();
+    const selfData = await this.apiClient.api.self.getSelf();
     return selfData;
   }
 
@@ -50,10 +50,10 @@ export class SelfService {
   }
 
   public setName(name: string): Promise<void> {
-    return this.apiClient.self.api.putSelf({name});
+    return this.apiClient.api.self.putSelf({name});
   }
 
   public setUsername(username: string): Promise<void> {
-    return this.apiClient.self.api.putHandle({handle: username});
+    return this.apiClient.api.self.putHandle({handle: username});
   }
 }

--- a/packages/core/src/main/user/UserService.ts
+++ b/packages/core/src/main/user/UserService.ts
@@ -48,7 +48,7 @@ export class UserService {
   }
 
   public getUser(userId: string | QualifiedId): Promise<User> {
-    return this.apiClient.user.api.getUser(userId as QualifiedId);
+    return this.apiClient.api.user.getUser(userId as QualifiedId);
   }
 
   public async getUsers(userIds: string[] | QualifiedId[]): Promise<User[]> {
@@ -56,8 +56,8 @@ export class UserService {
       return [];
     }
     return isQualifiedIdArray(userIds)
-      ? this.apiClient.user.api.postListUsers({qualified_ids: userIds})
-      : this.apiClient.user.api.getUsers({ids: userIds});
+      ? this.apiClient.api.user.postListUsers({qualified_ids: userIds})
+      : this.apiClient.api.user.getUsers({ids: userIds});
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE: All the specific api accessible from the apiClient have moved from `apiClient.<specificApi>.api` to `apiClient.api.<specificApi>` (eg. `apiClient.auth.api` needs to be replaced with `apiClient.api.auth`)


This will soon be needed once we can choose the apiVersion that we want to support (we will need to reinstantiate all the apis with the selected version). 