### PR TITLE
fix(react-ui-kit/accessibility): add aria-hidden to error message icon #ACC-23

### DIFF
--- a/packages/react-ui-kit/src/Form/ErrorMessage.tsx
+++ b/packages/react-ui-kit/src/Form/ErrorMessage.tsx
@@ -45,7 +45,7 @@ export const filterErrorMessageProps = (props: ErrorMessageProps) => {
 
 export const ErrorMessage = ({children, ...props}: ErrorMessageProps) => (
   <FlexBox css={theme => errorMessageStyle(theme, props)} {...props}>
-    <ErrorIcon style={{marginRight: '8px'}} />
+    <ErrorIcon style={{marginRight: '8px'}} aria-hidden="true" />
     <Text color={COLOR.RED} fontSize={'11px'}>
       {children}
     </Text>

--- a/packages/react-ui-kit/src/Form/__snapshots__/ErrorMessage.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/ErrorMessage.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`"ErrorMessage" renders 1`] = `
     className="emotion-2"
   >
     <svg
+      aria-hidden="true"
       className="emotion-0"
       height={12}
       style={


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes

Description:
In the application's, the decorative SVG graphics buttons, are not hidden with aria-hidden="true" for assistive technologies and are output when reading linearly with a screen reader.