### PR TITLE
refactor: Cleanup storage initialization

### DIFF
--- a/packages/bot-api/src/Bot.ts
+++ b/packages/bot-api/src/Bot.ts
@@ -91,7 +91,7 @@ export class Bot extends MessageHandler {
       await storeEngine?.updateOrCreate(AUTH_TABLE_NAME, AUTH_ACCESS_TOKEN_KEY, accessToken);
     });
 
-    this.account = storeEngine ? new Account(apiClient, () => Promise.resolve(storeEngine)) : new Account(apiClient);
+    this.account = new Account(apiClient, {createStore: () => Promise.resolve(storeEngine)});
 
     for (const payloadType of Object.values(PayloadBundleType)) {
       this.account.removeAllListeners(payloadType);
@@ -103,10 +103,10 @@ export class Bot extends MessageHandler {
         throw new Error('Store engine not provided');
       }
       const cookie = await this.getCookie(storeEngine);
-      await this.account.init(this.config.clientType, cookie, storeEngine);
+      await this.account.init(this.config.clientType, cookie);
     } catch (error) {
       this.logger.warn('Failed to init account from cookie', error);
-      await this.account.login(login, true, undefined, storeEngine);
+      await this.account.login(login);
     }
 
     await this.account.listen();

--- a/packages/bot-api/src/MessageHandler.test.node.ts
+++ b/packages/bot-api/src/MessageHandler.test.node.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {MemoryEngine} from '@wireapp/store-engine';
 import {MessageHandler} from '@wireapp/bot-api';
 import {Account} from '@wireapp/core';
 import {CONVERSATION_TYPING} from '@wireapp/api-client/src/conversation/data/';
@@ -41,7 +40,7 @@ describe('MessageHandler', () => {
   beforeEach(async () => {
     mainHandler = new MainHandler();
     mainHandler.account = new Account();
-    await mainHandler.account!.initServices(new MemoryEngine());
+    await mainHandler.account!.initServices({userId: 'user-id', clientType: ClientType.NONE});
     await mainHandler.account!['apiClient']['createContext']('user-id', ClientType.NONE);
 
     spyOn(mainHandler.account!.service!.conversation, 'send').and.returnValue(Promise.resolve({} as TextMessage));

--- a/packages/changelog-bot/src/main/ChangelogBot.ts
+++ b/packages/changelog-bot/src/main/ChangelogBot.ts
@@ -57,7 +57,7 @@ export class ChangelogBot {
 
     const client = new APIClient({urls: backendUrls});
 
-    const account = new Account(client, () => Promise.resolve(engine));
+    const account = new Account(client, {createStore: () => Promise.resolve(engine)});
     try {
       await account.login(this.loginData);
     } catch (error) {

--- a/packages/cli-client/src/index.ts
+++ b/packages/cli-client/src/index.ts
@@ -72,7 +72,7 @@ const storeEngineProvider = async (storeName: string) => {
 };
 
 const apiClient = new APIClient({urls: APIClient.BACKEND.PRODUCTION});
-const account = new Account(apiClient, storeEngineProvider);
+const account = new Account(apiClient, {createStore: storeEngineProvider});
 
 account.on(PayloadBundleType.TEXT, textMessage => {
   console.info(

--- a/packages/core/src/demo/sendCounter.ts
+++ b/packages/core/src/demo/sendCounter.ts
@@ -73,7 +73,7 @@ const {
   await engine.init('sender', {fileExtension: '.json'});
 
   const apiClient = new APIClient({urls: backend});
-  const account = new Account(apiClient, () => Promise.resolve(engine));
+  const account = new Account(apiClient, {createStore: () => Promise.resolve(engine)});
   await account.login(login);
   await account.listen();
 

--- a/packages/core/src/demo/sender.ts
+++ b/packages/core/src/demo/sender.ts
@@ -81,7 +81,7 @@ const {
   await engine.init('sender', {fileExtension: '.json'});
 
   const apiClient = new APIClient({urls: backend});
-  const account = new Account(apiClient, () => Promise.resolve(engine));
+  const account = new Account(apiClient, {createStore: () => Promise.resolve(engine)});
   await account.login(login);
   await account.listen();
 

--- a/packages/core/src/demo/status-bot.ts
+++ b/packages/core/src/demo/status-bot.ts
@@ -63,7 +63,7 @@ if (!message) {
   await engine.init('');
 
   const apiClient = new APIClient({urls: APIClient.BACKEND.PRODUCTION});
-  const account = new Account(apiClient, () => Promise.resolve(engine));
+  const account = new Account(apiClient, {createStore: () => Promise.resolve(engine)});
   await account.login(login);
 
   const text = message || `I am posting from ${name} v${version}. 🌞`;

--- a/packages/core/src/main/Account.test.node.ts
+++ b/packages/core/src/main/Account.test.node.ts
@@ -28,7 +28,6 @@ import {Notification, NotificationAPI} from '@wireapp/api-client/src/notificatio
 import {AccentColor, ValidationUtil} from '@wireapp/commons';
 import {GenericMessage, Text} from '@wireapp/protocol-messaging';
 import * as Proteus from '@wireapp/proteus';
-import {MemoryEngine} from '@wireapp/store-engine';
 import nock = require('nock');
 import {Account} from './Account';
 import {PayloadBundleSource, PayloadBundleType} from './conversation';
@@ -44,7 +43,10 @@ const MOCK_BACKEND = {
 async function createAccount(storageName = `test-${Date.now()}`): Promise<Account> {
   const apiClient = new APIClient({urls: MOCK_BACKEND});
   const account = new Account(apiClient);
-  await account.initServices(new MemoryEngine());
+  await account.initServices({
+    clientType: ClientType.TEMPORARY,
+    userId: '',
+  });
   return account;
 }
 
@@ -153,7 +155,7 @@ describe('Account', () => {
     it('initializes the Protocol buffers', async () => {
       const account = new Account();
 
-      await account.initServices(new MemoryEngine());
+      await account.initServices({clientType: ClientType.TEMPORARY, userId: ''});
 
       expect(account.service!.conversation).toBeDefined();
       expect(account.service!.cryptography).toBeDefined();
@@ -172,7 +174,7 @@ describe('Account', () => {
       const apiClient = new APIClient({urls: MOCK_BACKEND});
       const account = new Account(apiClient);
 
-      await account.initServices(new MemoryEngine());
+      await account.initServices({clientType: ClientType.TEMPORARY, userId: ''});
       const {clientId, clientType, userId} = await account.login({
         clientType: ClientType.TEMPORARY,
         email: 'hello@example.com',
@@ -188,7 +190,7 @@ describe('Account', () => {
       const apiClient = new APIClient({urls: MOCK_BACKEND});
       const account = new Account(apiClient);
 
-      await account.initServices(new MemoryEngine());
+      await account.initServices({clientType: ClientType.TEMPORARY, userId: ''});
 
       try {
         await account.login({

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -95,12 +95,12 @@ export interface Account {
   on(event: TOPIC.ERROR, listener: (payload: CoreError) => void): this;
 }
 
-export type StoreEngineProvider = (storeName: string) => Promise<CRUDEngine>;
+export type CreateStoreFn = (storeName: string, context: Context) => undefined | Promise<CRUDEngine | undefined>;
 
 export class Account extends EventEmitter {
   private readonly apiClient: APIClient;
   private readonly logger: logdown.Logger;
-  private readonly storeEngineProvider: StoreEngineProvider;
+  private readonly createStore: CreateStoreFn;
   private storeEngine?: CRUDEngine;
 
   public static readonly TOPIC = TOPIC;
@@ -123,21 +123,16 @@ export class Account extends EventEmitter {
 
   /**
    * @param apiClient The apiClient instance to use in the core (will create a new new one if undefined)
-   * @param storeEngineProvider Used to store info in the database (will create a inMemory engine if undefined)
+   * @param storeEngineProvider Used to store info in the database (will create a inMemory engine if returns undefined)
    */
-  constructor(apiClient: APIClient = new APIClient(), storeEngineProvider?: StoreEngineProvider) {
+  constructor(
+    apiClient: APIClient = new APIClient(),
+    {createStore = () => undefined, enableMls}: {createStore?: CreateStoreFn; enableMls?: boolean} = {},
+  ) {
     super();
     this.apiClient = apiClient;
     this.backendFeatures = this.apiClient.backendFeatures;
-    if (storeEngineProvider) {
-      this.storeEngineProvider = storeEngineProvider;
-    } else {
-      this.storeEngineProvider = async (storeName: string) => {
-        const engine = new MemoryEngine();
-        await engine.init(storeName);
-        return engine;
-      };
-    }
+    this.createStore = createStore;
 
     apiClient.on(APIClient.TOPIC.COOKIE_REFRESH, async (cookie?: Cookie) => {
       if (cookie && this.storeEngine) {
@@ -170,37 +165,29 @@ export class Account extends EventEmitter {
 
   public async register(registration: RegisterData, clientType: ClientType): Promise<Context> {
     const context = await this.apiClient.register(registration, clientType);
-    const storeEngine = await this.initEngine(context);
-    await this.initServices(storeEngine);
+    await this.initServices(context);
     return context;
   }
 
-  public async init(clientType: ClientType, cookie?: Cookie, initializedStoreEngine?: CRUDEngine): Promise<Context> {
+  public async init(clientType: ClientType, cookie?: Cookie, initClient: boolean = true): Promise<Context> {
     const context = await this.apiClient.init(clientType, cookie);
-    if (initializedStoreEngine) {
-      this.storeEngine = initializedStoreEngine;
-      this.logger.log(`Initialized store with existing engine "${this.storeEngine.storeName}".`);
-    } else {
-      this.storeEngine = await this.initEngine(context);
-    }
-    await this.initServices(this.storeEngine);
-    if (initializedStoreEngine) {
-      await this.initClient({
-        clientType,
-      });
+    await this.initServices(context);
+    if (initClient) {
+      await this.initClient({clientType});
     }
     return context;
   }
 
-  public async initServices(storeEngine: CRUDEngine): Promise<void> {
+  public async initServices(context: Context): Promise<void> {
+    this.storeEngine = await this.initEngine(context);
     const accountService = new AccountService(this.apiClient);
     const assetService = new AssetService(this.apiClient);
-    const cryptographyService = new CryptographyService(this.apiClient, storeEngine, {
+    const cryptographyService = new CryptographyService(this.apiClient, this.storeEngine, {
       // We want to encrypt with fully qualified session ids, only if the backend is federated with other backends
       useQualifiedIds: this.backendFeatures.isFederated,
     });
 
-    const clientService = new ClientService(this.apiClient, storeEngine, cryptographyService);
+    const clientService = new ClientService(this.apiClient, this.storeEngine, cryptographyService);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);
@@ -208,7 +195,7 @@ export class Account extends EventEmitter {
       // We can use qualified ids to send messages as long as the backend supports federated endpoints
       useQualifiedIds: this.backendFeatures.federationEndpoints,
     });
-    const notificationService = new NotificationService(this.apiClient, cryptographyService, storeEngine);
+    const notificationService = new NotificationService(this.apiClient, cryptographyService, this.storeEngine);
     const selfService = new SelfService(this.apiClient);
     const teamService = new TeamService(this.apiClient);
 
@@ -232,23 +219,12 @@ export class Account extends EventEmitter {
     };
   }
 
-  public async login(
-    loginData: LoginData,
-    initClient: boolean = true,
-    clientInfo?: ClientInfo,
-    initializedStoreEngine?: CRUDEngine,
-  ): Promise<Context> {
+  public async login(loginData: LoginData, initClient: boolean = true, clientInfo?: ClientInfo): Promise<Context> {
     this.resetContext();
     LoginSanitizer.removeNonPrintableCharacters(loginData);
 
     const context = await this.apiClient.login(loginData);
-    if (initializedStoreEngine) {
-      this.storeEngine = initializedStoreEngine;
-      this.logger.log(`Initialized store with existing engine "${this.storeEngine.storeName}".`);
-    } else {
-      this.storeEngine = await this.initEngine(context);
-    }
-    await this.initServices(this.storeEngine);
+    await this.initServices(context);
 
     if (initClient) {
       await this.initClient(loginData, clientInfo);
@@ -396,11 +372,22 @@ export class Account extends EventEmitter {
     const clientType = context.clientType === ClientType.NONE ? '' : `@${context.clientType}`;
     const dbName = `wire@${this.apiClient.config.urls.name}@${context.userId}${clientType}`;
     this.logger.log(`Initialising store with name "${dbName}"...`);
-    this.storeEngine = await this.storeEngineProvider(dbName);
+    const openDb = async () => {
+      const initializedDb = await this.createStore(dbName, context);
+      if (initializedDb) {
+        this.logger.log(`Initialized store with existing engine "${dbName}".`);
+        return initializedDb;
+      }
+      this.logger.log(`Initialized store with new memory engine "${dbName}".`);
+      const memoryEngine = new MemoryEngine();
+      await memoryEngine.init(dbName);
+      return memoryEngine;
+    };
+    const storeEngine = await openDb();
     const cookie = CookieStore.getCookie();
     if (cookie) {
-      await this.persistCookie(this.storeEngine, cookie);
+      await this.persistCookie(storeEngine, cookie);
     }
-    return this.storeEngine;
+    return storeEngine;
   }
 }

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -127,7 +127,7 @@ export class Account extends EventEmitter {
    */
   constructor(
     apiClient: APIClient = new APIClient(),
-    {createStore = () => undefined, enableMls}: {createStore?: CreateStoreFn; enableMls?: boolean} = {},
+    {createStore = () => undefined}: {createStore?: CreateStoreFn} = {},
   ) {
     super();
     this.apiClient = apiClient;


### PR DESCRIPTION
This PR harmonizes how an already initialized database can be given to the core.

Initially, there was 3 different methods where a db could be given. They would all have slightly different behavior and would mean exactly the same thing:
- either in the constructor of the Core, give a `storeEngineProvider` that will be called when a database needs to be accessed by the core
- or in the `login` or `init` methods give a direct instance of a database
- or overwrite the `storageEngine` of the instance directly (hack). 

Now there is only a single way to give an already existing database: add the `createStore` option in the constructor. 
This function will be called with the `storeName` and `context` so that the consumer can decide what kind of database should be given depending on the type of the device add (permanent, temporary or none). 

BREAKING CHANGE: 
- The constructor signature now changes.
If you were doing

```js
const account = new Account(apiClient, createStoreEngine);
```

Now you need to do 

```js
const account = new Account(apiClient, {createStore: createStoreEngine});
```

- The `login` and `init` function do not take a storage engine parameter anymore. You now need to give a `createStore` function to the constructor in order to give a custom storage engine to the core. 

BEFORE

```js
const account = new Accoun(apiClient);

account.login(data, initClient, clientInfo, database);
```

AFTER

```js
const account = new Accoun(apiClient, {createStore: () => database});

account.login(data, initClient, clientInfo);
```