### PR TITLE
feat: modify StyledApp to accept either theme object or themeId as prop

### DIFF
--- a/packages/react-ui-kit/src/Layout/StyledApp.tsx
+++ b/packages/react-ui-kit/src/Layout/StyledApp.tsx
@@ -23,11 +23,12 @@ import {CSSObject, jsx} from '@emotion/react';
 
 import {GlobalStyle} from '../GlobalStyle';
 import {filterProps} from '../util';
-import {THEME_ID, Theme, ThemeProvider} from './Theme';
+import {THEME_ID, Theme, ThemeProvider, themes} from './Theme';
 
 export interface StyledAppContainerProps<T = HTMLDivElement> extends React.HTMLProps<T> {
   backgroundColor?: string;
   themeId?: THEME_ID;
+  theme?: Theme;
 }
 
 const styledAppContainerStyle: <T>(theme: Theme, props: StyledAppContainerProps<T>) => CSSObject = (
@@ -46,7 +47,7 @@ const StyledAppContainer = (props: StyledAppContainerProps) => (
 );
 
 export const StyledApp = ({themeId = THEME_ID.LIGHT, children, ...props}) => (
-  <ThemeProvider themeId={themeId}>
+  <ThemeProvider theme={props.theme ? props.theme : themes[themeId]}>
     <StyledAppContainer {...props}>
       <GlobalStyle />
       {children}

--- a/packages/react-ui-kit/src/Layout/Theme.tsx
+++ b/packages/react-ui-kit/src/Layout/Theme.tsx
@@ -34,6 +34,7 @@ export interface Theme {
   general: {
     backgroundColor: string;
     color: string;
+    themeColor?: string;
   };
   Input: {
     backgroundColor: string;
@@ -68,11 +69,12 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
 };
 
 export interface ThemeProps<T = HTMLDivElement> extends React.HTMLProps<T> {
-  themeId: THEME_ID;
+  themeId?: THEME_ID;
+  theme?: Theme;
 }
 
 const filterThemeProps = (props: ThemeProps) => filterProps(props, ['themeId']);
 
 export const ThemeProvider = (props: ThemeProps) => (
-  <EmotionThemeProvider theme={themes[props.themeId]} {...filterThemeProps(props)} />
+  <EmotionThemeProvider theme={props.theme} {...filterThemeProps(props)} />
 );


### PR DESCRIPTION
Modify StyledApp and ThemeProvider so you can pass either a themeId for the prebuilt light/dark theme or a complete theme object as StyledApp prop.