### PR TITLE
fix: Allow sending targeted lastRead and Countly messages

### DIFF
--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -703,10 +703,16 @@ export class ConversationService {
    *
    * @param conversationId The conversation which has been read
    * @param lastReadTimestamp The timestamp at which the conversation was read
+   * @param userIds? recipients to send the message to (if not given will fetch all users from backend)
    * @param sendAsProtobuf?
    * @return Resolves when the message has been sent
    */
-  public async sendLastRead(conversationId: string, lastReadTimestamp: number, sendAsProtobuf?: boolean) {
+  public async sendLastRead(
+    conversationId: string,
+    lastReadTimestamp: number,
+    userIds?: QualifiedId[] | QualifiedUserClients,
+    sendAsProtobuf?: boolean,
+  ) {
     const lastRead = new LastRead({
       conversationId,
       lastReadTimestamp,
@@ -722,6 +728,7 @@ export class ConversationService {
     return this.sendGenericMessage(this.apiClient.validatedClientId, selfConversationId, genericMessage, {
       conversationDomain: selfConversationDomain,
       sendAsProtobuf,
+      userIds,
     });
   }
 
@@ -729,10 +736,15 @@ export class ConversationService {
    * Syncs all self user's devices with the countly id
    *
    * @param countlyId The countly id of the current device
+   * @param userIds? recipients to send the message to (if not given will fetch all users from backend)
    * @param sendAsProtobuf?
    * @return Resolves when the message has been sent
    */
-  public async sendCountlySync(countlyId: string, sendAsProtobuf?: boolean) {
+  public async sendCountlySync(
+    countlyId: string,
+    userIds: QualifiedId[] | QualifiedUserClients,
+    sendAsProtobuf?: boolean,
+  ) {
     const {id: selfConversationId, domain: selfConversationDomain} = await this.getSelfConversationId();
 
     const dataTransfer = new DataTransfer({
@@ -748,6 +760,7 @@ export class ConversationService {
     return this.sendGenericMessage(this.apiClient.validatedClientId, selfConversationId, genericMessage, {
       conversationDomain: selfConversationDomain,
       sendAsProtobuf,
+      userIds,
     });
   }
 

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -703,16 +703,10 @@ export class ConversationService {
    *
    * @param conversationId The conversation which has been read
    * @param lastReadTimestamp The timestamp at which the conversation was read
-   * @param userIds? recipients to send the message to (if not given will fetch all users from backend)
-   * @param sendAsProtobuf?
+   * @param sendingOptions?
    * @return Resolves when the message has been sent
    */
-  public async sendLastRead(
-    conversationId: string,
-    lastReadTimestamp: number,
-    userIds?: QualifiedId[] | QualifiedUserClients,
-    sendAsProtobuf?: boolean,
-  ) {
+  public async sendLastRead(conversationId: string, lastReadTimestamp: number, sendingOptions?: MessageSendingOptions) {
     const lastRead = new LastRead({
       conversationId,
       lastReadTimestamp,
@@ -727,8 +721,7 @@ export class ConversationService {
 
     return this.sendGenericMessage(this.apiClient.validatedClientId, selfConversationId, genericMessage, {
       conversationDomain: selfConversationDomain,
-      sendAsProtobuf,
-      userIds,
+      ...sendingOptions,
     });
   }
 
@@ -736,15 +729,10 @@ export class ConversationService {
    * Syncs all self user's devices with the countly id
    *
    * @param countlyId The countly id of the current device
-   * @param userIds? recipients to send the message to (if not given will fetch all users from backend)
-   * @param sendAsProtobuf?
+   * @param sendingOptions?
    * @return Resolves when the message has been sent
    */
-  public async sendCountlySync(
-    countlyId: string,
-    userIds: QualifiedId[] | QualifiedUserClients,
-    sendAsProtobuf?: boolean,
-  ) {
+  public async sendCountlySync(countlyId: string, sendingOptions: MessageSendingOptions) {
     const {id: selfConversationId, domain: selfConversationDomain} = await this.getSelfConversationId();
 
     const dataTransfer = new DataTransfer({
@@ -759,8 +747,7 @@ export class ConversationService {
 
     return this.sendGenericMessage(this.apiClient.validatedClientId, selfConversationId, genericMessage, {
       conversationDomain: selfConversationDomain,
-      sendAsProtobuf,
-      userIds,
+      ...sendingOptions,
     });
   }
 


### PR DESCRIPTION
When sending `lastRead` or `Countly` message, the consumer cannot give an explicit list of users to send to. 
This is a performance issue as the core will then try to download all the members of the conversation and send that message to all of them (useless back and forth with backend). 

Also since the backend returns all the members including the current device, we will try to create a session with the device the user is currently using which makes very little sense. 

BREAKING CHANGE: To send `lastRead` and `countly` as protobuf message, you now need to provide a `MessageSendingOptions` object as last parameter. 

```js
core.service.conversation.sendLastRead(conversation, timestamp, true);

// Becomes

core.service.converstaion.sendLastRead(conversation, timestamp, {sendAsProtobuf: true});
```