### PR TITLE
feat(api-client): add LEGAL_HOLD_SERVICE_UNAVAILABLE backend error label (#SQSERVICES-1493)

### DIFF
--- a/packages/api-client/src/http/BackendErrorLabel.ts
+++ b/packages/api-client/src/http/BackendErrorLabel.ts
@@ -104,6 +104,7 @@ export enum BackendErrorLabel {
 
   // Legalhold errors
   LEGAL_HOLD_MISSING_CONSENT = 'missing-legalhold-consent',
+  LEGAL_HOLD_SERVICE_UNAVAILABLE = 'legalhold-unavailable',
 
   // Service errors
   SERVICE_DISABLED = 'service-disabled',


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

Added error label which is returned on invalid secure hold url (TM).

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
