### PR TITLE
feat(react-ui-kit): add DropFileInput component (#SQSERVICES-758)

### DIFF
--- a/packages/react-ui-kit/src/Form/DropFileInput.md
+++ b/packages/react-ui-kit/src/Form/DropFileInput.md
@@ -1,0 +1,19 @@
+Demo:
+
+```js
+import {Fragment} from 'react';
+import {Columns, Column, DropFileInput} from '@wireapp/react-ui-kit';
+
+<>
+  <div>
+    <DropFileInput
+      onInvalidFilesDropError={console.log}
+      onFilesUploaded={() => console.error('error while uploading files')}
+      headingText="Drag & Drop an image \nor"
+      labelText="select one from your device"
+      accept="image/png, image/jpeg"
+      description="Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px"
+    />
+  </div>
+</>;
+```

--- a/packages/react-ui-kit/src/Form/DropFileInput.md
+++ b/packages/react-ui-kit/src/Form/DropFileInput.md
@@ -1,7 +1,6 @@
 Demo:
 
 ```js
-import {Fragment} from 'react';
 import {Columns, Column, DropFileInput} from '@wireapp/react-ui-kit';
 
 <>

--- a/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
@@ -19,17 +19,159 @@
 
 import React from 'react';
 import {matchComponent} from '../test/testUtil';
-import {DropFileInput} from './DropFileInput';
+import {DropFileInput, DropFileInputProps} from './DropFileInput';
+import {fireEvent, render} from '@testing-library/react';
+import {StyledApp, THEME_ID} from '../Layout';
 
-const defaultProps = {
-  onInvalidFilesDropError: () => {},
-  onFilesUploaded: () => {},
+//note: we don't have to test file type validation using native file upload,
+// it won't allow to pick different type thant expected
+
+const getDefaultProps = () => ({
+  onInvalidFilesDropError: jest.fn(),
+  onFilesUploaded: jest.fn(),
   headingText: 'Drag & Drop an image \nor',
   labelText: 'select one from your device',
   accept: 'image/png, image/jpeg',
   description: 'Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px',
-};
+});
 
-describe('"Button"', () => {
-  it('renders', () => matchComponent(<DropFileInput {...defaultProps} />));
+const ThemedDropFileInput = (props: DropFileInputProps) => (
+  <StyledApp themeId={THEME_ID.LIGHT}>
+    <DropFileInput {...props} />
+  </StyledApp>
+);
+
+describe('"DropFileInput"', () => {
+  it('matches snapshot', () => matchComponent(<ThemedDropFileInput {...getDefaultProps()} />));
+
+  it('returns file on native file upload', () => {
+    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+
+    const props = {
+      ...getDefaultProps(),
+      accept: undefined,
+    };
+
+    const {getByTestId} = render(<ThemedDropFileInput {...props} />);
+
+    const fileInput = getByTestId('file-input');
+
+    // i have to do this because `input.files =[file]` is not allowed
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+    });
+    fireEvent.change(fileInput);
+
+    expect(props.onFilesUploaded).toHaveBeenCalledWith([file]);
+  });
+
+  it('allows to upload different types of files when "accept" attribute not specified', () => {
+    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+    const file2 = new File(['(⌐□_□)'], 'chucknorris.xlsx', {type: '.xlsx'});
+
+    const props = {
+      ...getDefaultProps(),
+      accept: undefined,
+    };
+
+    const {getByTestId} = render(<ThemedDropFileInput {...props} />);
+
+    const dropZone = getByTestId('dropzone');
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file2],
+      },
+    });
+
+    expect(props.onFilesUploaded).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows to upload only file types specified in "accept" attribute', () => {
+    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+    const file2 = new File(['(⌐□_□)'], 'chucknorris.jpg', {type: 'image/jpeg'});
+
+    const props = {
+      ...getDefaultProps(),
+      accept: 'image/png',
+      onInvalidFilesDropError: jest.fn(),
+      onFilesUploaded: jest.fn(),
+    };
+
+    const {getByTestId} = render(<ThemedDropFileInput {...props} />);
+
+    const dropZone = getByTestId('dropzone');
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file],
+      },
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file2],
+      },
+    });
+
+    expect(props.onFilesUploaded).toHaveBeenCalledTimes(1);
+    expect(props.onInvalidFilesDropError).toHaveBeenCalled();
+  });
+
+  it('returns first file when "multiple" attribute not specified', () => {
+    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+    const file2 = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+
+    const props = {
+      ...getDefaultProps(),
+      accept: 'image/png',
+      onInvalidFilesDropError: jest.fn(),
+      onFilesUploaded: jest.fn(),
+    };
+
+    const {getByTestId} = render(<ThemedDropFileInput {...props} />);
+
+    const dropZone = getByTestId('dropzone');
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file, file2],
+      },
+    });
+
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file2],
+      },
+    });
+
+    expect(props.onFilesUploaded).toHaveBeenCalledWith([file]);
+  });
+
+  it('returns all files when "multiple" attribute specified', () => {
+    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+    const file2 = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+
+    const props = {
+      ...getDefaultProps(),
+      accept: 'image/png',
+      onInvalidFilesDropError: jest.fn(),
+      onFilesUploaded: jest.fn(),
+      multiple: true,
+    };
+
+    const {getByTestId} = render(<ThemedDropFileInput {...props} />);
+
+    const dropZone = getByTestId('dropzone');
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [file, file2],
+      },
+    });
+
+    expect(props.onFilesUploaded).toHaveBeenCalledWith([file, file2]);
+  });
 });

--- a/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
@@ -26,12 +26,15 @@ import {StyledApp, THEME_ID} from '../Layout';
 //note: we don't have to test file type validation using native file upload,
 // it won't allow to pick different type thant expected
 
-const getDefaultProps = () => ({
+const getDefaultProps = (
+  {accept, multiple}: {accept?: string; multiple?: boolean} = {accept: undefined, multiple: undefined},
+) => ({
+  accept,
+  multiple,
   onInvalidFilesDropError: jest.fn(),
   onFilesUploaded: jest.fn(),
   headingText: 'Drag & Drop an image \nor',
   labelText: 'select one from your device',
-  accept: 'image/png, image/jpeg',
   description: 'Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px',
 });
 
@@ -41,51 +44,44 @@ const ThemedDropFileInput = (props: DropFileInputProps) => (
   </StyledApp>
 );
 
+const pngFile = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
+const jpegFile = new File(['(⌐□_□)'], 'chucknorris.jpg', {type: 'image/jpeg'});
+const xlsxFile = new File(['(⌐□_□)'], 'chucknorris.xlsx', {type: '.xlsx'});
+
 describe('"DropFileInput"', () => {
-  it('matches snapshot', () => matchComponent(<ThemedDropFileInput {...getDefaultProps()} />));
+  it('matches snapshot', () =>
+    matchComponent(<ThemedDropFileInput {...getDefaultProps({accept: 'image/png, image/jpeg'})} />));
 
   it('returns file on native file upload', () => {
-    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-
-    const props = {
-      ...getDefaultProps(),
-      accept: undefined,
-    };
+    const props = getDefaultProps();
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
-
     const fileInput = getByTestId('file-input');
 
     // i have to do this because `input.files =[file]` is not allowed
     Object.defineProperty(fileInput, 'files', {
-      value: [file],
+      value: [pngFile],
     });
     fireEvent.change(fileInput);
 
-    expect(props.onFilesUploaded).toHaveBeenCalledWith([file]);
+    expect(props.onFilesUploaded).toHaveBeenCalledWith([pngFile]);
   });
 
   it('allows to upload different types of files when "accept" attribute not specified', () => {
-    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-    const file2 = new File(['(⌐□_□)'], 'chucknorris.xlsx', {type: '.xlsx'});
-
-    const props = {
-      ...getDefaultProps(),
-      accept: undefined,
-    };
+    const props = getDefaultProps();
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
-
     const dropZone = getByTestId('dropzone');
+
     fireEvent.drop(dropZone, {
       dataTransfer: {
-        files: [file],
+        files: [pngFile],
       },
     });
 
     fireEvent.drop(dropZone, {
       dataTransfer: {
-        files: [file2],
+        files: [xlsxFile],
       },
     });
 
@@ -93,28 +89,20 @@ describe('"DropFileInput"', () => {
   });
 
   it('allows to upload only file types specified in "accept" attribute', () => {
-    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-    const file2 = new File(['(⌐□_□)'], 'chucknorris.jpg', {type: 'image/jpeg'});
-
-    const props = {
-      ...getDefaultProps(),
-      accept: 'image/png',
-      onInvalidFilesDropError: jest.fn(),
-      onFilesUploaded: jest.fn(),
-    };
+    const props = getDefaultProps({accept: 'image/png'});
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
-
     const dropZone = getByTestId('dropzone');
+
     fireEvent.drop(dropZone, {
       dataTransfer: {
-        files: [file],
+        files: [pngFile],
       },
     });
 
     fireEvent.drop(dropZone, {
       dataTransfer: {
-        files: [file2],
+        files: [jpegFile],
       },
     });
 
@@ -123,55 +111,37 @@ describe('"DropFileInput"', () => {
   });
 
   it('returns first file when "multiple" attribute not specified', () => {
-    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-    const file2 = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-
-    const props = {
-      ...getDefaultProps(),
-      accept: 'image/png',
-      onInvalidFilesDropError: jest.fn(),
-      onFilesUploaded: jest.fn(),
-    };
+    const props = getDefaultProps({
+      accept: 'image/png, image/jpeg',
+    });
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
-
     const dropZone = getByTestId('dropzone');
-    fireEvent.drop(dropZone, {
-      dataTransfer: {
-        files: [file, file2],
-      },
-    });
 
     fireEvent.drop(dropZone, {
       dataTransfer: {
-        files: [file2],
+        files: [pngFile, jpegFile],
       },
     });
 
-    expect(props.onFilesUploaded).toHaveBeenCalledWith([file]);
+    expect(props.onFilesUploaded).toHaveBeenCalledWith([pngFile]);
   });
 
   it('returns all files when "multiple" attribute specified', () => {
-    const file = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-    const file2 = new File(['(⌐□_□)'], 'chucknorris.png', {type: 'image/png'});
-
-    const props = {
-      ...getDefaultProps(),
-      accept: 'image/png',
-      onInvalidFilesDropError: jest.fn(),
-      onFilesUploaded: jest.fn(),
+    const props = getDefaultProps({
+      accept: 'image/png, image/jpeg',
       multiple: true,
-    };
+    });
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
-
     const dropZone = getByTestId('dropzone');
+
     fireEvent.drop(dropZone, {
       dataTransfer: {
-        files: [file, file2],
+        files: [pngFile, jpegFile],
       },
     });
 
-    expect(props.onFilesUploaded).toHaveBeenCalledWith([file, file2]);
+    expect(props.onFilesUploaded).toHaveBeenCalledWith([pngFile, jpegFile]);
   });
 });

--- a/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
@@ -25,10 +25,12 @@ import {StyledApp, THEME_ID} from '../Layout';
 
 //note: we don't have to test file type validation using native file upload,
 // it won't allow to pick different type thant expected
+interface GetDefaultPropsType {
+  accept?: string;
+  multiple?: boolean;
+}
 
-const getDefaultProps = (
-  {accept, multiple}: {accept?: string; multiple?: boolean} = {accept: undefined, multiple: undefined},
-) => ({
+const getDefaultProps = ({accept, multiple}: GetDefaultPropsType) => ({
   accept,
   multiple,
   onInvalidFilesDropError: jest.fn(),
@@ -53,7 +55,7 @@ describe('"DropFileInput"', () => {
     matchComponent(<ThemedDropFileInput {...getDefaultProps({accept: 'image/png, image/jpeg'})} />));
 
   it('returns file on native file upload', () => {
-    const props = getDefaultProps();
+    const props = getDefaultProps({});
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
     const fileInput = getByTestId('file-input');
@@ -68,7 +70,7 @@ describe('"DropFileInput"', () => {
   });
 
   it('allows to upload different types of files when "accept" attribute not specified', () => {
-    const props = getDefaultProps();
+    const props = getDefaultProps({});
 
     const {getByTestId} = render(<ThemedDropFileInput {...props} />);
     const dropZone = getByTestId('dropzone');

--- a/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.test.tsx
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import React from 'react';
+import {matchComponent} from '../test/testUtil';
+import {DropFileInput} from './DropFileInput';
+
+const defaultProps = {
+  onInvalidFilesDropError: () => {},
+  onFilesUploaded: () => {},
+  headingText: 'Drag & Drop an image \nor',
+  labelText: 'select one from your device',
+  accept: 'image/png, image/jpeg',
+  description: 'Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px',
+};
+
+describe('"Button"', () => {
+  it('renders', () => matchComponent(<DropFileInput {...defaultProps} />));
+});

--- a/packages/react-ui-kit/src/Form/DropFileInput.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.tsx
@@ -164,7 +164,10 @@ export const DropFileInput: React.FC<DropFileInputProps<HTMLInputElement>> = Rea
   return (
     <div css={dropFileWrapperStyle}>
       <div
-        css={{...(theme: Theme) => dropFileZoneWrapperStyle(theme, isDraggedOver), ...dropFileZoneWrapperCSS}}
+        css={(theme: Theme) => ({
+          ...dropFileZoneWrapperStyle(theme, isDraggedOver),
+          ...dropFileZoneWrapperCSS,
+        })}
         onDragOver={handleDragOver}
         onDragLeave={() => setIsDraggedOver(false)}
         onDrop={handleDrop}

--- a/packages/react-ui-kit/src/Form/DropFileInput.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.tsx
@@ -33,6 +33,7 @@ export interface DropFileInputProps<T = HTMLInputElement> extends TextProps<T> {
   labelText: string;
   headingText: string;
   description?: string;
+  dropFileZoneWrapperCSS?: CSSObject;
 }
 
 const visuallyHiddenStyles: CSSObject = {
@@ -75,6 +76,9 @@ export const dropFileZoneLabelStyle: <T>(theme: Theme) => CSSObject = theme => {
     ':focus-within': {
       outline: `1px solid ${theme.general.primaryColor}`,
     },
+    ':hover': {
+      textDecoration: 'underline',
+    },
   };
 };
 
@@ -99,6 +103,7 @@ export const DropFileInput: React.FC<DropFileInputProps<HTMLInputElement>> = Rea
   const {
     onFilesUploaded,
     onInvalidFilesDropError,
+    dropFileZoneWrapperCSS,
     labelText,
     headingText,
     description,
@@ -159,7 +164,7 @@ export const DropFileInput: React.FC<DropFileInputProps<HTMLInputElement>> = Rea
   return (
     <div css={dropFileWrapperStyle}>
       <div
-        css={(theme: Theme) => dropFileZoneWrapperStyle(theme, isDraggedOver)}
+        css={{...(theme: Theme) => dropFileZoneWrapperStyle(theme, isDraggedOver), ...dropFileZoneWrapperCSS}}
         onDragOver={handleDragOver}
         onDragLeave={() => setIsDraggedOver(false)}
         onDrop={handleDrop}

--- a/packages/react-ui-kit/src/Form/DropFileInput.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.tsx
@@ -172,9 +172,7 @@ export const DropFileInput: React.FC<DropFileInputProps<HTMLInputElement>> = Rea
         <FlexBox align="center" justify="center" css={{position: 'relative'}}>
           <UploadIcon css={{position: 'absolute', left: '15px'}} />
           <div css={{maxWidth: '160px'}}>
-            <span css={dropFileZoneHeadingStyle} className="title">
-              {headingText}
-            </span>
+            <span css={dropFileZoneHeadingStyle}>{headingText}</span>
             <label
               aria-label={`${headingText} ${labelText} (${description})`}
               css={(theme: Theme) => dropFileZoneLabelStyle(theme)}

--- a/packages/react-ui-kit/src/Form/DropFileInput.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.tsx
@@ -171,6 +171,7 @@ export const DropFileInput: FC<DropFileInputProps<HTMLInputElement>> = forwardRe
             ...dropFileZoneWrapperStyle(theme, isDraggedOver),
             ...dropFileZoneWrapperCSS,
           })}
+          data-testid="dropzone"
           onDragOver={handleDragOver}
           onDragLeave={resetDraggedOver}
           onDrop={handleDrop}
@@ -185,6 +186,7 @@ export const DropFileInput: FC<DropFileInputProps<HTMLInputElement>> = forwardRe
               >
                 <span>{labelText}</span>
                 <input
+                  data-testid="file-input"
                   ref={ref}
                   accept={accept}
                   multiple={multiple}

--- a/packages/react-ui-kit/src/Form/DropFileInput.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.tsx
@@ -1,0 +1,194 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+/** @jsx jsx */
+import {CSSObject, jsx} from '@emotion/react';
+import React, {useState} from 'react';
+
+import {COLOR} from '../Identity';
+import type {Theme} from '../Layout';
+import type {TextProps} from '../Text';
+import {UploadIcon} from '../Icon';
+import {FlexBox} from '../Layout';
+
+export interface DropFileInputProps<T = HTMLInputElement> extends TextProps<T> {
+  onFilesUploaded: (files: File[]) => void;
+  onInvalidFilesDropError: () => void;
+  labelText: string;
+  headingText: string;
+  description?: string;
+}
+
+const visuallyHiddenStyles: CSSObject = {
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
+  height: '1px',
+  overflow: 'hidden',
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  width: '1px',
+};
+
+export const dropFileWrapperStyle: CSSObject = {
+  maxWidth: '330px',
+};
+
+export const dropFileZoneWrapperStyle: <T>(theme: Theme, isDraggedOver: boolean) => CSSObject = (
+  theme,
+  isDraggedOver,
+) => {
+  return {
+    width: '100%',
+    padding: '28px',
+    border: `1px dashed ${theme.general.primaryColor}`,
+    borderBottomWidth: '2px',
+    borderRadius: '6px',
+    textAlign: 'center',
+    backgroundColor: isDraggedOver ? theme.general.backgroundColor : COLOR.WHITE,
+    fontWeight: 400,
+    fontSize: '12px',
+    lineHeight: '13px',
+    color: COLOR.GRAY,
+  };
+};
+
+export const dropFileZoneLabelStyle: <T>(theme: Theme) => CSSObject = theme => {
+  return {
+    color: theme.general.primaryColor,
+    cursor: 'pointer',
+    ':focus-within': {
+      outline: `1px solid ${theme.general.primaryColor}`,
+    },
+  };
+};
+
+export const dropFileZoneHeadingStyle: CSSObject = {
+  display: 'block',
+  whiteSpace: 'pre-line',
+};
+
+export const dropFileZonDescriptionStyle: CSSObject = {
+  marginTop: '12px',
+  fontWeight: 400,
+  fontSize: '10px',
+  lineHeight: '13px',
+  color: COLOR.GRAY,
+  whiteSpace: 'pre-line',
+};
+
+export const DropFileInput: React.FC<DropFileInputProps<HTMLInputElement>> = React.forwardRef<
+  HTMLInputElement,
+  DropFileInputProps<HTMLInputElement>
+>((props, ref) => {
+  const {
+    onFilesUploaded,
+    onInvalidFilesDropError,
+    labelText,
+    headingText,
+    description,
+    accept,
+    multiple,
+    ...inputProps
+  } = props;
+
+  const [isDraggedOver, setIsDraggedOver] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+
+    if (e.dataTransfer.items.length > 0) {
+      setIsDraggedOver(true);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDraggedOver(false);
+
+    const {files} = e.dataTransfer;
+    if (files.length < 1) {
+      return;
+    }
+
+    const filesArr = multiple ? Array.from(files) : [files[0]];
+
+    const areFilesValid = !!accept
+      ? filesArr.every(file =>
+          accept
+            .split(',')
+            .map(v => v.trim())
+            .includes(file.type),
+        )
+      : true;
+
+    if (!areFilesValid) {
+      onInvalidFilesDropError();
+      return;
+    }
+
+    onFilesUploaded(filesArr);
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {files} = e.target;
+    if (files.length < 1) {
+      return;
+    }
+    onFilesUploaded(Array.from(files));
+  };
+
+  return (
+    <div css={dropFileWrapperStyle}>
+      <div
+        css={(theme: Theme) => dropFileZoneWrapperStyle(theme, isDraggedOver)}
+        onDragOver={handleDragOver}
+        onDragLeave={() => setIsDraggedOver(false)}
+        onDrop={handleDrop}
+      >
+        <FlexBox align="center" justify="center" css={{position: 'relative'}}>
+          <UploadIcon css={{position: 'absolute', left: '15px'}} />
+          <div css={{maxWidth: '160px'}}>
+            <span css={dropFileZoneHeadingStyle} className="title">
+              {headingText}
+            </span>
+            <label
+              aria-label={`${headingText} ${labelText} (${description})`}
+              css={(theme: Theme) => dropFileZoneLabelStyle(theme)}
+            >
+              <span>{labelText}</span>
+              <input
+                ref={ref}
+                accept={accept}
+                multiple={multiple}
+                css={visuallyHiddenStyles}
+                onChange={handleChange}
+                type="file"
+                {...inputProps}
+              />
+            </label>
+          </div>
+        </FlexBox>
+      </div>
+      {description && <p css={dropFileZonDescriptionStyle}>{description}</p>}
+    </div>
+  );
+});

--- a/packages/react-ui-kit/src/Form/DropFileInput.tsx
+++ b/packages/react-ui-kit/src/Form/DropFileInput.tsx
@@ -55,7 +55,7 @@ export const dropFileZoneWrapperStyle: <T>(theme: Theme, isDraggedOver: boolean)
   isDraggedOver,
 ) => ({
   width: '100%',
-  padding: '28px',
+  padding: '28px 12px',
   border: `1px dashed ${theme.general.primaryColor}`,
   borderBottomWidth: '2px',
   borderRadius: '6px',
@@ -175,9 +175,9 @@ export const DropFileInput: FC<DropFileInputProps<HTMLInputElement>> = forwardRe
           onDragLeave={resetDraggedOver}
           onDrop={handleDrop}
         >
-          <FlexBox align="center" justify="center" css={{position: 'relative'}}>
-            <UploadIcon css={{position: 'absolute', left: '15px'}} />
-            <div css={{maxWidth: '160px'}}>
+          <FlexBox align="center" justify="center" flexWrap="wrap" css={{maxWidth: '280px', margin: '0 auto'}}>
+            <UploadIcon css={{margin: '12px 0'}} />
+            <div css={{maxWidth: '160px', margin: '0 25px'}}>
               <span css={dropFileZoneHeadingStyle}>{headingText}</span>
               <label
                 aria-label={`${headingText} ${labelText} (${description})`}

--- a/packages/react-ui-kit/src/Form/__snapshots__/DropFileInput.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/DropFileInput.test.tsx.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`"Button" renders 1`] = `
+.emotion-0 {
+  background: #edeff0;
+  -webkit-transition: background 0.15s;
+  transition: background 0.15s;
+}
+
+.emotion-1 {
+  max-width: 330px;
+}
+
+.emotion-2 {
+  width: 100%;
+  padding: 28px 12px;
+  border: 1px dashed #0667c8;
+  border-bottom-width: 2px;
+  border-radius: 6px;
+  text-align: center;
+  background-color: #fff;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 13px;
+  color: #696c6e;
+}
+
+.emotion-3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+.emotion-4 {
+  fill: rgb(29, 30, 31);
+  overflow: visible;
+  margin: 12px 0;
+}
+
+.emotion-5 {
+  max-width: 160px;
+  margin: 0 25px;
+}
+
+.emotion-6 {
+  display: block;
+  white-space: pre-line;
+}
+
+.emotion-7 {
+  color: #0667c8;
+  cursor: pointer;
+}
+
+.emotion-7:focus-within {
+  outline: 1px solid #0667c8;
+}
+
+.emotion-7:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.emotion-8 {
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.emotion-9 {
+  margin-top: 12px;
+  font-weight: 400;
+  font-size: 10px;
+  line-height: 13px;
+  color: #696c6e;
+  white-space: pre-line;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-1"
+  >
+    <div
+      className="emotion-2"
+      onDragLeave={[Function]}
+      onDragOver={[Function]}
+      onDrop={[Function]}
+    >
+      <div
+        className="emotion-3"
+      >
+        <svg
+          className="emotion-4"
+          height={16}
+          viewBox="0 0 16 16"
+          width={16}
+        >
+          <g>
+            <path
+              d="M0 14H16V16H0V14ZM7 11H9V4H13L8 0L3 4H7V11Z"
+            />
+          </g>
+        </svg>
+        <div
+          className="emotion-5"
+        >
+          <span
+            className="emotion-6"
+          >
+            Drag & Drop an image 
+or
+          </span>
+          <label
+            aria-label="Drag & Drop an image 
+or select one from your device (Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px)"
+            className="emotion-7"
+          >
+            <span>
+              select one from your device
+            </span>
+            <input
+              accept="image/png, image/jpeg"
+              className="emotion-8"
+              onChange={[Function]}
+              type="file"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+    <p
+      className="emotion-9"
+    >
+      Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px
+    </p>
+  </div>
+</div>
+`;

--- a/packages/react-ui-kit/src/Form/__snapshots__/DropFileInput.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/DropFileInput.test.tsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`"Button" renders 1`] = `
+exports[`"DropFileInput" matches snapshot 1`] = `
 .emotion-0 {
   background: #edeff0;
   -webkit-transition: background 0.15s;
   transition: background 0.15s;
 }
 
-.emotion-1 {
+.emotion-2 {
   max-width: 330px;
 }
 
-.emotion-2 {
+.emotion-3 {
   width: 100%;
   padding: 28px 12px;
   border: 1px dashed #0667c8;
@@ -25,7 +25,7 @@ exports[`"Button" renders 1`] = `
   color: #696c6e;
 }
 
-.emotion-3 {
+.emotion-4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -49,37 +49,37 @@ exports[`"Button" renders 1`] = `
   margin: 0 auto;
 }
 
-.emotion-4 {
+.emotion-5 {
   fill: rgb(29, 30, 31);
   overflow: visible;
   margin: 12px 0;
 }
 
-.emotion-5 {
+.emotion-6 {
   max-width: 160px;
   margin: 0 25px;
 }
 
-.emotion-6 {
+.emotion-7 {
   display: block;
   white-space: pre-line;
 }
 
-.emotion-7 {
+.emotion-8 {
   color: #0667c8;
   cursor: pointer;
 }
 
-.emotion-7:focus-within {
+.emotion-8:focus-within {
   outline: 1px solid #0667c8;
 }
 
-.emotion-7:hover {
+.emotion-8:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.emotion-8 {
+.emotion-9 {
   clip: rect(0 0 0 0);
   -webkit-clip-path: inset(50%);
   clip-path: inset(50%);
@@ -90,7 +90,7 @@ exports[`"Button" renders 1`] = `
   width: 1px;
 }
 
-.emotion-9 {
+.emotion-10 {
   margin-top: 12px;
   font-weight: 400;
   font-size: 10px;
@@ -103,61 +103,67 @@ exports[`"Button" renders 1`] = `
   className="emotion-0"
 >
   <div
-    className="emotion-1"
+    className="emotion-0"
   >
     <div
       className="emotion-2"
-      onDragLeave={[Function]}
-      onDragOver={[Function]}
-      onDrop={[Function]}
     >
       <div
         className="emotion-3"
+        data-testid="dropzone"
+        onDragLeave={[Function]}
+        onDragOver={[Function]}
+        onDrop={[Function]}
       >
-        <svg
-          className="emotion-4"
-          height={16}
-          viewBox="0 0 16 16"
-          width={16}
-        >
-          <g>
-            <path
-              d="M0 14H16V16H0V14ZM7 11H9V4H13L8 0L3 4H7V11Z"
-            />
-          </g>
-        </svg>
         <div
-          className="emotion-5"
+          className="emotion-4"
         >
-          <span
+          <svg
+            className="emotion-5"
+            height={16}
+            viewBox="0 0 16 16"
+            width={16}
+          >
+            <g>
+              <path
+                d="M0 14H16V16H0V14ZM7 11H9V4H13L8 0L3 4H7V11Z"
+              />
+            </g>
+          </svg>
+          <div
             className="emotion-6"
           >
-            Drag & Drop an image 
+            <span
+              className="emotion-7"
+            >
+              Drag & Drop an image 
 or
-          </span>
-          <label
-            aria-label="Drag & Drop an image 
-or select one from your device (Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px)"
-            className="emotion-7"
-          >
-            <span>
-              select one from your device
             </span>
-            <input
-              accept="image/png, image/jpeg"
+            <label
+              aria-label="Drag & Drop an image 
+or select one from your device (Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px)"
               className="emotion-8"
-              onChange={[Function]}
-              type="file"
-            />
-          </label>
+            >
+              <span>
+                select one from your device
+              </span>
+              <input
+                accept="image/png, image/jpeg"
+                className="emotion-9"
+                data-testid="file-input"
+                onChange={[Function]}
+                type="file"
+              />
+            </label>
+          </div>
         </div>
       </div>
+      <p
+        className="emotion-10"
+      >
+        Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px
+      </p>
     </div>
-    <p
-      className="emotion-9"
-    >
-      Image (JPG/PNG) size up to 1 MB, minimum 200 x 600 px
-    </p>
   </div>
 </div>
 `;

--- a/packages/react-ui-kit/src/Icon/SVGIcon.md
+++ b/packages/react-ui-kit/src/Icon/SVGIcon.md
@@ -78,6 +78,7 @@ import {
   HideIcon,
   TriangleIcon,
   TwitterIcon,
+  UploadIcon,
   WireIcon,
 } from '@wireapp/react-ui-kit';
 
@@ -141,6 +142,7 @@ const icons = [
   TeamIcon,
   TimedIcon,
   TrashIcon,
+  UploadIcon,
   TrashCrossIcon,
   TriangleIcon,
   HideIcon,

--- a/packages/react-ui-kit/src/Icon/UploadIcon.tsx
+++ b/packages/react-ui-kit/src/Icon/UploadIcon.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,20 +17,12 @@
  *
  */
 
-export * from './Button';
-export * from './ButtonLink';
-export * from './Checkbox';
-export * from './CodeInput';
-export * from './DropFileInput';
-export * from './ErrorMessage';
-export * from './Form';
-export * from './Input';
-export * from './InputBlock';
-export * from './InputSubmitCombo';
-export * from './RoundIconButton';
-export * from './Select';
-export * from './ShakeBox';
-export * from './Switch';
-export * from './TextArea';
-export * from './Tooltip';
-export * from './InputLabel';
+/** @jsx jsx */
+import {jsx} from '@emotion/react';
+import {SVGIcon, SVGIconProps} from './SVGIcon';
+
+export const UploadIcon = (props: SVGIconProps) => (
+  <SVGIcon realWidth={16} realHeight={16} {...props}>
+    <path d="M0 14H16V16H0V14ZM7 11H9V4H13L8 0L3 4H7V11Z" />
+  </SVGIcon>
+);

--- a/packages/react-ui-kit/src/Icon/index.ts
+++ b/packages/react-ui-kit/src/Icon/index.ts
@@ -79,6 +79,7 @@ export * from './TimedIcon';
 export * from './TrashIcon';
 export * from './TrashCrossIcon';
 export * from './TriangleIcon';
+export * from './UploadIcon';
 export * from './WireIcon';
 
 // Brand Icons


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

Added file input with drop zone area:

- user is able to upload files by dropping files in the zone or by clicking on input's label text (eg. select file from your device)
- customisable:
    - dropdown text (heading and clickable label) 
    - description under input
    - zone's styles (css object)
- `onFilesUploaded` callback passed as props run after file is successfully uploaded using dropdown or native file select; takes an array of files as a first (and only) param.
- `onInvalidFilesDropError` - native file picker won't allow user to pick file with unexpected type, but we have to validate types of files uploaded using drop area. This callback will run after invalid file was dropped on drop area.
- `accept` (native file input's attribute) - accepted file mime-types list joined with comma (`,`)
- `multiple` (native file input's attribute) - allows to upload multiple files
- component supports theme colors

How to test: 
- navigate to `wire-web-packages/packages/react-ui-kit` directory
- run `yarn start`
- http://localhost:8090 -> `DropFileInput` section 

//todo: unit tests

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
