### PR TITLE
feat: Upgrade conversation member endpoint to v2

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI.ts
@@ -988,10 +988,10 @@ export class ConversationAPI {
    * @param conversationId The conversation ID to add the users to
    * @param users List of users to add to a conversation
    */
-  public async postMembers(conversationId: string, users: QualifiedId[]): Promise<ConversationMemberJoinEvent> {
+  public async postMembers(conversationId: QualifiedId, users: QualifiedId[]): Promise<ConversationMemberJoinEvent> {
     if (!this.backendFeatures.federationEndpoints) {
       return this.postMembersV0(
-        conversationId,
+        conversationId.id,
         users.map(user => user.id),
       );
     }
@@ -1004,8 +1004,8 @@ export class ConversationAPI {
       method: 'post',
       url:
         this.backendFeatures.version >= 2
-          ? `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}`
-          : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${ConversationAPI.URL.V2}`,
+          ? `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}`
+          : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${ConversationAPI.URL.V2}`,
     };
 
     try {

--- a/packages/core/src/main/conversation/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService.ts
@@ -1030,7 +1030,7 @@ export class ConversationService {
   }
 
   public async addUser(
-    conversationId: string,
+    conversationId: QualifiedId,
     userIds: string | string[] | QualifiedId | QualifiedId[],
   ): Promise<QualifiedId[]> {
     const ids = Array.isArray(userIds) ? userIds : [userIds];


### PR DESCRIPTION
With API V2, the conversation member endpoint became qualified. In order to be able to use this method regardless of the api version used underneath, we need to have it consuming qualified ids. 