### PR TITLE
fix(core): Make sure access token is valid before connecting to websocket

### DIFF
--- a/packages/api-client/src/APIClient.test.browser.ts
+++ b/packages/api-client/src/APIClient.test.browser.ts
@@ -41,7 +41,7 @@ describe('Client', () => {
         clientType: ClientType.TEMPORARY,
         userId: 'userId',
       };
-      apiClient['accessTokenStore'].accessToken = accessTokenData;
+      apiClient['accessTokenStore'].accessToken = {...accessTokenData, expireAt: 10000};
 
       const promise = apiClient.connect();
       apiClient.transport.ws['socket']['internalOnMessage'](message);

--- a/packages/api-client/src/APIClient.test.browser.ts
+++ b/packages/api-client/src/APIClient.test.browser.ts
@@ -41,7 +41,7 @@ describe('Client', () => {
         clientType: ClientType.TEMPORARY,
         userId: 'userId',
       };
-      apiClient['accessTokenStore'].accessToken = {...accessTokenData, expireAt: 10000};
+      apiClient['accessTokenStore'].accessToken = accessTokenData;
 
       const promise = apiClient.connect();
       apiClient.transport.ws['socket']['internalOnMessage'](message);

--- a/packages/api-client/src/http/HttpClient.test.node.ts
+++ b/packages/api-client/src/http/HttpClient.test.node.ts
@@ -99,7 +99,7 @@ describe('HttpClient', () => {
     }
   });
 
-  describe('accessTokenIsValid', () => {
+  describe('hasValidAccessToken', () => {
     (
       [
         [{expireAt: Date.now() - 100_000}, false],
@@ -110,7 +110,7 @@ describe('HttpClient', () => {
 
       it(`returns the validation state (${JSON.stringify(tokenData)})`, () => {
         mockedAccessTokenStore.accessToken!.expireAt = tokenData.expireAt;
-        expect(client.accessTokenIsValid()).toBe(expected);
+        expect(client.hasValidAccessToken()).toBe(expected);
       });
     });
   });

--- a/packages/api-client/src/http/HttpClient.test.node.ts
+++ b/packages/api-client/src/http/HttpClient.test.node.ts
@@ -33,6 +33,7 @@ describe('HttpClient', () => {
         'DPOBfBP-uz_b0gAKBQ==.v=1.k=1.d=1498600993.t=a.l=.u=aaf9a833-ef30-4c2' +
         '2-86a0-9adc8a15b3b4.c=15037015562284012115',
       expires_in: 900,
+      expireAt: 10000,
       token_type: 'Bearer',
       user: 'aaf9a833-ef30-4c22-86a0-9adc8a15b3b4',
     },

--- a/packages/api-client/src/http/HttpClient.test.node.ts
+++ b/packages/api-client/src/http/HttpClient.test.node.ts
@@ -33,7 +33,6 @@ describe('HttpClient', () => {
         'DPOBfBP-uz_b0gAKBQ==.v=1.k=1.d=1498600993.t=a.l=.u=aaf9a833-ef30-4c2' +
         '2-86a0-9adc8a15b3b4.c=15037015562284012115',
       expires_in: 900,
-      expireAt: 10000,
       token_type: 'Bearer',
       user: 'aaf9a833-ef30-4c22-86a0-9adc8a15b3b4',
     },
@@ -102,14 +101,14 @@ describe('HttpClient', () => {
   describe('hasValidAccessToken', () => {
     (
       [
-        [{expireAt: Date.now() - 100_000}, false],
-        [{expireAt: Date.now() + 100_000}, true],
+        [Date.now() - 100_000, false],
+        [Date.now() + 100_000, true],
       ] as const
-    ).forEach(([tokenData, expected]) => {
+    ).forEach(([expirationDate, expected]) => {
       const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore);
 
-      it(`returns the validation state (${JSON.stringify(tokenData)})`, () => {
-        mockedAccessTokenStore.accessToken!.expireAt = tokenData.expireAt;
+      it(`returns the validation state (${JSON.stringify(expirationDate)})`, () => {
+        mockedAccessTokenStore.tokenExpirationDate = expirationDate;
         expect(client.hasValidAccessToken()).toBe(expected);
       });
     });

--- a/packages/api-client/src/http/HttpClient.test.node.ts
+++ b/packages/api-client/src/http/HttpClient.test.node.ts
@@ -98,4 +98,20 @@ describe('HttpClient', () => {
       expect((error as BackendError).message).toBe('Authentication failed because the cookie is missing.');
     }
   });
+
+  describe('accessTokenIsValid', () => {
+    (
+      [
+        [{expireAt: Date.now() - 100_000}, false],
+        [{expireAt: Date.now() + 100_000}, true],
+      ] as const
+    ).forEach(([tokenData, expected]) => {
+      const client = new HttpClient(testConfig, mockedAccessTokenStore as AccessTokenStore);
+
+      it(`returns the validation state (${JSON.stringify(tokenData)})`, () => {
+        mockedAccessTokenStore.accessToken!.expireAt = tokenData.expireAt;
+        expect(client.accessTokenIsValid()).toBe(expected);
+      });
+    });
+  });
 });

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -197,6 +197,19 @@ export class HttpClient extends EventEmitter {
     }
     return false;
   }
+  /**
+   * Will return true if the stored access token is still valid (not expired)
+   *
+   * @param  {number} errorMargin - Since the expiration date is subject to time shift between client and server, an error margin can be used. Defaults to 10s
+   */
+  public accessTokenIsValid(errorMargin: number = 10000): boolean {
+    if (this.accessTokenStore.accessToken) {
+      const now = Date.now();
+      const expirationDate = this.accessTokenStore.accessToken.expireAt;
+      return expirationDate - errorMargin < now;
+    }
+    return false;
+  }
 
   public async refreshAccessToken(): Promise<AccessTokenData> {
     let expiredAccessToken: AccessTokenData | undefined;

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -202,7 +202,7 @@ export class HttpClient extends EventEmitter {
    *
    * @param  {number} errorMargin - Since the expiration date is subject to time shift between client and server, an error margin can be used. Defaults to 10s
    */
-  public accessTokenIsValid(errorMargin: number = 10000): boolean {
+  public hasValidAccessToken(errorMargin: number = 10000): boolean {
     if (this.accessTokenStore.accessToken) {
       const now = Date.now();
       const expirationDate = this.accessTokenStore.accessToken.expireAt;

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -203,9 +203,9 @@ export class HttpClient extends EventEmitter {
    * @param  {number} errorMargin - Since the expiration date is subject to time shift between client and server, an error margin can be used. Defaults to 10s
    */
   public hasValidAccessToken(errorMargin: number = 10000): boolean {
-    if (this.accessTokenStore.accessToken) {
+    if (this.accessTokenStore.tokenExpirationDate) {
       const now = Date.now();
-      const expirationDate = this.accessTokenStore.accessToken.expireAt;
+      const expirationDate = this.accessTokenStore.tokenExpirationDate;
       return expirationDate - errorMargin >= now;
     }
     return false;

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -206,7 +206,7 @@ export class HttpClient extends EventEmitter {
     if (this.accessTokenStore.accessToken) {
       const now = Date.now();
       const expirationDate = this.accessTokenStore.accessToken.expireAt;
-      return expirationDate - errorMargin < now;
+      return expirationDate - errorMargin >= now;
     }
     return false;
   }

--- a/packages/api-client/src/tcp/WebSocketClient.test.node.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.test.node.ts
@@ -37,6 +37,7 @@ const fakeHttpClient: any = {
     accessToken: accessTokenPayload,
   },
   refreshAccessToken: () => Promise.resolve(accessTokenPayload),
+  hasValidAccessToken: () => true,
 };
 
 const invalidTokenHttpClient: any = {
@@ -44,6 +45,7 @@ const invalidTokenHttpClient: any = {
     accessToken: accessTokenPayload,
   },
   refreshAccessToken: () => Promise.reject(new InvalidTokenError('Invalid token')),
+  hasValidAccessToken: () => true,
 };
 
 const fakeSocket = {

--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -107,6 +107,10 @@ export class WebSocketClient extends EventEmitter {
   };
 
   private readonly onReconnect = async () => {
+    if (!this.client.accessTokenIsValid()) {
+      // before we try any connection, we first refresh the access token to make sure we will avoid concurrent accessToken refreshes
+      await this.refreshAccessToken();
+    }
     // Note: Do NOT await `onConnect` otherwise the websocket will not connect during notification stream processing
     void this.onConnect();
     return this.buildWebSocketUrl();

--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -107,7 +107,7 @@ export class WebSocketClient extends EventEmitter {
   };
 
   private readonly onReconnect = async () => {
-    if (!this.client.accessTokenIsValid()) {
+    if (!this.client.hasValidAccessToken()) {
       // before we try any connection, we first refresh the access token to make sure we will avoid concurrent accessToken refreshes
       await this.refreshAccessToken();
     }

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -493,9 +493,8 @@ export class Account extends EventEmitter {
     await this.apiClient.connect(onBeforeConnect);
 
     return () => {
+      this.apiClient.transport.ws.removeAllListeners();
       this.apiClient.disconnect();
-      this.apiClient.transport.ws.removeAllListeners(WebSocketClient.TOPIC.ON_MESSAGE);
-      this.apiClient.transport.ws.removeListener(WebSocketClient.TOPIC.ON_STATE_CHANGE, onConnectionStateChanged);
     };
   }
 


### PR DESCRIPTION
We had a nasty race condition when reconnecting to the websocket after the access token was expired. In this race condition both the notification stream request and the websocket would both trigger an access token refresh ending up in both coliding with each other

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
