### PR TITLE
feat: Add listen dryrun option

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -397,7 +397,7 @@ export class Account extends EventEmitter {
     onConnectionStateChanged = () => {},
     onNotificationStreamProgress = () => {},
     onMissedNotifications = () => {},
-    dryRun,
+    dryRun = false,
   }: {
     /**
      * Called when a new event arrives from backend

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -397,6 +397,7 @@ export class Account extends EventEmitter {
     onConnectionStateChanged = () => {},
     onNotificationStreamProgress = () => {},
     onMissedNotifications = () => {},
+    dryRun,
   }: {
     /**
      * Called when a new event arrives from backend
@@ -428,6 +429,11 @@ export class Account extends EventEmitter {
      * @param  {string} notificationId
      */
     onMissedNotifications?: (notificationId: string) => void;
+
+    /**
+     * When set will not decrypt and not store the last notification ID. This is useful if you only want to subscribe to unencrypted backend events
+     */
+    dryRun?: boolean;
   } = {}): Promise<() => void> {
     if (!this.apiClient.context) {
       throw new Error('Context is not set - please login first');
@@ -454,7 +460,11 @@ export class Account extends EventEmitter {
 
     const handleNotification = async (notification: Notification, source: PayloadBundleSource): Promise<void> => {
       try {
-        const messages = this.service!.notification.handleNotification(notification, PayloadBundleSource.WEBSOCKET);
+        const messages = this.service!.notification.handleNotification(
+          notification,
+          PayloadBundleSource.WEBSOCKET,
+          dryRun,
+        );
         for await (const message of messages) {
           await handleEvent(message, source);
         }

--- a/packages/core/src/main/notification/NotificationService.test.node.ts
+++ b/packages/core/src/main/notification/NotificationService.test.node.ts
@@ -87,6 +87,7 @@ describe('NotificationService', () => {
       );
 
       await handledNotifications.next();
+      await handledNotifications.next();
 
       expect(spySetLastNotificationId.calls.count()).toBe(1);
     });

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -142,7 +142,7 @@ export class NotificationService extends EventEmitter {
   public async *handleNotification(
     notification: Notification,
     source: PayloadBundleSource,
-    dryRun?: boolean,
+    dryRun: boolean = false,
   ): AsyncGenerator<HandledEventPayload> {
     for (const event of notification.payload) {
       this.logger.log(`Handling event of type "${event.type}" for notification with ID "${notification.id}"`, event);
@@ -193,7 +193,7 @@ export class NotificationService extends EventEmitter {
   private async handleEvent(
     event: Events.BackendEvent,
     source: PayloadBundleSource,
-    dryRun?: boolean,
+    dryRun: boolean = false,
   ): Promise<HandledEventPayload> {
     switch (event.type) {
       // Encrypted events

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -142,15 +142,12 @@ export class NotificationService extends EventEmitter {
   public async *handleNotification(
     notification: Notification,
     source: PayloadBundleSource,
+    dryRun?: boolean,
   ): AsyncGenerator<HandledEventPayload> {
     for (const event of notification.payload) {
       this.logger.log(`Handling event of type "${event.type}" for notification with ID "${notification.id}"`, event);
       try {
-        const data = await this.handleEvent(event, source);
-        if (!notification.transient) {
-          // keep track of the last handled notification for next time we fetch the notification stream
-          await this.setLastNotificationId(notification);
-        }
+        const data = await this.handleEvent(event, source, dryRun);
         yield {
           ...data,
           mappedEvent: data.mappedEvent ? this.cleanupPayloadBundle(data.mappedEvent) : undefined,
@@ -168,7 +165,7 @@ export class NotificationService extends EventEmitter {
         this.emit(NotificationService.TOPIC.NOTIFICATION_ERROR, notificationError);
       }
     }
-    if (!notification.transient) {
+    if (!dryRun && !notification.transient) {
       // keep track of the last handled notification for next time we fetch the notification stream
       await this.setLastNotificationId(notification);
     }
@@ -193,10 +190,19 @@ export class NotificationService extends EventEmitter {
     }
   }
 
-  private async handleEvent(event: Events.BackendEvent, source: PayloadBundleSource): Promise<HandledEventPayload> {
+  private async handleEvent(
+    event: Events.BackendEvent,
+    source: PayloadBundleSource,
+    dryRun?: boolean,
+  ): Promise<HandledEventPayload> {
     switch (event.type) {
       // Encrypted events
       case Events.CONVERSATION_EVENT.OTR_MESSAGE_ADD: {
+        if (dryRun) {
+          // In case of a dry run, we do not want to decrypt messages
+          // We just return the raw event to the caller
+          return {event};
+        }
         try {
           const decryptedData = await this.cryptographyService.decryptMessage(event);
           return {


### PR DESCRIPTION
This will allow consumer to just get events without storing the last notification id and not decrypting events
