### PR TITLE
runfix: adjust theming of select and input label for use in webapp

### DIFF
--- a/packages/react-ui-kit/src/Form/InputLabel.tsx
+++ b/packages/react-ui-kit/src/Form/InputLabel.tsx
@@ -20,6 +20,7 @@
 /** @jsx jsx */
 import {jsx} from '@emotion/react';
 import {COLOR_V2} from '../Identity';
+import type {Theme} from '../Layout';
 import React, {FC, ReactNode} from 'react';
 
 export interface InputLabelProps {
@@ -32,12 +33,12 @@ export interface InputLabelProps {
 const InputLabel: FC<InputLabelProps> = ({htmlFor, markInvalid, isRequired, children, ...props}) => (
   <label
     htmlFor={htmlFor}
-    css={{
+    css={(theme: Theme) => ({
       fontSize: '14px',
       fontWeight: 400,
       lineHeight: '16px',
-      color: markInvalid ? COLOR_V2.RED_LIGHT_500 : COLOR_V2.GRAY_80,
-    }}
+      color: markInvalid ? COLOR_V2.RED_LIGHT_500 : theme.Input.labelColor,
+    })}
     {...props}
   >
     {children}

--- a/packages/react-ui-kit/src/Form/Select.tsx
+++ b/packages/react-ui-kit/src/Form/Select.tsx
@@ -48,10 +48,10 @@ export interface SelectProps<T extends SelectOption = SelectOption> {
   wrapperCSS?: CSSObject;
 }
 
-const ArrowDown = (theme: Theme) => `
+const ArrowDown = (theme: Theme, disabled: boolean) => `
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
         <path fill="${
-          theme.darkMode ? 'white' : 'black'
+          disabled ? (theme.darkMode ? '#9fa1a7' : '#676b71') : theme.darkMode ? 'white' : 'black'
         }" fill-rule="evenodd" clip-rule="evenodd" d="M7.99963 12.5711L15.6565 4.91421L14.2423 3.5L7.99963 9.74264L1.75699 3.5L0.342773 4.91421L7.99963 12.5711Z"/>
     </svg>
 `;
@@ -71,21 +71,26 @@ export const selectStyle: <T>(theme: Theme, props, error?: boolean) => CSSObject
   },
   appearance: 'none',
   background: disabled
-    ? `${theme.Input.backgroundColorDisabled} center right 16px no-repeat url("${inlineSVG(ArrowDown(theme))}")`
-    : `${theme.Input.backgroundColor} center right 16px no-repeat url("${inlineSVG(ArrowDown(theme))}")`,
-  boxShadow: markInvalid ? `0 0 0 1px ${COLOR_V2.RED}` : `0 0 0 1px ${theme.select.disabledColor}`,
+    ? `${theme.Input.backgroundColorDisabled} center right 16px no-repeat url("${inlineSVG(
+        ArrowDown(theme, disabled),
+      )}")`
+    : `${theme.Input.backgroundColor} center right 16px no-repeat url("${inlineSVG(ArrowDown(theme, disabled))}")`,
+  boxShadow: markInvalid ? `0 0 0 1px ${COLOR_V2.RED}` : `0 0 0 1px ${theme.select.borderColor}`,
   cursor: disabled ? 'normal' : 'pointer',
   fontSize: '16px',
   fontWeight: 300,
   paddingRight: '30px',
   textAlign: 'left',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
   marginBottom: error && '8px',
   '&:invalid, option:first-of-type': {
     color: COLOR_V2.RED,
   },
   ...(!disabled && {
     '&:hover': {
-      boxShadow: `0 0 0 1px ${theme.select.disabledColor}`,
+      boxShadow: `0 0 0 1px ${theme.select.borderColor}`,
     },
     '&:focus, &:active': {
       boxShadow: `0 0 0 1px ${theme.general.primaryColor}`,
@@ -126,7 +131,10 @@ const dropdownOptionStyles = (theme: Theme, isSelected: boolean): CSSObject => (
     borderRadius: '0 0 10px 10px',
   },
   '&:not(:last-of-type)': {
-    borderBottom: `1px solid ${COLOR_V2.GRAY_40}`,
+    borderBottom: `1px solid ${theme.select.borderColor}`,
+  },
+  '&:not(:first-of-type)': {
+    borderTop: `1px solid ${theme.select.borderColor}`,
   },
   '&:hover, &:active, &:focus': {
     background: theme.general.primaryColor,
@@ -250,14 +258,14 @@ export const Select = <T extends SelectOption = SelectOption>({
 
   return (
     <div
-      css={{
+      css={(theme: Theme) => ({
         marginBottom: markInvalid ? '2px' : '20px',
         width: '100%',
         '&:focus-within label': {
-          color: COLOR_V2.BLUE,
+          color: theme.general.primaryColor,
         },
         ...wrapperCSS,
-      }}
+      })}
       data-uie-name={dataUieName}
       ref={selectContainerRef}
     >
@@ -320,11 +328,11 @@ export const Select = <T extends SelectOption = SelectOption>({
 
                 {option.description && (
                   <p
-                    css={{
+                    css={(theme: Theme) => ({
                       marginBottom: 0,
                       fontSize: '14px',
-                      color: isSelected ? COLOR_V2.WHITE : COLOR_V2.GRAY_80,
-                    }}
+                      color: isSelected ? theme.general.color : theme.Input.labelColor,
+                    })}
                   >
                     {option.description}
                   </p>
@@ -336,7 +344,9 @@ export const Select = <T extends SelectOption = SelectOption>({
       </div>
 
       {!hasError && helperText && (
-        <p css={{fontSize: '12px', fontWeight: 400, color: COLOR_V2.GRAY_80, marginTop: 8}}>{helperText}</p>
+        <p css={(theme: Theme) => ({fontSize: '12px', fontWeight: 400, color: theme.Input.labelColor, marginTop: 8})}>
+          {helperText}
+        </p>
       )}
 
       {error}

--- a/packages/react-ui-kit/src/Layout/Theme.tsx
+++ b/packages/react-ui-kit/src/Layout/Theme.tsx
@@ -41,11 +41,13 @@ export interface Theme {
     backgroundColor: string;
     backgroundColorDisabled: string;
     placeholderColor: string;
+    labelColor: string;
   };
   select: {
     disabledColor?: string;
     contrastTextColor?: string;
     fillColor?: string;
+    borderColor?: string;
   };
 }
 
@@ -56,6 +58,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
       backgroundColor: COLOR.WHITE,
       backgroundColorDisabled: COLOR_V2.GRAY_20,
       placeholderColor: COLOR.GRAY_DARKEN_24,
+      labelColor: COLOR_V2.GRAY_80,
     },
     general: {
       backgroundColor: COLOR.GRAY_LIGHTEN_88,
@@ -63,16 +66,18 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
       primaryColor: COLOR_V2.BLUE,
     },
     select: {
-      disabledColor: COLOR_V2.GRAY,
+      disabledColor: COLOR_V2.GRAY_70,
       contrastTextColor: COLOR.WHITE,
+      borderColor: COLOR_V2.GRAY_40,
     },
   },
   [THEME_ID.DARK]: {
     darkMode: true,
     Input: {
       backgroundColor: COLOR.BLACK_LIGHTEN_24,
-      backgroundColorDisabled: COLOR.DISABLED,
+      backgroundColorDisabled: COLOR.GRAY_100,
       placeholderColor: COLOR.GRAY_LIGHTEN_88,
+      labelColor: COLOR_V2.GRAY_40,
     },
     general: {
       backgroundColor: COLOR.BLACK,
@@ -80,8 +85,9 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
       primaryColor: COLOR_V2.BLUE,
     },
     select: {
-      disabledColor: COLOR_V2.GRAY,
+      disabledColor: COLOR_V2.GRAY_60,
       contrastTextColor: COLOR.BLACK,
+      borderColor: COLOR_V2.GRAY_90,
     },
   },
 };


### PR DESCRIPTION
### Changes

- replace hard-coded color variables from the select component by new theme properties
- check that the components look as they should in default Light and Dark modes
- tweak the look of the webapp to fit the figma file

![image](https://user-images.githubusercontent.com/78490891/176221810-835d9980-9fa9-4918-b437-fd8c742d6397.png)
![image](https://user-images.githubusercontent.com/78490891/176221919-06beaa1d-1a1a-4933-b7fe-4c23a067d818.png)
 