### PR TITLE
feat: add a link variant for use in the webapp

### DIFF
--- a/packages/react-ui-kit/src/Form/Checkbox.tsx
+++ b/packages/react-ui-kit/src/Form/Checkbox.tsx
@@ -21,9 +21,8 @@
 import {jsx} from '@emotion/react';
 import React from 'react';
 
-import {COLOR} from '../Identity';
 import {Theme} from '../Layout';
-import {Text, TextProps, textStyle, textLinkStyle} from '../Text';
+import {Text, TextProps, textStyle} from '../Text';
 import {filterProps} from '../util';
 import {INPUT_CLASSNAME, InputProps} from './Input';
 
@@ -78,9 +77,6 @@ const StyledLabel = (props: StyledLabelProps) => {
           lineHeight: 1.4,
           margin: '0 8px 0 0px',
           color: theme.general.color,
-        },
-        a: {
-          ...textLinkStyle(theme, {}),
         },
         position: 'relative',
         margin: '0 0 0 -16px',
@@ -151,17 +147,12 @@ export const Checkbox: React.FC<CheckboxProps<HTMLInputElement>> = React.forward
 
 export type CheckboxLabelProps<T = HTMLSpanElement> = TextProps<T>;
 
-export const CheckboxLabel = ({color = COLOR.TEXT, ...props}: CheckboxLabelProps) => (
+export const CheckboxLabel = ({...props}: CheckboxLabelProps) => (
   <Text
     css={(theme: Theme) => ({
       ...textStyle(theme, {
-        color,
         ...props,
       }),
-      a: {
-        color: COLOR.LINK,
-        textDecoration: 'none',
-      },
     })}
     {...props}
   />

--- a/packages/react-ui-kit/src/Form/Input.tsx
+++ b/packages/react-ui-kit/src/Form/Input.tsx
@@ -18,7 +18,7 @@
  */
 
 /** @jsx jsx */
-import {CSSObject, jsx} from '@emotion/react';
+import {CSSObject, jsx, useTheme} from '@emotion/react';
 import type {Property} from 'csstype';
 import React, {ReactElement, useState} from 'react';
 
@@ -60,18 +60,20 @@ export const inputStyle: <T>(theme: Theme, props: InputProps<T>, hasError?: bool
       ...placeholderStyle,
     },
     '&:focus': {
-      boxShadow: `0 0 0 1px ${COLOR_V2.BLUE}`,
+      boxShadow: `inset 0 0 0 1px ${theme.general.primaryColor}`,
     },
     '&:invalid:not(:focus)': !markInvalid
       ? {
-          boxShadow: `0 0 0 1px ${COLOR_V2.GRAY}`,
+          boxShadow: `inset 0 0 0 1px ${theme.Select.borderColor}`,
         }
       : {},
     background: disabled ? theme.Input.backgroundColorDisabled : theme.Input.backgroundColor,
     border: 'none',
-    borderRadius: '4px',
-    boxShadow: markInvalid ? `0 0 0 1px ${COLOR_V2.RED}` : `0 0 0 1px ${COLOR_V2.GRAY_40}`,
-    caretColor: COLOR_V2.BLUE,
+    borderRadius: '12px',
+    boxShadow: markInvalid
+      ? `inset 0 0 0 1px ${theme.general.dangerColor}`
+      : `inset 0 0 0 1px ${theme.Select.borderColor}`,
+    caretColor: theme.general.primaryColor,
     color: theme.general.color,
     fontWeight: 300,
     height: '48px',
@@ -106,17 +108,19 @@ export const Input: React.FC<InputProps<HTMLInputElement>> = React.forwardRef<
 
   const toggleSetPassword = () => setTogglePassword(prevState => !prevState);
 
+  const theme = useTheme();
+
   return (
     <div
       className={INPUT_GROUP}
-      css={{
+      css={(theme: Theme) => ({
         marginBottom: hasError ? '2px' : '20px',
         width: '100%',
         '&:focus-within label': {
-          color: COLOR_V2.BLUE,
+          color: theme.general.primaryColor,
         },
         ...wrapperCSS,
-      }}
+      })}
     >
       {label && (
         <InputLabel htmlFor={props.id} isRequired={props.required} markInvalid={props.markInvalid}>
@@ -148,13 +152,22 @@ export const Input: React.FC<InputProps<HTMLInputElement>> = React.forwardRef<
             aria-controls={props.id}
             aria-expanded={togglePassword}
           >
-            {togglePassword ? <HideIcon color={COLOR_V2.BLACK} /> : <ShowIcon color={COLOR_V2.BLACK} />}
+            {togglePassword ? <HideIcon /> : <ShowIcon />}
           </button>
         )}
       </div>
 
       {!hasError && helperText && (
-        <p css={{fontSize: '12px', fontWeight: 400, color: COLOR_V2.GRAY_80, marginTop: 8}}>{helperText}</p>
+        <p
+          css={(theme: Theme) => ({
+            fontSize: '12px',
+            fontWeight: 400,
+            color: theme.Input.placeholderColor,
+            marginTop: 8,
+          })}
+        >
+          {helperText}
+        </p>
       )}
 
       {error}

--- a/packages/react-ui-kit/src/Form/Input.tsx
+++ b/packages/react-ui-kit/src/Form/Input.tsx
@@ -22,7 +22,6 @@ import {CSSObject, jsx, useTheme} from '@emotion/react';
 import type {Property} from 'csstype';
 import React, {ReactElement, useState} from 'react';
 
-import {COLOR_V2} from '../Identity';
 import type {Theme} from '../Layout';
 import type {TextProps} from '../Text';
 import {filterProps} from '../util';
@@ -60,19 +59,17 @@ export const inputStyle: <T>(theme: Theme, props: InputProps<T>, hasError?: bool
       ...placeholderStyle,
     },
     '&:focus': {
-      boxShadow: `inset 0 0 0 1px ${theme.general.primaryColor}`,
+      boxShadow: `0 0 0 1px ${theme.general.primaryColor}`,
     },
     '&:invalid:not(:focus)': !markInvalid
       ? {
-          boxShadow: `inset 0 0 0 1px ${theme.Select.borderColor}`,
+          boxShadow: `0 0 0 1px ${theme.Select.borderColor}`,
         }
       : {},
     background: disabled ? theme.Input.backgroundColorDisabled : theme.Input.backgroundColor,
     border: 'none',
     borderRadius: '12px',
-    boxShadow: markInvalid
-      ? `inset 0 0 0 1px ${theme.general.dangerColor}`
-      : `inset 0 0 0 1px ${theme.Select.borderColor}`,
+    boxShadow: markInvalid ? `0 0 0 1px ${theme.general.dangerColor}` : `0 0 0 1px ${theme.Select.borderColor}`,
     caretColor: theme.general.primaryColor,
     color: theme.general.color,
     fontWeight: 300,

--- a/packages/react-ui-kit/src/Form/Select.tsx
+++ b/packages/react-ui-kit/src/Form/Select.tsx
@@ -39,6 +39,7 @@ export type Option = {
 
 interface SelectProps<IsMulti extends boolean> extends StateManagerProps<Option, IsMulti> {
   id: string;
+  disabled: boolean;
   dataUieName: string;
   options: Option[];
   wrapperCSS?: CSSObject;
@@ -55,6 +56,7 @@ export const Select = <IsMulti extends boolean = false>({
   label,
   error,
   helperText,
+  disabled = false,
   dataUieName,
   options,
   isMulti,
@@ -94,6 +96,7 @@ export const Select = <IsMulti extends boolean = false>({
           ValueContainer,
           IndicatorsContainer,
         }}
+        isDisabled={disabled}
         hideSelectedOptions={false}
         isSearchable={false}
         isClearable={false}

--- a/packages/react-ui-kit/src/Form/SelectStyles.tsx
+++ b/packages/react-ui-kit/src/Form/SelectStyles.tsx
@@ -76,33 +76,46 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
     borderRadius: 12,
     marginBottom: 0,
     marginTop: 4,
+    overflowY: 'overlay',
   }),
   menuList: provided => ({
     ...provided,
+    borderRadius: 12,
     paddingBottom: 0,
     paddingTop: 0,
   }),
   option: (provided, {isDisabled, isFocused, isSelected}) => ({
     ...provided,
+    backgroundColor: theme.Input.backgroundColor,
+    color: theme.general.color,
     padding: '10px 18px',
     cursor: isDisabled ? 'not-allowed' : 'pointer',
     fontSize: '16px',
     fontWeight: 300,
     lineHeight: '24px',
-    ...(isSelected && {
-      backgroundColor: 'inherit',
-      color: 'inherit',
-    }),
-    ...(isFocused && {
-      background: theme.general.primaryColor,
-      borderColor: theme.general.primaryColor,
-      color: theme.Select.contrastTextColor,
-    }),
+    ...(isFocused &&
+      !isDisabled && {
+        background: theme.general.primaryColor,
+        borderColor: theme.general.primaryColor,
+        color: theme.Select.contrastTextColor,
+      }),
     '&:hover, &:active, &:focus': {
       background: theme.general.primaryColor,
       borderColor: theme.general.primaryColor,
       color: theme.Select.contrastTextColor,
     },
+    ...(isDisabled && {
+      backgroundColor: theme.Input.backgroundColorDisabled,
+      color: theme.Select.disabledColor,
+      '&:hover, &:active, &:focus': {
+        backgroundColor: theme.Select.borderColor,
+        color: theme.Select.disabledColor,
+      },
+      ...(isFocused && {
+        backgroundColor: theme.Select.borderColor,
+        color: theme.Select.disabledColor,
+      }),
+    }),
     '&:not(:last-of-type)': {
       borderBottom: `1px solid ${theme.Select.borderColor}`,
     },
@@ -118,5 +131,9 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
     padding: 0,
     width: '100%',
     display: 'grid',
+  }),
+  singleValue: provided => ({
+    ...provided,
+    color: theme.general.color,
   }),
 });

--- a/packages/react-ui-kit/src/Form/SelectStyles.tsx
+++ b/packages/react-ui-kit/src/Form/SelectStyles.tsx
@@ -29,6 +29,7 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
   }),
   container: (provided, {isDisabled, selectProps}) => {
     const {menuIsOpen} = selectProps;
+    const isSelectDisabled = selectProps.isDisabled;
 
     return {
       ...inputStyle(theme, {disabled: isDisabled, markInvalid}),
@@ -53,13 +54,13 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
       }),
       ...(!menuIsOpen && {
         '&:hover': {
-          boxShadow: `0 0 0 1px ${theme.Select.borderColor}`,
+          boxShadow: !isSelectDisabled && `0 0 0 1px ${theme.Select.borderColor}`,
         },
         '&:focus, &:active': {
-          boxShadow: `0 0 0 1px ${theme.general.primaryColor}`,
+          boxShadow: !isSelectDisabled && `0 0 0 1px ${theme.general.primaryColor}`,
         },
       }),
-      cursor: 'pointer',
+      cursor: !isSelectDisabled && 'pointer',
     };
   },
   control: () => ({
@@ -70,6 +71,15 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
     height: 'auto',
     minHeight: '48px',
   }),
+  dropdownIndicator: (provided, selectProps) => {
+    const isSelectDisabled = selectProps.isDisabled;
+    return {
+      ...provided,
+      '& > svg': {
+        fill: isSelectDisabled && theme.Input.placeholderColor,
+      },
+    };
+  },
   menu: provided => ({
     ...provided,
     boxShadow: `0 0 0 1px ${theme.general.primaryColor}, 0 4px 11px hsl(0deg 0% 0% / 10%)`,
@@ -132,8 +142,11 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
     width: '100%',
     display: 'grid',
   }),
-  singleValue: provided => ({
-    ...provided,
-    color: theme.general.color,
-  }),
+  singleValue: (provided, selectProps) => {
+    const isSelectDisabled = selectProps.isDisabled;
+    return {
+      ...provided,
+      color: isSelectDisabled ? theme.Input.placeholderColor : theme.general.color,
+    };
+  },
 });

--- a/packages/react-ui-kit/src/Form/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Checkbox.test.tsx.snap
@@ -76,30 +76,6 @@ exports[`"Checkbox" renders (dark theme) 1`] = `
   color: #fff;
 }
 
-.emotion-2 a {
-  color: #0667c8;
-  display: inline;
-  font-size: 16px;
-  font-weight: 300;
-  text-align: left;
-  text-transform: none;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: all 0.24s;
-  transition: all 0.24s;
-}
-
-.emotion-2 a:hover {
-  color: rgb(5, 87, 168);
-}
-
-.emotion-2 a:visited,
-.emotion-2 a:link,
-.emotion-2 a:active {
-  color: #0667c8;
-}
-
 <div
   className="emotion-0"
 >
@@ -214,30 +190,6 @@ exports[`"Checkbox" renders 1`] = `
   line-height: 1.4;
   margin: 0 8px 0 0px;
   color: rgb(29, 30, 31);
-}
-
-.emotion-2 a {
-  color: #0667c8;
-  display: inline;
-  font-size: 16px;
-  font-weight: 300;
-  text-align: left;
-  text-transform: none;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: all 0.24s;
-  transition: all 0.24s;
-}
-
-.emotion-2 a:hover {
-  color: rgb(5, 87, 168);
-}
-
-.emotion-2 a:visited,
-.emotion-2 a:link,
-.emotion-2 a:active {
-  color: #0667c8;
 }
 
 <div
@@ -356,30 +308,6 @@ exports[`"Checkbox" renders as invalid 1`] = `
   color: rgb(29, 30, 31);
 }
 
-.emotion-2 a {
-  color: #0667c8;
-  display: inline;
-  font-size: 16px;
-  font-weight: 300;
-  text-align: left;
-  text-transform: none;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: all 0.24s;
-  transition: all 0.24s;
-}
-
-.emotion-2 a:hover {
-  color: rgb(5, 87, 168);
-}
-
-.emotion-2 a:visited,
-.emotion-2 a:link,
-.emotion-2 a:active {
-  color: #0667c8;
-}
-
 <div
   className="emotion-0"
 >
@@ -492,30 +420,6 @@ exports[`"Checkbox" renders disabled 1`] = `
   color: rgb(29, 30, 31);
 }
 
-.emotion-2 a {
-  color: #0667c8;
-  display: inline;
-  font-size: 16px;
-  font-weight: 300;
-  text-align: left;
-  text-transform: none;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-transition: all 0.24s;
-  transition: all 0.24s;
-}
-
-.emotion-2 a:hover {
-  color: rgb(5, 87, 168);
-}
-
-.emotion-2 a:visited,
-.emotion-2 a:link,
-.emotion-2 a:active {
-  color: #0667c8;
-}
-
 <div
   className="emotion-0"
 >
@@ -578,12 +482,6 @@ exports[`"CheckboxLabel" renders 1`] = `
   font-weight: 300;
   text-align: left;
   text-transform: none;
-}
-
-.emotion-1 a {
-  color: rgb(29, 30, 31);
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 <div

--- a/packages/react-ui-kit/src/Form/__snapshots__/ErrorMessage.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/ErrorMessage.test.tsx.snap
@@ -52,19 +52,15 @@ exports[`"ErrorMessage" renders 1`] = `
 .emotion-1 a {
   color: rgb(29, 30, 31);
   display: inline;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 300;
   text-align: left;
-  text-transform: none;
+  text-transform: uppercase;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   -webkit-transition: all 0.24s;
   transition: all 0.24s;
-}
-
-.emotion-1 a:hover {
-  color: rgb(24, 25, 26);
 }
 
 .emotion-1 a:visited,
@@ -73,8 +69,12 @@ exports[`"ErrorMessage" renders 1`] = `
   color: rgb(29, 30, 31);
 }
 
+.emotion-1 a:hover {
+  color: rgb(24, 25, 26);
+}
+
 .emotion-2 {
-  color: rgb(29, 30, 31);
+  color: #c20013;
   display: inline;
   font-size: 12px;
   font-weight: 300;

--- a/packages/react-ui-kit/src/Form/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Input.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`"Input" renders 1`] = `
 .emotion-3 {
   background: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #dce0e3;
   caret-color: #0667c8;
   color: rgb(29, 30, 31);
@@ -59,7 +59,7 @@ exports[`"Input" renders 1`] = `
 }
 
 .emotion-3:invalid:not(:focus) {
-  box-shadow: 0 0 0 1px undefined;
+  box-shadow: 0 0 0 1px #dce0e3;
 }
 
 <div
@@ -102,7 +102,7 @@ exports[`"Input" renders as disabled 1`] = `
 .emotion-3 {
   background: #edeff0;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #dce0e3;
   caret-color: #0667c8;
   color: rgb(29, 30, 31);
@@ -138,7 +138,7 @@ exports[`"Input" renders as disabled 1`] = `
 }
 
 .emotion-3:invalid:not(:focus) {
-  box-shadow: 0 0 0 1px undefined;
+  box-shadow: 0 0 0 1px #dce0e3;
 }
 
 <div
@@ -182,7 +182,7 @@ exports[`"Input" renders as invalid 1`] = `
 .emotion-3 {
   background: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #c20013;
   caret-color: #0667c8;
   color: rgb(29, 30, 31);
@@ -257,7 +257,7 @@ exports[`"Input" renders with placeholderTextTransform 1`] = `
 .emotion-3 {
   background: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #dce0e3;
   caret-color: #0667c8;
   color: rgb(29, 30, 31);
@@ -293,7 +293,7 @@ exports[`"Input" renders with placeholderTextTransform 1`] = `
 }
 
 .emotion-3:invalid:not(:focus) {
-  box-shadow: 0 0 0 1px undefined;
+  box-shadow: 0 0 0 1px #dce0e3;
 }
 
 <div

--- a/packages/react-ui-kit/src/Form/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Select.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`"Select" renders 1`] = `
 .emotion-2 {
   background: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #dce0e3;
   caret-color: #0667c8;
   color: rgb(29, 30, 31);
@@ -58,7 +58,7 @@ exports[`"Select" renders 1`] = `
 }
 
 .emotion-2:invalid:not(:focus) {
-  box-shadow: 0 0 0 1px undefined;
+  box-shadow: 0 0 0 1px #dce0e3;
 }
 
 .emotion-2:-moz-focusring {
@@ -299,12 +299,12 @@ exports[`"Select" renders as disabled 1`] = `
 }
 
 .emotion-2 {
-  background: #fff;
+  background: #edeff0;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #dce0e3;
   caret-color: #0667c8;
-  color: rgb(29, 30, 31);
+  color: #676b71;
   font-weight: 300;
   height: auto;
   line-height: 24px;
@@ -313,7 +313,7 @@ exports[`"Select" renders as disabled 1`] = `
   width: 100%;
   min-height: 48px;
   position: relative;
-  cursor: pointer;
+  background-color: #edeff0;
 }
 
 .emotion-2::-moz-placeholder {
@@ -340,21 +340,12 @@ exports[`"Select" renders as disabled 1`] = `
 }
 
 .emotion-2:invalid:not(:focus) {
-  box-shadow: 0 0 0 1px undefined;
+  box-shadow: 0 0 0 1px #dce0e3;
 }
 
 .emotion-2:-moz-focusring {
   color: transparent;
   text-shadow: 0 0 0 #000;
-}
-
-.emotion-2:hover {
-  box-shadow: 0 0 0 1px #dce0e3;
-}
-
-.emotion-2:focus,
-.emotion-2:active {
-  box-shadow: 0 0 0 1px #0667c8;
 }
 
 .emotion-3 {
@@ -473,6 +464,10 @@ exports[`"Select" renders as disabled 1`] = `
   color: hsl(0, 0%, 60%);
 }
 
+.emotion-11>svg {
+  fill: rgb(80, 82, 84);
+}
+
 .emotion-12 {
   fill: rgb(29, 30, 31);
   overflow: visible;
@@ -521,7 +516,7 @@ exports[`"Select" renders as disabled 1`] = `
             aria-haspopup={true}
             aria-readonly={true}
             className="emotion-8"
-            disabled={false}
+            disabled={true}
             id="react-select-3-input"
             inputMode="none"
             onBlur={[Function]}
@@ -583,7 +578,7 @@ exports[`"Select" renders as invalid 1`] = `
 .emotion-2 {
   background: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 12px;
   box-shadow: 0 0 0 1px #c20013;
   caret-color: #0667c8;
   color: rgb(29, 30, 31);

--- a/packages/react-ui-kit/src/Text/Link.tsx
+++ b/packages/react-ui-kit/src/Text/Link.tsx
@@ -47,12 +47,12 @@ export const linkStyle: <T>(theme: Theme, props: LinkProps<T>) => CSSObject = (
     color: color,
     cursor: 'pointer',
     textDecoration: 'none',
+    '&:visited, &:link, &:active': {
+      color: color,
+    },
     ...(variant === LinkVariant.PRIMARY && {
       '&:hover, &:visited:hover': {
         color: theme.general.primaryColor,
-      },
-      '&:visited': {
-        color: color,
       },
       textDecoration: 'underline',
       textUnderlineOffset: '2px',
@@ -64,9 +64,6 @@ export const linkStyle: <T>(theme: Theme, props: LinkProps<T>) => CSSObject = (
       transition: defaultTransition,
       '&:hover': {
         color: hoverColor,
-      },
-      '&:visited, &:link, &:active': {
-        color: color,
       },
     }),
   };

--- a/packages/react-ui-kit/src/Text/Link.tsx
+++ b/packages/react-ui-kit/src/Text/Link.tsx
@@ -23,30 +23,52 @@ import Color from 'color';
 
 import {COLOR} from '../Identity/colors';
 import {defaultTransition} from '../Identity/motions';
-import type {Theme} from '../Layout';
+import {Theme} from '../Layout';
 import {filterProps} from '../util';
 import {TextProps, filterTextProps, textStyle} from './Text';
 
-export interface LinkProps<T = HTMLAnchorElement> extends TextProps<T> {}
+export enum LinkVariant {
+  PRIMARY = 'primary',
+  SECONDARY = 'secondary',
+}
+
+export interface LinkProps<T = HTMLAnchorElement> extends TextProps<T> {
+  variant?: LinkVariant;
+}
 
 export const linkStyle: <T>(theme: Theme, props: LinkProps<T>) => CSSObject = (
   theme,
-  {bold = true, color = theme.general.color, fontSize = '11px', textTransform = 'uppercase', ...props},
+  {variant = LinkVariant.SECONDARY, color = theme.general.color, ...props},
 ) => {
   const darker = 0.16;
-  const hoverColor = Color(color).mix(Color(COLOR.BLACK), darker).toString();
+  const hoverColor = color === COLOR.TEXT ? Color(color)?.mix(Color(COLOR.BLACK), darker).toString() : COLOR.BLACK;
   return {
-    ...textStyle(theme, {bold, color, fontSize, textTransform, ...props}),
-    '&:hover': {
-      color: hoverColor,
-    },
-    '&:visited, &:link, &:active': {
-      color: color,
-    },
+    ...textStyle(theme, {color, ...props}),
     color: color,
     cursor: 'pointer',
     textDecoration: 'none',
-    transition: defaultTransition,
+    ...(variant === LinkVariant.PRIMARY && {
+      '&:hover, &:visited:hover': {
+        color: theme.general.primaryColor,
+      },
+      '&:visited': {
+        color: color,
+      },
+      textDecoration: 'underline',
+      textUnderlineOffset: '2px',
+    }),
+    ...(variant === LinkVariant.SECONDARY && {
+      bold: true,
+      fontSize: '11px',
+      textTransform: 'uppercase',
+      transition: defaultTransition,
+      '&:hover': {
+        color: hoverColor,
+      },
+      '&:visited, &:link, &:active': {
+        color: color,
+      },
+    }),
   };
 };
 

--- a/packages/react-ui-kit/src/Text/Text.tsx
+++ b/packages/react-ui-kit/src/Text/Text.tsx
@@ -69,7 +69,7 @@ export const textStyle: <T>(theme: Theme, props: TextProps<T>) => CSSObject = (
     truncate = false,
   },
 ) => ({
-  color: muted ? COLOR.GRAY : theme.general.color,
+  color: muted ? COLOR.GRAY : color,
   display: block ? 'block' : 'inline',
   fontSize: fontSize,
   fontWeight: bold ? 600 : light ? 200 : 300,

--- a/packages/react-ui-kit/src/Text/__snapshots__/Label.test.tsx.snap
+++ b/packages/react-ui-kit/src/Text/__snapshots__/Label.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`"LabelLink" renders (dark theme) 1`] = `
 .emotion-1 {
   color: #fff;
   display: inline;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 300;
   text-align: left;
   text-transform: uppercase;
   cursor: pointer;
@@ -85,14 +85,14 @@ exports[`"LabelLink" renders (dark theme) 1`] = `
   transition: all 0.24s;
 }
 
-.emotion-1:hover {
-  color: rgb(214, 214, 214);
-}
-
 .emotion-1:visited,
 .emotion-1:link,
 .emotion-1:active {
   color: #fff;
+}
+
+.emotion-1:hover {
+  color: #000;
 }
 
 <div
@@ -116,8 +116,8 @@ exports[`"LabelLink" renders 1`] = `
 .emotion-1 {
   color: rgb(29, 30, 31);
   display: inline;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 300;
   text-align: left;
   text-transform: uppercase;
   cursor: pointer;
@@ -127,14 +127,14 @@ exports[`"LabelLink" renders 1`] = `
   transition: all 0.24s;
 }
 
-.emotion-1:hover {
-  color: rgb(24, 25, 26);
-}
-
 .emotion-1:visited,
 .emotion-1:link,
 .emotion-1:active {
   color: rgb(29, 30, 31);
+}
+
+.emotion-1:hover {
+  color: rgb(24, 25, 26);
 }
 
 <div

--- a/packages/react-ui-kit/src/Text/__snapshots__/Link.test.tsx.snap
+++ b/packages/react-ui-kit/src/Text/__snapshots__/Link.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`"Link" renders (dark theme) 1`] = `
   color: #fff;
   display: inline;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 300;
   text-align: left;
   text-transform: uppercase;
   cursor: pointer;
@@ -21,14 +21,14 @@ exports[`"Link" renders (dark theme) 1`] = `
   transition: all 0.24s;
 }
 
-.emotion-1:hover {
-  color: rgb(214, 214, 214);
-}
-
 .emotion-1:visited,
 .emotion-1:link,
 .emotion-1:active {
   color: #fff;
+}
+
+.emotion-1:hover {
+  color: #000;
 }
 
 <div
@@ -54,7 +54,7 @@ exports[`"Link" renders 1`] = `
   color: rgb(29, 30, 31);
   display: inline;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 300;
   text-align: left;
   text-transform: uppercase;
   cursor: pointer;
@@ -64,14 +64,14 @@ exports[`"Link" renders 1`] = `
   transition: all 0.24s;
 }
 
-.emotion-1:hover {
-  color: rgb(24, 25, 26);
-}
-
 .emotion-1:visited,
 .emotion-1:link,
 .emotion-1:active {
   color: rgb(29, 30, 31);
+}
+
+.emotion-1:hover {
+  color: rgb(24, 25, 26);
 }
 
 <div

--- a/packages/react-ui-kit/src/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/react-ui-kit/src/Text/__snapshots__/Text.test.tsx.snap
@@ -225,7 +225,7 @@ exports[`"Text" renders with color 1`] = `
 }
 
 .emotion-1 {
-  color: rgb(29, 30, 31);
+  color: #0772de;
   display: inline;
   font-size: 16px;
   font-weight: 300;

--- a/packages/react-ui-kit/src/Text/__snapshots__/TextLink.test.tsx.snap
+++ b/packages/react-ui-kit/src/Text/__snapshots__/TextLink.test.tsx.snap
@@ -10,10 +10,10 @@ exports[`"TextLink" renders (dark theme) 1`] = `
 .emotion-1 {
   color: #0667c8;
   display: inline;
-  font-size: 16px;
+  font-size: 11px;
   font-weight: 300;
   text-align: left;
-  text-transform: none;
+  text-transform: uppercase;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -21,14 +21,14 @@ exports[`"TextLink" renders (dark theme) 1`] = `
   transition: all 0.24s;
 }
 
-.emotion-1:hover {
-  color: rgb(5, 87, 168);
-}
-
 .emotion-1:visited,
 .emotion-1:link,
 .emotion-1:active {
   color: #0667c8;
+}
+
+.emotion-1:hover {
+  color: #000;
 }
 
 <div
@@ -53,10 +53,10 @@ exports[`"TextLink" renders 1`] = `
 .emotion-1 {
   color: #0667c8;
   display: inline;
-  font-size: 16px;
+  font-size: 11px;
   font-weight: 300;
   text-align: left;
-  text-transform: none;
+  text-transform: uppercase;
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -64,14 +64,14 @@ exports[`"TextLink" renders 1`] = `
   transition: all 0.24s;
 }
 
-.emotion-1:hover {
-  color: rgb(5, 87, 168);
-}
-
 .emotion-1:visited,
 .emotion-1:link,
 .emotion-1:active {
   color: #0667c8;
+}
+
+.emotion-1:hover {
+  color: #000;
 }
 
 <div

--- a/packages/react-ui-kit/src/Text/__snapshots__/Title.test.tsx.snap
+++ b/packages/react-ui-kit/src/Text/__snapshots__/Title.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`"Title" renders (dark theme) 1`] = `
 }
 
 .emotion-1 {
-  color: #fff;
+  color: #696c6e;
   display: block;
   font-size: 32px;
   font-weight: 600;
@@ -36,7 +36,7 @@ exports[`"Title" renders 1`] = `
 }
 
 .emotion-1 {
-  color: rgb(29, 30, 31);
+  color: #696c6e;
   display: block;
   font-size: 32px;
   font-weight: 600;


### PR DESCRIPTION
#### Link

- Add a Link variant to use the UI-kit Link in the web-app
- Keep the previous option as the default not to require any change to team-management

#### Checkbox

- Remove hardcoded style for color and links from Checkbox component

#### Select

- Fix styles that were not being applied because of React-Select prebaked theme
- Restore the disabled prop to Select and apply the corresponding styles
- Apply a border radius to Input corresponding to webapp design
![Peek 2022-08-09 15-25](https://user-images.githubusercontent.com/78490891/183658285-3928a8c8-6d2a-4eff-94e5-bcf5bb246570.gif)

