### PR TITLE
feat: move the theme in ui-kit and expose css variables

### DIFF
--- a/packages/react-ui-kit/src/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/GlobalCssVariables.tsx
@@ -41,6 +41,7 @@ const light: <T>() => CSSObject = () => ({
   '--text-input-label': COLOR_V2.GRAY_80,
   '--danger-color': COLOR_V2.RED_LIGHT_500,
   '--app-bg': COLOR_V2.GRAY_10,
+  '--main-color': COLOR.BLACK,
 });
 
 const dark: <T>() => CSSObject = () => ({
@@ -63,6 +64,7 @@ const dark: <T>() => CSSObject = () => ({
   '--text-input-label': COLOR_V2.GRAY_40,
   '--danger-color': COLOR_V2.RED_DARK_500,
   '--app-bg': COLOR_V2.GRAY_95,
+  '--main-color': COLOR.WHITE,
 });
 
 const accentColors: <T>() => CSSObject = () => ({

--- a/packages/react-ui-kit/src/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/GlobalCssVariables.tsx
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2019 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/packages/react-ui-kit/src/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/GlobalCssVariables.tsx
@@ -21,7 +21,7 @@
 import {CSSObject} from '@emotion/react';
 import {COLOR, COLOR_V2} from './Identity';
 
-const light: <T>() => CSSObject = () => ({
+const light: () => CSSObject = () => ({
   // Checkbox
   '--checkbox-background': COLOR_V2.GRAY_20,
   '--checkbox-background-disabled': COLOR_V2.GRAY_10,
@@ -51,7 +51,7 @@ const light: <T>() => CSSObject = () => ({
   '--main-color': COLOR.BLACK,
 });
 
-const dark: <T>() => CSSObject = () => ({
+const dark: () => CSSObject = () => ({
   // Checkbox
   '--checkbox-background': COLOR_V2.GRAY_90,
   '--checkbox-background-disabled': COLOR_V2.GRAY_90,
@@ -81,7 +81,7 @@ const dark: <T>() => CSSObject = () => ({
   '--main-color': COLOR.WHITE,
 });
 
-const accentColors: <T>() => CSSObject = () => ({
+const accentColors: () => CSSObject = () => ({
   '--accent-color': COLOR_V2.BLUE_LIGHT_500,
   '--accent-color-highlight': COLOR_V2.BLUE_LIGHT_50,
   '--accent-color-highlight-inversed': COLOR_V2.BLUE_LIGHT_800,

--- a/packages/react-ui-kit/src/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/GlobalCssVariables.tsx
@@ -22,46 +22,60 @@ import {CSSObject} from '@emotion/react';
 import {COLOR, COLOR_V2} from './Identity';
 
 const light: <T>() => CSSObject = () => ({
+  // Checkbox
   '--checkbox-background': COLOR_V2.GRAY_20,
   '--checkbox-background-disabled': COLOR_V2.GRAY_10,
   '--checkbox-background-disabled-selected': COLOR_V2.GRAY_60,
   '--checkbox-border': COLOR_V2.GRAY_80,
   '--checkbox-border-disabled': COLOR_V2.GRAY_70,
+
+  // Icon Button
   '--icon-button-primary-enabled-bg': COLOR.WHITE,
   '--icon-button-primary-hover-bg': COLOR_V2.GRAY_20,
   '--icon-button-primary-border': COLOR_V2.GRAY_40,
   '--icon-button-primary-disabled-bg': COLOR_V2.GRAY_20,
   '--icon-button-primary-disabled-border': COLOR_V2.GRAY_40,
   '--icon-button-primary-hover-border': COLOR_V2.GRAY_50,
+
+  // Inputs
   '--text-input-background': COLOR.WHITE,
   '--text-input-border': COLOR_V2.GRAY_40,
   '--text-input-border-hover': COLOR_V2.GRAY_60,
   '--text-input-placeholder': COLOR_V2.GRAY_70,
   '--text-input-disabled': COLOR_V2.GRAY_20,
   '--text-input-label': COLOR_V2.GRAY_80,
+
+  // General
   '--danger-color': COLOR_V2.RED_LIGHT_500,
   '--app-bg': COLOR_V2.GRAY_10,
   '--main-color': COLOR.BLACK,
 });
 
 const dark: <T>() => CSSObject = () => ({
+  // Checkbox
   '--checkbox-background': COLOR_V2.GRAY_90,
   '--checkbox-background-disabled': COLOR_V2.GRAY_90,
   '--checkbox-background-disabled-selected': COLOR_V2.GRAY_80,
   '--checkbox-border': COLOR_V2.GRAY_60,
   '--checkbox-border-disabled': COLOR_V2.GRAY_60,
+
+  // Icon Button
   '--icon-button-primary-enabled-bg': COLOR_V2.GRAY_90,
   '--icon-button-primary-hover-bg': COLOR_V2.GRAY_80,
   '--icon-button-primary-border': COLOR_V2.GRAY_100,
   '--icon-button-primary-disabled-bg': COLOR_V2.GRAY_95,
   '--icon-button-primary-disabled-border': COLOR_V2.GRAY_90,
   '--icon-button-primary-hover-border': COLOR_V2.GRAY_70,
+
+  // Inputs
   '--text-input-background': COLOR.BLACK,
   '--text-input-border': COLOR_V2.GRAY_80,
   '--text-input-border-hover': COLOR_V2.GRAY_40,
   '--text-input-placeholder': COLOR_V2.GRAY_60,
   '--text-input-disabled': COLOR_V2.GRAY_100,
   '--text-input-label': COLOR_V2.GRAY_40,
+
+  // General
   '--danger-color': COLOR_V2.RED_DARK_500,
   '--app-bg': COLOR_V2.GRAY_95,
   '--main-color': COLOR.WHITE,

--- a/packages/react-ui-kit/src/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/GlobalCssVariables.tsx
@@ -1,0 +1,82 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+/** @jsx jsx */
+import {CSSObject} from '@emotion/react';
+import {COLOR, COLOR_V2} from './Identity';
+
+const light: <T>() => CSSObject = () => ({
+  '--checkbox-background': COLOR_V2.GRAY_20,
+  '--checkbox-background-disabled': COLOR_V2.GRAY_10,
+  '--checkbox-background-disabled-selected': COLOR_V2.GRAY_60,
+  '--checkbox-border': COLOR_V2.GRAY_80,
+  '--checkbox-border-disabled': COLOR_V2.GRAY_70,
+  '--icon-button-primary-enabled-bg': COLOR.WHITE,
+  '--icon-button-primary-hover-bg': COLOR_V2.GRAY_20,
+  '--icon-button-primary-border': COLOR_V2.GRAY_40,
+  '--icon-button-primary-disabled-bg': COLOR_V2.GRAY_20,
+  '--icon-button-primary-disabled-border': COLOR_V2.GRAY_40,
+  '--icon-button-primary-hover-border': COLOR_V2.GRAY_50,
+  '--text-input-background': COLOR.WHITE,
+  '--text-input-border': COLOR_V2.GRAY_40,
+  '--text-input-border-hover': COLOR_V2.GRAY_60,
+  '--text-input-placeholder': COLOR_V2.GRAY_70,
+  '--text-input-disabled': COLOR_V2.GRAY_20,
+  '--text-input-label': COLOR_V2.GRAY_80,
+  '--danger-color': COLOR_V2.RED_LIGHT_500,
+  '--app-bg': COLOR_V2.GRAY_10,
+});
+
+const dark: <T>() => CSSObject = () => ({
+  '--checkbox-background': COLOR_V2.GRAY_90,
+  '--checkbox-background-disabled': COLOR_V2.GRAY_90,
+  '--checkbox-background-disabled-selected': COLOR_V2.GRAY_80,
+  '--checkbox-border': COLOR_V2.GRAY_60,
+  '--checkbox-border-disabled': COLOR_V2.GRAY_60,
+  '--icon-button-primary-enabled-bg': COLOR_V2.GRAY_90,
+  '--icon-button-primary-hover-bg': COLOR_V2.GRAY_80,
+  '--icon-button-primary-border': COLOR_V2.GRAY_100,
+  '--icon-button-primary-disabled-bg': COLOR_V2.GRAY_95,
+  '--icon-button-primary-disabled-border': COLOR_V2.GRAY_90,
+  '--icon-button-primary-hover-border': COLOR_V2.GRAY_70,
+  '--text-input-background': COLOR.BLACK,
+  '--text-input-border': COLOR_V2.GRAY_80,
+  '--text-input-border-hover': COLOR_V2.GRAY_40,
+  '--text-input-placeholder': COLOR_V2.GRAY_60,
+  '--text-input-disabled': COLOR_V2.GRAY_100,
+  '--text-input-label': COLOR_V2.GRAY_40,
+  '--danger-color': COLOR_V2.RED_DARK_500,
+  '--app-bg': COLOR_V2.GRAY_95,
+});
+
+const accentColors: <T>() => CSSObject = () => ({
+  '--accent-color': COLOR_V2.BLUE_LIGHT_500,
+  '--accent-color-highlight': COLOR_V2.BLUE_LIGHT_50,
+  '--accent-color-highlight-inversed': COLOR_V2.BLUE_LIGHT_800,
+  '--accent-color-border': COLOR_V2.BLUE_LIGHT_500,
+  '--accent-color-focus': COLOR_V2.BLUE_LIGHT_400,
+  '--icon-primary-active-fill': COLOR_V2.BLUE_LIGHT_500,
+  '--icon-secondary-active-border': 'transparent',
+});
+
+export const GlobalCssVariables = {
+  light,
+  dark,
+  accentColors,
+};

--- a/packages/react-ui-kit/src/GlobalStyle.tsx
+++ b/packages/react-ui-kit/src/GlobalStyle.tsx
@@ -20,6 +20,7 @@
 /** @jsx jsx */
 import {Global, CSSObject, css, jsx, withTheme} from '@emotion/react';
 import emotionNormalize from 'emotion-normalize';
+import {GlobalCssVariables} from './GlobalCssVariables';
 
 import type {Theme} from './Layout';
 import {textLinkStyle} from './Text/TextLink';
@@ -35,6 +36,7 @@ const globalStyles: (theme: Theme) => CSSObject = (theme: Theme) => ({
     fontWeight: 600,
   },
   body: {
+    ...GlobalCssVariables.accentColors(),
     MozOsxFontSmoothing: 'grayscale',
     WebkitFontSmoothing: 'antialiased',
     background: theme.general.backgroundColor,
@@ -46,6 +48,12 @@ const globalStyles: (theme: Theme) => CSSObject = (theme: Theme) => ({
     lineHeight: 1.5,
     minHeight: '100vh',
     transition: 'background 0.15s',
+  },
+  'body, body.theme-default': {
+    ...GlobalCssVariables.light(),
+  },
+  'body.theme-dark': {
+    ...GlobalCssVariables.dark(),
   },
   html: {
     background: theme.general.backgroundColor,

--- a/packages/react-ui-kit/src/Layout/Theme.tsx
+++ b/packages/react-ui-kit/src/Layout/Theme.tsx
@@ -28,6 +28,7 @@ import {filterProps} from '../util';
 export enum THEME_ID {
   DARK = 'THEME_DARK',
   LIGHT = 'THEME_LIGHT',
+  DEFAULT = 'THEME_DEFAULT',
 }
 
 export interface Theme {
@@ -74,6 +75,46 @@ export interface Theme {
 }
 
 export const themes: {[themeId in THEME_ID]: Theme} = {
+  [THEME_ID.DEFAULT]: {
+    Checkbox: {
+      background: 'var(--checkbox-background)',
+      border: 'var(--checkbox-border)',
+      borderFocused: 'var(--accent-color)',
+      disableBgColor: 'var(--checkbox-background-disabled)',
+      disableBorderColor: 'var(--checkbox-border-disabled)',
+      disablecheckedBgColor: 'var(--checkbox-background-disabled-selected)',
+      invalidBorderColor: 'var(--danger-color)',
+    },
+    IconButton: {
+      activePrimaryBgColor: 'var(--accent-color-highlight)',
+      focusBorderColor: 'var(--accent-color-border)',
+      hoverPrimaryBgColor: 'var(--icon-button-primary-hover-bg)',
+      primaryActiveFillColor: 'var(--icon-primary-active-fill)',
+      primaryBgColor: 'var(--icon-button-primary-enabled-bg)',
+      primaryBorderColor: 'var(--icon-button-primary-border)',
+      primaryDisabledBgColor: 'var(--icon-button-primary-disabled-bg)',
+      primaryDisabledBorderColor: 'var(--icon-button-primary-disabled-border)',
+      primaryHoverBorderColor: 'var(--icon-button-primary-hover-border)',
+      secondaryActiveBorderColor: 'var(--icon-secondary-active-border)',
+    },
+    Input: {
+      backgroundColor: 'var(--text-input-background)',
+      backgroundColorDisabled: 'var(--text-input-disabled)',
+      labelColor: 'var(--text-input-label)',
+      placeholderColor: 'var(--text-input-placeholder)',
+    },
+    Select: {
+      borderColor: 'var(--text-input-border)',
+      contrastTextColor: 'var(--text-input-background)',
+      disabledColor: 'var(--text-input-placeholder)',
+    },
+    general: {
+      backgroundColor: 'var(--app-bg)',
+      color: 'var(--main-color)',
+      dangerColor: 'var(--danger-color)',
+      primaryColor: 'var(--accent-color)',
+    },
+  },
   [THEME_ID.LIGHT]: {
     IconButton: {
       activePrimaryBgColor: COLOR_V2.BLUE_LIGHT_50,


### PR DESCRIPTION
#### What?

- Move the theme object from the webapp to the ui-kit
- Expose css variables in GlobalStyles so they can be accessible from team setting and removed from the webapp .less files

#### Why?

- It ables us to change components in the ui-kit wthout having to fiddle with .less files on the webapp
- It will allow team-setting to use the same theme as webapp