### PR TITLE
feat: Allow consumer to set number of prekeys generated

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -100,7 +100,16 @@ export type CreateStoreFn = (storeName: string, context: Context) => undefined |
 interface AccountOptions {
   /** Used to store info in the database (will create a inMemory engine if returns undefined) */
   createStore?: CreateStoreFn;
-  /** Number of prekeys to generate when creating a new device (defaults to 100) */
+
+  /** Number of prekeys to generate when creating a new device (defaults to 100)
+   * Prekeys are a way to create unique secured sessions between two devices.
+   * Having a high value will:
+   *    - make creating a new device consuming more CPU resources
+   *    - make it possible that the user creates multiple session with multiple users without needing to create new prekeys (or be connected)
+   * Having a low value will:
+   *    - make creating a new device fast
+   *    - make it likely that the user runs out of prekeys and the last resort prekey is needed to create new session
+   */
   nbPrekeys?: number;
 }
 
@@ -109,7 +118,7 @@ export class Account extends EventEmitter {
   private readonly logger: logdown.Logger;
   private readonly createStore: CreateStoreFn;
   private storeEngine?: CRUDEngine;
-  private readonly nbPrekeys?: number;
+  private readonly nbPrekeys: number;
 
   public static readonly TOPIC = TOPIC;
   public service?: {
@@ -135,7 +144,7 @@ export class Account extends EventEmitter {
    */
   constructor(
     apiClient: APIClient = new APIClient(),
-    {createStore = () => undefined, nbPrekeys}: AccountOptions = {nbPrekeys: 2},
+    {createStore = () => undefined, nbPrekeys = 2}: AccountOptions = {},
   ) {
     super();
     this.apiClient = apiClient;

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -135,7 +135,7 @@ export class Account extends EventEmitter {
    */
   constructor(
     apiClient: APIClient = new APIClient(),
-    {createStore = () => undefined, nbPrekeys}: AccountOptions = {nbPrekeys: 100},
+    {createStore = () => undefined, nbPrekeys}: AccountOptions = {nbPrekeys: 2},
   ) {
     super();
     this.apiClient = apiClient;

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -101,7 +101,7 @@ interface AccountOptions {
   /** Used to store info in the database (will create a inMemory engine if returns undefined) */
   createStore?: CreateStoreFn;
 
-  /** Number of prekeys to generate when creating a new device (defaults to 100)
+  /** Number of prekeys to generate when creating a new device (defaults to 2)
    * Prekeys are Diffie-Hellmann public keys which allow offline initiation of a secure Proteus session between two devices.
    * Having a high value will:
    *    - make creating a new device consuming more CPU resources

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -102,13 +102,13 @@ interface AccountOptions {
   createStore?: CreateStoreFn;
 
   /** Number of prekeys to generate when creating a new device (defaults to 100)
-   * Prekeys are a way to create unique secured sessions between two devices.
+   * Prekeys are Diffie-Hellmann public keys which allow offline initiation of a secure Proteus session between two devices.
    * Having a high value will:
    *    - make creating a new device consuming more CPU resources
-   *    - make it possible that the user creates multiple session with multiple users without needing to create new prekeys (or be connected)
+   *    - make it less likely that all prekeys get consumed while the device is offline and the last resort prekey will not be used to create new session
    * Having a low value will:
    *    - make creating a new device fast
-   *    - make it likely that the user runs out of prekeys and the last resort prekey is needed to create new session
+   *    - make it likely that all prekeys get consumed while the device is offline and the last resort prekey will be used to create new session
    */
   nbPrekeys?: number;
 }

--- a/packages/core/src/main/conversation/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService.test.node.ts
@@ -37,9 +37,13 @@ describe('ConversationService', () => {
       userId: PayloadHelper.getUUID(),
       clientId: PayloadHelper.getUUID(),
     };
-    return new ConversationService(client, new CryptographyService(client, new MemoryEngine()), {
-      useQualifiedIds: federated,
-    });
+    return new ConversationService(
+      client,
+      new CryptographyService(client, new MemoryEngine(), {useQualifiedIds: false, nbPrekeys: 1}),
+      {
+        useQualifiedIds: federated,
+      },
+    );
   }
 
   describe('"send"', () => {

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -88,7 +88,7 @@ function fakeEncrypt(
 
 describe('MessageService', () => {
   const apiClient = new APIClient();
-  const cryptographyService = new CryptographyService(apiClient, {} as any);
+  const cryptographyService = new CryptographyService(apiClient, {} as any, {useQualifiedIds: false, nbPrekeys: 1});
   const messageService = new MessageService(apiClient, cryptographyService);
 
   beforeEach(() => {

--- a/packages/core/src/main/cryptography/CryptographyService.test.browser.js
+++ b/packages/core/src/main/cryptography/CryptographyService.test.browser.js
@@ -41,7 +41,7 @@ describe('CryptographyService', () => {
   });
 
   beforeEach(async () => {
-    cryptography = new CryptographyService(undefined, await createEngine('wire'), undefined);
+    cryptography = new CryptographyService(undefined, await createEngine('wire'), {useQualifiedIds: false, nbPrekeys: 1});
     const preKeys = await cryptography.cryptobox.create();
     aliceLastResortPreKey = preKeys.filter(preKey => preKey.key_id === Proteus.keys.PreKey.MAX_PREKEY_ID)[0];
     bob = new Cryptobox(await createEngine('wire'));
@@ -59,7 +59,7 @@ describe('CryptographyService', () => {
     it('constructs a Session ID by a given User ID and Client ID.', async () => {
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
-      cryptography = new CryptographyService(undefined, await createEngine('wire'), undefined);
+      cryptography = new CryptographyService(undefined, await createEngine('wire'), {useQualifiedIds: false, nbPrekeys: 1});
       const actual = cryptography.constructSessionId(userId, clientId);
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -46,7 +46,10 @@ describe('CryptographyService', () => {
   });
 
   beforeEach(async () => {
-    cryptographyService = new CryptographyService(new APIClient(), await createEngine('wire'));
+    cryptographyService = new CryptographyService(new APIClient(), await createEngine('wire'), {
+      nbPrekeys: 1,
+      useQualifiedIds: false,
+    });
     const preKeys = await cryptographyService.cryptobox.create();
     aliceLastResortPreKey = preKeys.filter(preKey => preKey.key_id === Proteus.keys.PreKey.MAX_PREKEY_ID)[0];
     bob = new Cryptobox(await createEngine('wire'));
@@ -72,6 +75,7 @@ describe('CryptographyService', () => {
     it('constructs a Session ID by a given User ID and Client ID and domain.', async () => {
       const cryptographyService = new CryptographyService(new APIClient(), await createEngine('wire'), {
         useQualifiedIds: true,
+        nbPrekeys: 1,
       });
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
@@ -84,6 +88,7 @@ describe('CryptographyService', () => {
     it('constructs a qualified Session ID by a given qualified User ID and Client ID.', async () => {
       const cryptographyService = new CryptographyService(new APIClient(), await createEngine('wire'), {
         useQualifiedIds: true,
+        nbPrekeys: 1,
       });
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -58,7 +58,7 @@ export class CryptographyService {
   constructor(
     readonly apiClient: APIClient,
     private readonly storeEngine: CRUDEngine,
-    private readonly config: {useQualifiedIds?: boolean; nbPrekeys?: number} = {nbPrekeys: 2},
+    private readonly config: {useQualifiedIds: boolean; nbPrekeys: number},
   ) {
     this.cryptobox = new Cryptobox(this.storeEngine, config.nbPrekeys);
     this.database = new CryptographyDatabaseRepository(this.storeEngine);

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -58,9 +58,9 @@ export class CryptographyService {
   constructor(
     readonly apiClient: APIClient,
     private readonly storeEngine: CRUDEngine,
-    private readonly config: {useQualifiedIds?: boolean} = {},
+    private readonly config: {useQualifiedIds?: boolean; nbPrekeys?: number} = {nbPrekeys: 2},
   ) {
-    this.cryptobox = new Cryptobox(this.storeEngine);
+    this.cryptobox = new Cryptobox(this.storeEngine, config.nbPrekeys);
     this.database = new CryptographyDatabaseRepository(this.storeEngine);
     this.logger = logdown('@wireapp/core/cryptography/CryptographyService', {
       logger: console,


### PR DESCRIPTION
Will allow the consumer to set a number of prekeys to generate. 

As of now it defaults to 1, which means that we only ever use the last resort prekey. 
This will allow generating more prekeys and let cryptobox generate new as they are consumed