### PR TITLE
feat(react-ui-kit): add custom RangeInput component (#SQSERVICES-758)

### DIFF
--- a/packages/react-ui-kit/src/Form/RangeInput.md
+++ b/packages/react-ui-kit/src/Form/RangeInput.md
@@ -1,0 +1,27 @@
+Demo:
+
+```js
+import {Columns, Column, RangeInput} from '@wireapp/react-ui-kit';
+import {useState} from 'react';
+
+const [zoom, setZoom] = useState(1);
+
+const handleChange = e => {
+  setZoom(+e.target.value);
+};
+
+<>
+  <div>
+    <RangeInput
+      label={'Zoom'}
+      minValueLabel="-"
+      maxValueLabel="+"
+      onChange={handleChange}
+      value={zoom}
+      min={1}
+      max={3}
+      step={0.1}
+    />
+  </div>
+</>;
+```

--- a/packages/react-ui-kit/src/Form/RangeInput.styles.ts
+++ b/packages/react-ui-kit/src/Form/RangeInput.styles.ts
@@ -1,0 +1,75 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CSSObject} from '@emotion/react';
+import {Theme} from '../Layout';
+import {COLOR_V2} from '../Identity';
+import {manySelectors} from '../util';
+
+export const rangeInputWrapperStyles: CSSObject = {
+  position: 'relative',
+  marginTop: '19px',
+};
+
+const thumbSelectors = ['&::-webkit-slider-thumb', '&::-moz-range-thumb', '&::-ms-thumb'];
+const sliderSelectors = ['&::-webkit-slider-runnable-track', '&::-moz-range-track', '&::-ms-track'];
+
+export const getImageCropZoomInputStyles = (theme: Theme, backgroundSize: `${number}% ${number}%`): CSSObject => ({
+  display: 'block',
+  '-webkit-appearance': 'none',
+  width: '100%',
+  height: '8px',
+  background: COLOR_V2.GRAY_60,
+  borderRadius: '4px',
+  backgroundImage: `linear-gradient(${theme.general.primaryColor}, ${theme.general.primaryColor})`,
+  backgroundSize: backgroundSize || '0% 100%',
+  backgroundRepeat: 'no-repeat',
+
+  ...manySelectors(thumbSelectors, {
+    '-webkit-appearance': 'none',
+    height: '18px',
+    width: '18px',
+    borderRadius: '50%',
+    background: COLOR_V2.GRAY_80,
+    cursor: 'pointer',
+    border: 'none',
+    boxShadow: 'none',
+  }),
+
+  ...manySelectors(sliderSelectors, {
+    '-webkit-appearance': 'none',
+    boxShadow: 'none',
+    border: 'none',
+    background: 'transparent',
+  }),
+});
+
+export enum ValueLabelPosition {
+  LEFT = 'left',
+  RIGHT = 'right',
+}
+
+export const getValueLabelStyles = (position: ValueLabelPosition): CSSObject => ({
+  pointerEvents: 'none',
+  bottom: '100%',
+  fontSize: '16px',
+  fontWeight: 300,
+  position: 'absolute',
+  [position]: '4px',
+});

--- a/packages/react-ui-kit/src/Form/RangeInput.test.tsx
+++ b/packages/react-ui-kit/src/Form/RangeInput.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import React from 'react';
+import {matchComponent} from '../test/testUtil';
+import {RangeInput, RangeInputProps} from './RangeInput';
+import {fireEvent, render} from '@testing-library/react';
+import {StyledApp, THEME_ID} from '../Layout';
+import {matchers} from '@emotion/jest';
+expect.extend(matchers);
+
+const getDefaultProps = () => ({
+  id: 'zoom-input',
+  label: 'Zoom',
+  minValueLabel: '-',
+  maxValueLabel: '+',
+  onChange: jest.fn(),
+  value: 0,
+  min: 1,
+  max: 3,
+  step: 0.1,
+});
+
+const ThemedRangeInput = (props: RangeInputProps) => (
+  <StyledApp themeId={THEME_ID.LIGHT}>
+    <RangeInput {...props} />
+  </StyledApp>
+);
+
+describe('"RangeInput"', () => {
+  it('matches snapshot', () => matchComponent(<ThemedRangeInput {...getDefaultProps()} />));
+
+  it('renders label', () => {
+    const props = getDefaultProps();
+    const {getByLabelText} = render(<ThemedRangeInput {...props} />);
+    expect(getByLabelText(props.label)).toBeDefined();
+  });
+
+  it('renders min and max value labels', () => {
+    const props = getDefaultProps();
+    const {getByText} = render(<ThemedRangeInput {...props} />);
+    expect(getByText(props.minValueLabel)).toBeDefined();
+    expect(getByText(props.maxValueLabel)).toBeDefined();
+  });
+
+  it('fires onChange callback', () => {
+    const props = getDefaultProps();
+    const {getByRole} = render(<ThemedRangeInput {...props} />);
+
+    const rangeInput = getByRole('slider');
+    fireEvent.change(rangeInput, {value: 2});
+
+    expect(props.onChange).toHaveBeenCalled();
+  });
+
+  it("updates slider's background-size prop based on value", () => {
+    const {getByRole, rerender} = render(<ThemedRangeInput {...getDefaultProps()} value={1} />);
+    const rangeInput = getByRole('slider');
+
+    expect(rangeInput).toHaveStyleRule('background-size', '0% 100%');
+
+    rerender(<ThemedRangeInput {...getDefaultProps()} value={2} />);
+    expect(rangeInput).toHaveStyleRule('background-size', '50% 100%');
+
+    rerender(<ThemedRangeInput {...getDefaultProps()} value={3} />);
+    expect(rangeInput).toHaveStyleRule('background-size', '100% 100%');
+  });
+});

--- a/packages/react-ui-kit/src/Form/RangeInput.tsx
+++ b/packages/react-ui-kit/src/Form/RangeInput.tsx
@@ -1,0 +1,124 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+/** @jsx jsx */
+import {CSSObject, jsx} from '@emotion/react';
+import React, {FC, forwardRef, Fragment} from 'react';
+import {TextProps} from '../Text';
+import {COLOR_V2} from '../Identity';
+import {manySelectors} from '../util';
+import {Theme} from '../Layout';
+import InputLabel from './InputLabel';
+
+const rangeInputWrapperStyles: CSSObject = {
+  position: 'relative',
+  marginTop: '19px',
+};
+
+const thumbSelectors = ['&::-webkit-slider-thumb', '&::-moz-range-thumb', '&::-ms-thumb'];
+const sliderSelectors = ['&::-webkit-slider-runnable-track', '&::-moz-range-track', '&::-ms-track'];
+
+const getImageCropZoomInputStyles = (theme: Theme, backgroundSize: `${number}% ${number}%`): CSSObject => ({
+  display: 'block',
+  '-webkit-appearance': 'none',
+  width: '100%',
+  height: '8px',
+  background: COLOR_V2.GRAY_60,
+  borderRadius: '4px',
+  backgroundImage: `linear-gradient(${theme.general.primaryColor}, ${theme.general.primaryColor})`,
+  backgroundSize: backgroundSize || '0% 100%',
+  backgroundRepeat: 'no-repeat',
+
+  ...manySelectors(thumbSelectors, {
+    '-webkit-appearance': 'none',
+    height: '18px',
+    width: '18px',
+    borderRadius: '50%',
+    background: COLOR_V2.GRAY_80,
+    cursor: 'pointer',
+    border: 'none',
+    boxShadow: 'none',
+  }),
+
+  ...manySelectors(sliderSelectors, {
+    '-webkit-appearance': 'none',
+    boxShadow: 'none',
+    border: 'none',
+    background: 'transparent',
+  }),
+});
+
+enum ValueLabelPosition {
+  LEFT = 'left',
+  RIGHT = 'right',
+}
+
+const getValueLabelStyles = (position: ValueLabelPosition): CSSObject => ({
+  pointerEvents: 'none',
+  bottom: '100%',
+  fontSize: '16px',
+  fontWeight: 300,
+  position: 'absolute',
+  [position]: '4px',
+});
+
+export interface RangeInputProps<T = HTMLInputElement> extends TextProps<T> {
+  label?: string;
+  minValueLabel?: string;
+  maxValueLabel?: string;
+}
+
+export const RangeInput: FC<RangeInputProps> = forwardRef<HTMLInputElement, RangeInputProps<HTMLInputElement>>(
+  ({
+    ref,
+    id = Math.random().toString(),
+    label,
+    minValueLabel,
+    maxValueLabel,
+    min = '0',
+    max = '100',
+    value = '0',
+    onChange,
+    ...inputProps
+  }) => {
+    const backgroundSize = `${((Number(value) - Number(min)) * 100) / (Number(max) - Number(min))}% 100%` as const;
+
+    return (
+      <Fragment>
+        {label && <InputLabel htmlFor={id}>{label}</InputLabel>}
+        <div css={rangeInputWrapperStyles}>
+          {minValueLabel && <span css={getValueLabelStyles(ValueLabelPosition.LEFT)}>{minValueLabel}</span>}
+          {maxValueLabel && <span css={getValueLabelStyles(ValueLabelPosition.RIGHT)}>{maxValueLabel}</span>}
+          <input
+            ref={ref}
+            css={(theme: Theme) => getImageCropZoomInputStyles(theme, backgroundSize)}
+            id={id}
+            name={id}
+            min={min}
+            max={max}
+            value={value}
+            onChange={onChange}
+            type="range"
+            {...inputProps}
+          />
+        </div>
+      </Fragment>
+    );
+  },
+);

--- a/packages/react-ui-kit/src/Form/RangeInput.tsx
+++ b/packages/react-ui-kit/src/Form/RangeInput.tsx
@@ -21,62 +21,14 @@
 import {CSSObject, jsx} from '@emotion/react';
 import React, {FC, forwardRef} from 'react';
 import {TextProps} from '../Text';
-import {COLOR_V2} from '../Identity';
-import {manySelectors} from '../util';
 import {Theme} from '../Layout';
 import InputLabel from './InputLabel';
-
-const rangeInputWrapperStyles: CSSObject = {
-  position: 'relative',
-  marginTop: '19px',
-};
-
-const thumbSelectors = ['&::-webkit-slider-thumb', '&::-moz-range-thumb', '&::-ms-thumb'];
-const sliderSelectors = ['&::-webkit-slider-runnable-track', '&::-moz-range-track', '&::-ms-track'];
-
-const getImageCropZoomInputStyles = (theme: Theme, backgroundSize: `${number}% ${number}%`): CSSObject => ({
-  display: 'block',
-  '-webkit-appearance': 'none',
-  width: '100%',
-  height: '8px',
-  background: COLOR_V2.GRAY_60,
-  borderRadius: '4px',
-  backgroundImage: `linear-gradient(${theme.general.primaryColor}, ${theme.general.primaryColor})`,
-  backgroundSize: backgroundSize || '0% 100%',
-  backgroundRepeat: 'no-repeat',
-
-  ...manySelectors(thumbSelectors, {
-    '-webkit-appearance': 'none',
-    height: '18px',
-    width: '18px',
-    borderRadius: '50%',
-    background: COLOR_V2.GRAY_80,
-    cursor: 'pointer',
-    border: 'none',
-    boxShadow: 'none',
-  }),
-
-  ...manySelectors(sliderSelectors, {
-    '-webkit-appearance': 'none',
-    boxShadow: 'none',
-    border: 'none',
-    background: 'transparent',
-  }),
-});
-
-enum ValueLabelPosition {
-  LEFT = 'left',
-  RIGHT = 'right',
-}
-
-const getValueLabelStyles = (position: ValueLabelPosition): CSSObject => ({
-  pointerEvents: 'none',
-  bottom: '100%',
-  fontSize: '16px',
-  fontWeight: 300,
-  position: 'absolute',
-  [position]: '4px',
-});
+import {
+  getImageCropZoomInputStyles,
+  getValueLabelStyles,
+  rangeInputWrapperStyles,
+  ValueLabelPosition,
+} from './RangeInput.styles';
 
 export interface RangeInputProps<T = HTMLInputElement> extends TextProps<T> {
   label?: string;
@@ -99,7 +51,11 @@ export const RangeInput: FC<RangeInputProps> = forwardRef<HTMLInputElement, Rang
     wrapperCSS,
     ...inputProps
   }) => {
-    const backgroundSize = `${((Number(value) - Number(min)) * 100) / (Number(max) - Number(min))}% 100%` as const;
+    const minNum = Number(min);
+    const maxNum = Number(max);
+    const valueNum = Number(value);
+
+    const backgroundSize = `${((valueNum - minNum) * 100) / (maxNum - minNum)}% 100%` as const;
 
     return (
       <div css={wrapperCSS}>

--- a/packages/react-ui-kit/src/Form/RangeInput.tsx
+++ b/packages/react-ui-kit/src/Form/RangeInput.tsx
@@ -19,7 +19,7 @@
 
 /** @jsx jsx */
 import {CSSObject, jsx} from '@emotion/react';
-import React, {FC, forwardRef, Fragment} from 'react';
+import React, {FC, forwardRef} from 'react';
 import {TextProps} from '../Text';
 import {COLOR_V2} from '../Identity';
 import {manySelectors} from '../util';
@@ -82,6 +82,7 @@ export interface RangeInputProps<T = HTMLInputElement> extends TextProps<T> {
   label?: string;
   minValueLabel?: string;
   maxValueLabel?: string;
+  wrapperCSS?: CSSObject;
 }
 
 export const RangeInput: FC<RangeInputProps> = forwardRef<HTMLInputElement, RangeInputProps<HTMLInputElement>>(
@@ -95,12 +96,13 @@ export const RangeInput: FC<RangeInputProps> = forwardRef<HTMLInputElement, Rang
     max = '100',
     value = '0',
     onChange,
+    wrapperCSS,
     ...inputProps
   }) => {
     const backgroundSize = `${((Number(value) - Number(min)) * 100) / (Number(max) - Number(min))}% 100%` as const;
 
     return (
-      <Fragment>
+      <div css={wrapperCSS}>
         {label && <InputLabel htmlFor={id}>{label}</InputLabel>}
         <div css={rangeInputWrapperStyles}>
           {minValueLabel && <span css={getValueLabelStyles(ValueLabelPosition.LEFT)}>{minValueLabel}</span>}
@@ -118,7 +120,7 @@ export const RangeInput: FC<RangeInputProps> = forwardRef<HTMLInputElement, Rang
             {...inputProps}
           />
         </div>
-      </Fragment>
+      </div>
     );
   },
 );

--- a/packages/react-ui-kit/src/Form/__snapshots__/RangeInput.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/RangeInput.test.tsx.snap
@@ -7,25 +7,16 @@ exports[`"RangeInput" matches snapshot 1`] = `
   transition: background 0.15s;
 }
 
-.emotion-2 {
+.emotion-3 {
   font-size: 14px;
   font-weight: 400;
   line-height: 16px;
   color: #54585f;
 }
 
-.emotion-3 {
+.emotion-4 {
   position: relative;
   margin-top: 19px;
-}
-
-.emotion-4 {
-  pointer-events: none;
-  bottom: 100%;
-  font-size: 16px;
-  font-weight: 300;
-  position: absolute;
-  left: 4px;
 }
 
 .emotion-5 {
@@ -34,10 +25,19 @@ exports[`"RangeInput" matches snapshot 1`] = `
   font-size: 16px;
   font-weight: 300;
   position: absolute;
-  right: 4px;
+  left: 4px;
 }
 
 .emotion-6 {
+  pointer-events: none;
+  bottom: 100%;
+  font-size: 16px;
+  font-weight: 300;
+  position: absolute;
+  right: 4px;
+}
+
+.emotion-7 {
   display: block;
   -webkit-appearance: none;
   width: 100%;
@@ -50,7 +50,7 @@ exports[`"RangeInput" matches snapshot 1`] = `
   background-repeat: no-repeat;
 }
 
-.emotion-6::-webkit-slider-thumb {
+.emotion-7::-webkit-slider-thumb {
   -webkit-appearance: none;
   height: 18px;
   width: 18px;
@@ -61,7 +61,7 @@ exports[`"RangeInput" matches snapshot 1`] = `
   box-shadow: none;
 }
 
-.emotion-6::-moz-range-thumb {
+.emotion-7::-moz-range-thumb {
   -webkit-appearance: none;
   height: 18px;
   width: 18px;
@@ -72,7 +72,7 @@ exports[`"RangeInput" matches snapshot 1`] = `
   box-shadow: none;
 }
 
-.emotion-6::-ms-thumb {
+.emotion-7::-ms-thumb {
   -webkit-appearance: none;
   height: 18px;
   width: 18px;
@@ -83,21 +83,21 @@ exports[`"RangeInput" matches snapshot 1`] = `
   box-shadow: none;
 }
 
-.emotion-6::-webkit-slider-runnable-track {
+.emotion-7::-webkit-slider-runnable-track {
   -webkit-appearance: none;
   box-shadow: none;
   border: none;
   background: transparent;
 }
 
-.emotion-6::-moz-range-track {
+.emotion-7::-moz-range-track {
   -webkit-appearance: none;
   box-shadow: none;
   border: none;
   background: transparent;
 }
 
-.emotion-6::-ms-track {
+.emotion-7::-ms-track {
   -webkit-appearance: none;
   box-shadow: none;
   border: none;
@@ -110,36 +110,40 @@ exports[`"RangeInput" matches snapshot 1`] = `
   <div
     className="emotion-0"
   >
-    <label
-      className="emotion-2"
-      htmlFor="zoom-input"
-    >
-      Zoom
-    </label>
     <div
-      className="emotion-3"
+      className="emotion-2"
     >
-      <span
+      <label
+        className="emotion-3"
+        htmlFor="zoom-input"
+      >
+        Zoom
+      </label>
+      <div
         className="emotion-4"
       >
-        -
-      </span>
-      <span
-        className="emotion-5"
-      >
-        +
-      </span>
-      <input
-        className="emotion-6"
-        id="zoom-input"
-        max={3}
-        min={1}
-        name="zoom-input"
-        onChange={[MockFunction]}
-        step={0.1}
-        type="range"
-        value={0}
-      />
+        <span
+          className="emotion-5"
+        >
+          -
+        </span>
+        <span
+          className="emotion-6"
+        >
+          +
+        </span>
+        <input
+          className="emotion-7"
+          id="zoom-input"
+          max={3}
+          min={1}
+          name="zoom-input"
+          onChange={[MockFunction]}
+          step={0.1}
+          type="range"
+          value={0}
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/react-ui-kit/src/Form/__snapshots__/RangeInput.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/RangeInput.test.tsx.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`"RangeInput" matches snapshot 1`] = `
+.emotion-0 {
+  background: #edeff0;
+  -webkit-transition: background 0.15s;
+  transition: background 0.15s;
+}
+
+.emotion-2 {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 16px;
+  color: #54585f;
+}
+
+.emotion-3 {
+  position: relative;
+  margin-top: 19px;
+}
+
+.emotion-4 {
+  pointer-events: none;
+  bottom: 100%;
+  font-size: 16px;
+  font-weight: 300;
+  position: absolute;
+  left: 4px;
+}
+
+.emotion-5 {
+  pointer-events: none;
+  bottom: 100%;
+  font-size: 16px;
+  font-weight: 300;
+  position: absolute;
+  right: 4px;
+}
+
+.emotion-6 {
+  display: block;
+  -webkit-appearance: none;
+  width: 100%;
+  height: 8px;
+  background: #9fa1a7;
+  border-radius: 4px;
+  background-image: linear-gradient(#0667c8, #0667c8);
+  -webkit-background-size: -50% 100%;
+  background-size: -50% 100%;
+  background-repeat: no-repeat;
+}
+
+.emotion-6::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 18px;
+  width: 18px;
+  border-radius: 50%;
+  background: #54585f;
+  cursor: pointer;
+  border: none;
+  box-shadow: none;
+}
+
+.emotion-6::-moz-range-thumb {
+  -webkit-appearance: none;
+  height: 18px;
+  width: 18px;
+  border-radius: 50%;
+  background: #54585f;
+  cursor: pointer;
+  border: none;
+  box-shadow: none;
+}
+
+.emotion-6::-ms-thumb {
+  -webkit-appearance: none;
+  height: 18px;
+  width: 18px;
+  border-radius: 50%;
+  background: #54585f;
+  cursor: pointer;
+  border: none;
+  box-shadow: none;
+}
+
+.emotion-6::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  box-shadow: none;
+  border: none;
+  background: transparent;
+}
+
+.emotion-6::-moz-range-track {
+  -webkit-appearance: none;
+  box-shadow: none;
+  border: none;
+  background: transparent;
+}
+
+.emotion-6::-ms-track {
+  -webkit-appearance: none;
+  box-shadow: none;
+  border: none;
+  background: transparent;
+}
+
+<div
+  className="emotion-0"
+>
+  <div
+    className="emotion-0"
+  >
+    <label
+      className="emotion-2"
+      htmlFor="zoom-input"
+    >
+      Zoom
+    </label>
+    <div
+      className="emotion-3"
+    >
+      <span
+        className="emotion-4"
+      >
+        -
+      </span>
+      <span
+        className="emotion-5"
+      >
+        +
+      </span>
+      <input
+        className="emotion-6"
+        id="zoom-input"
+        max={3}
+        min={1}
+        name="zoom-input"
+        onChange={[MockFunction]}
+        step={0.1}
+        type="range"
+        value={0}
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react-ui-kit/src/Form/index.ts
+++ b/packages/react-ui-kit/src/Form/index.ts
@@ -27,6 +27,7 @@ export * from './Form';
 export * from './Input';
 export * from './InputBlock';
 export * from './InputSubmitCombo';
+export * from './RangeInput';
 export * from './RoundIconButton';
 export * from './Select';
 export * from './ShakeBox';

--- a/packages/react-ui-kit/src/util.ts
+++ b/packages/react-ui-kit/src/util.ts
@@ -33,9 +33,9 @@ export const filterProps: <T extends Record<string, any>>(props: T, propsToFilte
   );
 };
 
-export function manySelectors(selectors: string[], css: CSSObject) {
+export const manySelectors = (selectors: string[], css: CSSObject) => {
   return selectors.reduce((acc, selector) => {
     acc[selector] = css;
     return acc;
   }, {});
-}
+};

--- a/packages/react-ui-kit/src/util.ts
+++ b/packages/react-ui-kit/src/util.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {CSSObject} from '@emotion/react';
+
 export const noop = () => {};
 
 export const inlineSVG = (svg: string) => `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
@@ -30,3 +32,10 @@ export const filterProps: <T extends Record<string, any>>(props: T, propsToFilte
     {},
   );
 };
+
+export function manySelectors(selectors: string[], css: CSSObject) {
+  return selectors.reduce((acc, selector) => {
+    acc[selector] = css;
+    return acc;
+  }, {});
+}

--- a/packages/react-ui-kit/src/util.ts
+++ b/packages/react-ui-kit/src/util.ts
@@ -33,9 +33,7 @@ export const filterProps: <T extends Record<string, any>>(props: T, propsToFilte
   );
 };
 
-export const manySelectors = (selectors: string[], css: CSSObject) => {
-  return selectors.reduce((acc, selector) => {
+export const manySelectors = (selectors: string[], css: CSSObject) => selectors.reduce((acc, selector) => {
     acc[selector] = css;
     return acc;
   }, {});
-};

--- a/packages/react-ui-kit/src/util.ts
+++ b/packages/react-ui-kit/src/util.ts
@@ -33,7 +33,8 @@ export const filterProps: <T extends Record<string, any>>(props: T, propsToFilte
   );
 };
 
-export const manySelectors = (selectors: string[], css: CSSObject) => selectors.reduce((acc, selector) => {
+export const manySelectors = (selectors: string[], css: CSSObject) =>
+  selectors.reduce((acc, selector) => {
     acc[selector] = css;
     return acc;
   }, {});


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

Add custom `RangeInput` (`range` type input) component to `react-ui-kit` package. (we need it in TM splash screen customisation component). Custom input styling was applied, so input should look the same across different browsers.

<img width="541" alt="Screenshot 2022-07-25 at 08 54 54" src="https://user-images.githubusercontent.com/45733298/180716330-de24c9a2-5029-4979-a52b-1eb69cea2285.png">

Customisable:
- wrapper styles (`wrapperCSS` prop)
- input styles (`css` emotions prop)
- min and max value labels (`minValueLabel` and `maxValueLabel` strings)
- label (`label` string prop)
- all input's native props (`onChange`, `value`, `min`, `max`, `step`, etc.)

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
