### PR TITLE
feat: Add missed notifications hook

### DIFF
--- a/packages/api-client/src/notification/NotificationAPI.ts
+++ b/packages/api-client/src/notification/NotificationAPI.ts
@@ -25,8 +25,8 @@ import type {Notification, NotificationList} from './';
 export const NOTIFICATION_SIZE_MAXIMUM = 10000;
 
 type NotificationsReponse = {
-  notifications: Notification[]; 
-  missedNotification?: string
+  notifications: Notification[];
+  missedNotification?: string;
 };
 
 export class NotificationAPI {
@@ -94,9 +94,9 @@ export class NotificationAPI {
       currentNotificationId?: string,
     ): Promise<NotificationsReponse> => {
       let payload: NotificationList = {
-        notifications: [], 
-        time: '0', 
-        has_more: false
+        notifications: [],
+        time: '0',
+        has_more: false,
       };
       let hasMissedNotifications = false;
       try {

--- a/packages/api-client/src/notification/NotificationAPI.ts
+++ b/packages/api-client/src/notification/NotificationAPI.ts
@@ -24,7 +24,11 @@ import type {Notification, NotificationList} from './';
 
 export const NOTIFICATION_SIZE_MAXIMUM = 10000;
 
-type NotificationsReponse = {notifications: Notification[]; missedNotification?: string};
+type NotificationsReponse = {
+  notifications: Notification[]; 
+  missedNotification?: string
+};
+
 export class NotificationAPI {
   constructor(private readonly client: HttpClient) {}
 
@@ -89,7 +93,11 @@ export class NotificationAPI {
       currentClientId?: string,
       currentNotificationId?: string,
     ): Promise<NotificationsReponse> => {
-      let payload: NotificationList = {notifications: [], time: '0', has_more: false};
+      let payload: NotificationList = {
+        notifications: [], 
+        time: '0', 
+        has_more: false
+      };
       let hasMissedNotifications = false;
       try {
         payload = await this.getNotifications(currentClientId, NOTIFICATION_SIZE_MAXIMUM, currentNotificationId);

--- a/packages/core/src/main/notification/NotificationBackendRepository.ts
+++ b/packages/core/src/main/notification/NotificationBackendRepository.ts
@@ -23,7 +23,7 @@ import type {Notification} from '@wireapp/api-client/src/notification/';
 export class NotificationBackendRepository {
   constructor(private readonly apiClient: APIClient) {}
 
-  public async getAllNotifications(clientId?: string, lastNotificationId?: string): Promise<Notification[]> {
+  public async getAllNotifications(clientId?: string, lastNotificationId?: string) {
     return this.apiClient.api.notification.getAllNotifications(clientId, lastNotificationId);
   }
 


### PR DESCRIPTION
When fetching the notification stream, if the current client has connected for more than 28 days, we will have notifications that have been missed and removed from the backend. 
This hook allows the consumer to be warned when such missed notifications are detected