### PR TITLE
runfix: make disabled prop optional on select component

### DIFF
--- a/packages/react-ui-kit/src/Form/Select.tsx
+++ b/packages/react-ui-kit/src/Form/Select.tsx
@@ -39,7 +39,7 @@ export type Option = {
 
 interface SelectProps<IsMulti extends boolean> extends StateManagerProps<Option, IsMulti> {
   id: string;
-  disabled: boolean;
+  disabled?: boolean;
   dataUieName: string;
   options: Option[];
   wrapperCSS?: CSSObject;


### PR DESCRIPTION
- disabled prop restored [here](https://github.com/wireapp/wire-web-packages/pull/4354) should be optional
