### PR TITLE
fix: centre align auth screen checkbox(ACC-207)

### DIFF
--- a/packages/react-ui-kit/src/Form/Checkbox.tsx
+++ b/packages/react-ui-kit/src/Form/Checkbox.tsx
@@ -30,12 +30,13 @@ import {INPUT_CLASSNAME, InputProps} from './Input';
 export interface StyledLabelProps<T = HTMLLabelElement> extends React.HTMLProps<T> {
   disabled?: boolean;
   markInvalid?: boolean;
+  alignCenter?: boolean;
 }
 
 const filterStyledLabelProps = (props: StyledLabelProps) => filterProps(props, ['markInvalid']);
 
 const StyledLabel = (props: StyledLabelProps) => {
-  const {disabled, markInvalid} = props;
+  const {disabled, markInvalid, alignCenter = false} = props;
   return (
     <label
       css={(theme: Theme) => ({
@@ -83,7 +84,7 @@ const StyledLabel = (props: StyledLabelProps) => {
         },
         position: 'relative',
         margin: '0 0 0 -16px',
-        width: '100%',
+        width: alignCenter ? 'auto' : '100%',
         lineHeight: 1.4,
         display: 'flex',
         opacity: disabled ? 0.56 : 1,
@@ -101,6 +102,7 @@ const StyledLabel = (props: StyledLabelProps) => {
 
 interface CheckboxProps<T = HTMLInputElement> extends InputProps<T> {
   id?: string;
+  alignCenter?: boolean;
 }
 
 const filterCheckboxProps = (props: CheckboxProps) => filterProps(props, ['markInvalid']);
@@ -140,7 +142,7 @@ export const Checkbox: React.FC<CheckboxProps<HTMLInputElement>> = React.forward
       {...filterCheckboxProps(props)}
     />
 
-    <StyledLabel htmlFor={id} disabled={disabled} markInvalid={props.markInvalid}>
+    <StyledLabel htmlFor={id} disabled={disabled} markInvalid={props.markInvalid} alignCenter={props.alignCenter}>
       {children}
     </StyledLabel>
   </div>


### PR DESCRIPTION
auth screens checkbox are centre aligned, while other checkbox after login are left aligned. To resolve the issue we are using a flag alignCenter whose default value is false and set to true for auth screen checkbox only. Using the flag we set width to be 100 percent or auto.
