### PR TITLE
feat(core): update keys periodically (FS-562)

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -51,7 +51,8 @@ import type {CoreCrypto} from '@otak/core-crypto';
 import {WEBSOCKET_STATE} from '@wireapp/api-client/src/tcp/ReconnectingWebsocket';
 import {createCustomEncryptedStore, createEncryptedStore} from './util/encryptedStore';
 import {Encoder} from 'bazinga64';
-import {MLSService} from './mls/MLSService/MLSService';
+import type {MLSService} from './mls';
+import type {MLSConfig} from './mls/types';
 
 export type ProcessedEventPayload = HandledEventPayload;
 
@@ -98,30 +99,6 @@ export interface Account {
 }
 
 export type CreateStoreFn = (storeName: string, context: Context) => undefined | Promise<CRUDEngine | undefined>;
-type SecretCrypto<T> = {
-  encrypt: (value: Uint8Array) => Promise<T>;
-  decrypt: (payload: T) => Promise<Uint8Array>;
-};
-
-export interface MLSConfig<T = any> {
-  /**
-   * encrypt/decrypt function pair that will be called before storing/fetching secrets in the secrets database.
-   * If not provided will use the built in encryption mechanism
-   */
-  secretsCrypto?: SecretCrypto<T>;
-
-  /**
-   * path on the public server to the core crypto wasm file.
-   * This file will be downloaded lazily when corecrypto is needed.
-   * It, thus, needs to know where, on the server, the file can be found
-   */
-  coreCrypoWasmFilePath: string;
-
-  /**
-   * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
-   */
-  keyingMaterialUpdateThreshold?: number;
-}
 
 interface AccountOptions<T> {
   /** Used to store info in the database (will create a inMemory engine if returns undefined) */

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -103,7 +103,7 @@ type SecretCrypto<T> = {
   decrypt: (payload: T) => Promise<Uint8Array>;
 };
 
-interface MLSConfig<T = any> {
+export interface MLSConfig<T = any> {
   /**
    * encrypt/decrypt function pair that will be called before storing/fetching secrets in the secrets database.
    * If not provided will use the built in encryption mechanism
@@ -116,6 +116,11 @@ interface MLSConfig<T = any> {
    * It, thus, needs to know where, on the server, the file can be found
    */
   coreCrypoWasmFilePath: string;
+
+  /**
+   * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
+   */
+  keyingMaterialUpdateThreshold: number;
 }
 
 interface AccountOptions<T> {
@@ -353,7 +358,7 @@ export class Account<T = any> extends EventEmitter {
     });
 
     const clientService = new ClientService(this.apiClient, this.storeEngine, cryptographyService);
-    const mlsService = new MLSService(this.apiClient, () => this.coreCryptoClient);
+    const mlsService = new MLSService(this.mlsConfig, this.apiClient, () => this.coreCryptoClient);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -51,7 +51,7 @@ import type {CoreCrypto} from '@otak/core-crypto';
 import {WEBSOCKET_STATE} from '@wireapp/api-client/src/tcp/ReconnectingWebsocket';
 import {createCustomEncryptedStore, createEncryptedStore} from './util/encryptedStore';
 import {Encoder} from 'bazinga64';
-import type {MLSService} from './mls';
+import {MLSService} from './mls';
 import type {MLSConfig} from './mls/types';
 
 export type ProcessedEventPayload = HandledEventPayload;

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -362,7 +362,6 @@ export class Account<T = any> extends EventEmitter {
       cryptographyService,
       mlsService,
       this.storeEngine,
-      () => this.coreCryptoClient,
     );
     const conversationService = new ConversationService(
       this.apiClient,
@@ -373,7 +372,6 @@ export class Account<T = any> extends EventEmitter {
       },
       notificationService,
       mlsService,
-      () => this.coreCryptoClient!,
     );
 
     const selfService = new SelfService(this.apiClient);

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -353,7 +353,7 @@ export class Account<T = any> extends EventEmitter {
     });
 
     const clientService = new ClientService(this.apiClient, this.storeEngine, cryptographyService);
-    const mlsService = new MLSService(this.apiClient, () => this.coreCryptoClient!);
+    const mlsService = new MLSService(this.apiClient, () => this.coreCryptoClient);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -120,7 +120,7 @@ export interface MLSConfig<T = any> {
   /**
    * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
    */
-  keyingMaterialUpdateThreshold: number;
+  keyingMaterialUpdateThreshold?: number;
 }
 
 interface AccountOptions<T> {

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
@@ -32,6 +32,9 @@ import {MessageTargetMode} from './ConversationService.types';
 import {MessageBuilder} from '../message/MessageBuilder';
 import {OtrMessage} from '../message/OtrMessage';
 import {NotificationService} from '../../notification/NotificationService';
+import {MLSService} from '../../mls/MLSService/MLSService';
+
+const mockedMLSService = {} as unknown as MLSService;
 
 describe('ConversationService', () => {
   beforeAll(() => {
@@ -62,13 +65,14 @@ describe('ConversationService', () => {
       {
         useQualifiedIds: federated,
       },
+      {
+        commitPendingProposals: () => Promise.resolve(),
+      } as unknown as NotificationService,
+      mockedMLSService,
       () =>
         ({
           encryptMessage: async () => Uint8Array.from([1, 2, 3]),
         } as unknown as CoreCrypto),
-      {
-        commitPendingProposals: () => Promise.resolve(),
-      } as unknown as NotificationService,
     );
   }
 

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {CoreCrypto} from '@otak/core-crypto/platforms/web/corecrypto';
 import {APIClient} from '@wireapp/api-client';
 import {ClientType} from '@wireapp/api-client/src/client';
 import {ConversationProtocol} from '@wireapp/api-client/src/conversation';
@@ -69,10 +68,6 @@ describe('ConversationService', () => {
         commitPendingProposals: () => Promise.resolve(),
       } as unknown as NotificationService,
       mockedMLSService,
-      () =>
-        ({
-          encryptMessage: async () => Uint8Array.from([1, 2, 3]),
-        } as unknown as CoreCrypto),
     );
   }
 

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
@@ -33,7 +33,9 @@ import {OtrMessage} from '../message/OtrMessage';
 import {NotificationService} from '../../notification/NotificationService';
 import {MLSService} from '../../mls/MLSService/MLSService';
 
-const mockedMLSService = {} as unknown as MLSService;
+const mockedMLSService = {
+  encryptMessage: () => {},
+} as unknown as MLSService;
 
 describe('ConversationService', () => {
   beforeAll(() => {

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.test.node.ts
@@ -31,7 +31,7 @@ import {MessageTargetMode} from './ConversationService.types';
 import {MessageBuilder} from '../message/MessageBuilder';
 import {OtrMessage} from '../message/OtrMessage';
 import {NotificationService} from '../../notification/NotificationService';
-import {MLSService} from '../../mls/MLSService/MLSService';
+import type {MLSService} from '../../mls';
 
 const mockedMLSService = {
   encryptMessage: () => {},

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -1262,6 +1262,10 @@ export class ConversationService {
 
     const messageResponse = await this.mlsService.uploadCoreCryptoCommitBundle(groupIdDecodedFromBase64, commitBundle);
 
+    //key material gets updated after removing a user from the group, so we can reset last key update time value in the store
+    const userRemovalTime = new Date().getTime();
+    await this.notificationService.storeLastKeyMaterialUpdateDate({groupId, previousUpdateDate: userRemovalTime});
+
     const conversation = await this.getConversations(conversationId.id);
 
     return {

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -1292,6 +1292,13 @@ export class ConversationService {
       //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
       optionalToUint8Array(externalProposal),
     );
+
+    //We store the info when user was added (and key material was created), so we will know when to renew it
+    const userAddedTimeStamp = new Date().getTime();
+    await this.notificationService.storeLastKeyMaterialUpdateDate({
+      previousUpdateDate: userAddedTimeStamp,
+      groupId: conversationGroupId,
+    });
   }
 
   public async isMLSConversationEstablished(conversationGroupId: string) {

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -65,7 +65,7 @@ import {
 } from '../../conversation/';
 import type {ClearedContent, DeletedContent, HiddenContent, RemoteData} from '../content';
 import type {CryptographyService} from '../../cryptography/';
-import type {MLSService} from '../../mls/MLSService/MLSService';
+import type {MLSService} from '../../mls';
 import type {NotificationService} from '../../notification';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {isStringArray, isQualifiedIdArray, isQualifiedUserClients, isUserClients} from '../../util/TypePredicateUtil';

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -66,6 +66,8 @@ import {
 } from '../../conversation/';
 import type {ClearedContent, DeletedContent, HiddenContent, RemoteData} from '../content';
 import type {CryptographyService} from '../../cryptography/';
+import type {MLSService} from '../../mls/MLSService/MLSService';
+import type {NotificationService} from '../../notification';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {isStringArray, isQualifiedIdArray, isQualifiedUserClients, isUserClients} from '../../util/TypePredicateUtil';
 import {MessageBuilder} from '../message/MessageBuilder';
@@ -93,7 +95,6 @@ import type {
   TextMessage,
 } from '../message/OtrMessage';
 import {XOR} from '@wireapp/commons/src/main/util/TypeUtil';
-import type {NotificationService} from '../../notification';
 import {
   AddUsersParams,
   MessageSendingCallbacks,
@@ -105,7 +106,6 @@ import {
 } from './ConversationService.types';
 import {Decoder} from 'bazinga64';
 import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/mapQualifiedUserClientIdsToFullyQualifiedClientIds';
-import {MLSService} from '../../mls/MLSService/MLSService';
 
 export class ConversationService {
   public readonly messageTimer: MessageTimer;

--- a/packages/core/src/main/cryptography/CryptographyDatabaseRepository.ts
+++ b/packages/core/src/main/cryptography/CryptographyDatabaseRepository.ts
@@ -27,6 +27,7 @@ export enum DatabaseStores {
   SESSIONS = 'sessions',
   GROUP_IDS = 'group_ids',
   PENDING_PROPOSALS = 'pending_proposals',
+  LAST_KEY_MATERIAL_UPDATE_DATES = 'last_key_material_update_dates',
 }
 
 export class CryptographyDatabaseRepository {

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -150,4 +150,8 @@ export class MLSService {
   public async commitPendingProposals(conversationId: ConversationId): Promise<CommitBundle> {
     return this.getCoreCryptoClient().commitPendingProposals(conversationId);
   }
+
+  public async conversationExists(conversationId: ConversationId): Promise<boolean> {
+    return this.getCoreCryptoClient().conversationExists(conversationId);
+  }
 }

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -29,10 +29,21 @@ export const optionalToUint8Array = (array: Uint8Array | []): Uint8Array => {
 };
 
 export class MLSService {
-  constructor(private readonly apiClient: APIClient, private readonly coreCryptoClientProvider: () => CoreCrypto) {}
+  constructor(
+    private readonly apiClient: APIClient,
+    private readonly coreCryptoClientProvider: () => CoreCrypto | undefined,
+  ) {}
+
+  private getCoreCryptoClient() {
+    const client = this.coreCryptoClientProvider();
+    if (!client) {
+      throw new Error('Could not get coreCryptoClient');
+    }
+    return client;
+  }
 
   public async uploadCoreCryptoCommitBundle(groupIdDecodedFromBase64: Uint8Array, commitBundle: CommitBundle) {
-    const coreCryptoClient = this.coreCryptoClientProvider();
+    const coreCryptoClient = this.getCoreCryptoClient();
 
     if (commitBundle.welcome) {
       //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
@@ -50,7 +61,7 @@ export class MLSService {
   }
 
   public async addUsersToExistingMLSConversation(groupIdDecodedFromBase64: Uint8Array, invitee: Invitee[]) {
-    const coreCryptoClient = this.coreCryptoClientProvider();
+    const coreCryptoClient = this.getCoreCryptoClient();
     const memberAddedMessages = await coreCryptoClient.addClientsToConversation(groupIdDecodedFromBase64, invitee);
 
     if (memberAddedMessages?.welcome) {

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -34,10 +34,6 @@ export class MLSService {
   public async uploadCoreCryptoCommitBundle(groupIdDecodedFromBase64: Uint8Array, commitBundle: CommitBundle) {
     const coreCryptoClient = this.coreCryptoClientProvider();
 
-    if (!coreCryptoClient) {
-      throw new Error('Could not get coreCryptoClient');
-    }
-
     if (commitBundle.welcome) {
       //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
       await this.apiClient.api.conversation.postMlsWelcomeMessage(optionalToUint8Array(commitBundle.welcome));

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -28,6 +28,7 @@ import {
 import {APIClient} from '@wireapp/api-client';
 import {QualifiedUsers} from '../../conversation';
 import {Decoder, Encoder} from 'bazinga64';
+import {MLSConfig} from '../../Account';
 
 //@todo: this function is temporary, we wait for the update from core-crypto side
 //they are returning regular array instead of Uint8Array for commit and welcome messages
@@ -37,6 +38,7 @@ export const optionalToUint8Array = (array: Uint8Array | []): Uint8Array => {
 
 export class MLSService {
   constructor(
+    public readonly config: MLSConfig | undefined,
     private readonly apiClient: APIClient,
     private readonly coreCryptoClientProvider: () => CoreCrypto | undefined,
   ) {}

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -123,6 +123,10 @@ export class MLSService {
     return this.getCoreCryptoClient().decryptMessage(conversationId, payload);
   }
 
+  public async encryptMessage(conversationId: ConversationId, message: Uint8Array): Promise<Uint8Array> {
+    return this.getCoreCryptoClient().encryptMessage(conversationId, message);
+  }
+
   public async updateKeyingMaterial(conversationId: ConversationId): Promise<CommitBundle> {
     return this.getCoreCryptoClient().updateKeyingMaterial(conversationId);
   }
@@ -132,10 +136,6 @@ export class MLSService {
     configuration?: ConversationConfiguration,
   ): Promise<any> {
     return this.getCoreCryptoClient().createConversation(conversationId, configuration);
-  }
-
-  public async encryptMessage(conversationId: ConversationId, message: Uint8Array): Promise<Uint8Array> {
-    return this.getCoreCryptoClient().encryptMessage(conversationId, message);
   }
 
   public async removeClientsFromConversation(

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -17,7 +17,14 @@
  *
  */
 
-import {CommitBundle, CoreCrypto, Invitee} from '@otak/core-crypto/platforms/web/corecrypto';
+import {
+  CommitBundle,
+  ConversationConfiguration,
+  ConversationId,
+  CoreCrypto,
+  DecryptedMessage,
+  Invitee,
+} from '@otak/core-crypto/platforms/web/corecrypto';
 import {APIClient} from '@wireapp/api-client';
 import {QualifiedUsers} from '../../conversation';
 import {Decoder, Encoder} from 'bazinga64';
@@ -106,5 +113,39 @@ export class MLSService {
     }, []);
 
     return coreCryptoKeyPackagesPayload;
+  }
+
+  public async processWelcomeMessage(welcomeMessage: Uint8Array): Promise<ConversationId> {
+    return this.getCoreCryptoClient().processWelcomeMessage(welcomeMessage);
+  }
+
+  public async decryptMessage(conversationId: ConversationId, payload: Uint8Array): Promise<DecryptedMessage> {
+    return this.getCoreCryptoClient().decryptMessage(conversationId, payload);
+  }
+
+  public async updateKeyingMaterial(conversationId: ConversationId): Promise<CommitBundle> {
+    return this.getCoreCryptoClient().updateKeyingMaterial(conversationId);
+  }
+
+  public async createConversation(
+    conversationId: ConversationId,
+    configuration?: ConversationConfiguration,
+  ): Promise<any> {
+    return this.getCoreCryptoClient().createConversation(conversationId, configuration);
+  }
+
+  public async encryptMessage(conversationId: ConversationId, message: Uint8Array): Promise<Uint8Array> {
+    return this.getCoreCryptoClient().encryptMessage(conversationId, message);
+  }
+
+  public async removeClientsFromConversation(
+    conversationId: ConversationId,
+    clientIds: Uint8Array[],
+  ): Promise<CommitBundle> {
+    return this.getCoreCryptoClient().removeClientsFromConversation(conversationId, clientIds);
+  }
+
+  public async commitPendingProposals(conversationId: ConversationId): Promise<CommitBundle> {
+    return this.getCoreCryptoClient().commitPendingProposals(conversationId);
   }
 }

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {CommitBundle, CoreCrypto, Invitee} from '@otak/core-crypto/platforms/web/corecrypto';
+import {APIClient} from '@wireapp/api-client';
+import {QualifiedUsers} from '../../conversation';
+import {Decoder, Encoder} from 'bazinga64';
+
+//@todo: this function is temporary, we wait for the update from core-crypto side
+//they are returning regular array instead of Uint8Array for commit and welcome messages
+export const optionalToUint8Array = (array: Uint8Array | []): Uint8Array => {
+  return Array.isArray(array) ? Uint8Array.from(array) : array;
+};
+
+export class MLSService {
+  constructor(private readonly apiClient: APIClient, private readonly coreCryptoClientProvider: () => CoreCrypto) {}
+
+  public async uploadCoreCryptoCommitBundle(groupIdDecodedFromBase64: Uint8Array, commitBundle: CommitBundle) {
+    const coreCryptoClient = this.coreCryptoClientProvider();
+
+    if (!coreCryptoClient) {
+      throw new Error('Could not get coreCryptoClient');
+    }
+
+    if (commitBundle.welcome) {
+      //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
+      await this.apiClient.api.conversation.postMlsWelcomeMessage(optionalToUint8Array(commitBundle.welcome));
+    }
+    if (commitBundle.commit) {
+      const messageResponse = await this.apiClient.api.conversation.postMlsMessage(
+        //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
+        optionalToUint8Array(commitBundle.commit),
+      );
+      await coreCryptoClient.commitAccepted(groupIdDecodedFromBase64);
+      return messageResponse;
+    }
+    return null;
+  }
+
+  public async addUsersToExistingMLSConversation(groupIdDecodedFromBase64: Uint8Array, invitee: Invitee[]) {
+    const coreCryptoClient = this.coreCryptoClientProvider();
+    const memberAddedMessages = await coreCryptoClient.addClientsToConversation(groupIdDecodedFromBase64, invitee);
+
+    if (memberAddedMessages?.welcome) {
+      //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
+      await this.apiClient.api.conversation.postMlsWelcomeMessage(optionalToUint8Array(memberAddedMessages.welcome));
+    }
+    if (memberAddedMessages?.commit) {
+      const messageResponse = await this.apiClient.api.conversation.postMlsMessage(
+        //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array
+        optionalToUint8Array(memberAddedMessages.commit),
+      );
+      await coreCryptoClient.commitAccepted(groupIdDecodedFromBase64);
+      return messageResponse;
+    }
+    return null;
+  }
+
+  public async getCoreCryptoKeyPackagesPayload(qualifiedUsers: QualifiedUsers[]) {
+    /**
+     * @note We need to fetch key packages for all the users
+     * we want to add to the new MLS conversations,
+     * includes self user too.
+     */
+    const keyPackages = await Promise.all([
+      ...qualifiedUsers.map(({id, domain, skipOwn}) =>
+        this.apiClient.api.client.claimMLSKeyPackages(id, domain, skipOwn),
+      ),
+    ]);
+
+    const coreCryptoKeyPackagesPayload = keyPackages.reduce<Invitee[]>((previousValue, currentValue) => {
+      // skip users that have not uploaded their MLS key packages
+      if (currentValue.key_packages.length > 0) {
+        return [
+          ...previousValue,
+          ...currentValue.key_packages.map(keyPackage => ({
+            id: Encoder.toBase64(keyPackage.client).asBytes,
+            kp: Decoder.fromBase64(keyPackage.key_package).asBytes,
+          })),
+        ];
+      }
+      return previousValue;
+    }, []);
+
+    return coreCryptoKeyPackagesPayload;
+  }
+}

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -28,7 +28,7 @@ import {
 import {APIClient} from '@wireapp/api-client';
 import {QualifiedUsers} from '../../conversation';
 import {Decoder, Encoder} from 'bazinga64';
-import {MLSConfig} from '../../Account';
+import type {MLSConfig} from '../types';
 
 //@todo: this function is temporary, we wait for the update from core-crypto side
 //they are returning regular array instead of Uint8Array for commit and welcome messages

--- a/packages/core/src/main/mls/index.ts
+++ b/packages/core/src/main/mls/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './MLSService/MLSService';

--- a/packages/core/src/main/mls/index.ts
+++ b/packages/core/src/main/mls/index.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2022 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/packages/core/src/main/mls/types.ts
+++ b/packages/core/src/main/mls/types.ts
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+type SecretCrypto<T> = {
+  encrypt: (value: Uint8Array) => Promise<T>;
+  decrypt: (payload: T) => Promise<Uint8Array>;
+};
+
+export interface MLSConfig<T = any> {
+  /**
+   * encrypt/decrypt function pair that will be called before storing/fetching secrets in the secrets database.
+   * If not provided will use the built in encryption mechanism
+   */
+  secretsCrypto?: SecretCrypto<T>;
+
+  /**
+   * path on the public server to the core crypto wasm file.
+   * This file will be downloaded lazily when corecrypto is needed.
+   * It, thus, needs to know where, on the server, the file can be found
+   */
+  coreCrypoWasmFilePath: string;
+
+  /**
+   * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
+   */
+  keyingMaterialUpdateThreshold?: number;
+}

--- a/packages/core/src/main/notification/NotificationDatabaseRepository.ts
+++ b/packages/core/src/main/notification/NotificationDatabaseRepository.ts
@@ -22,7 +22,7 @@ import type {Notification} from '@wireapp/api-client/src/notification/';
 import type {CRUDEngine} from '@wireapp/store-engine';
 
 import {CryptographyDatabaseRepository} from '../cryptography/CryptographyDatabaseRepository';
-import {CommonMLS, CompoundGroupIdParams, StorePendingProposalsParams} from './types';
+import {CommonMLS, CompoundGroupIdParams, LastKeyMaterialUpdateParams, StorePendingProposalsParams} from './types';
 
 export enum DatabaseStores {
   EVENTS = 'events',
@@ -129,5 +129,37 @@ export class NotificationDatabaseRepository {
    */
   public async getStoredPendingProposals() {
     return this.storeEngine.readAll<StorePendingProposalsParams>(STORES.PENDING_PROPOSALS);
+  }
+
+  /**
+   * ## MLS only ##
+   * Store groupIds with last key material update dates.
+   *
+   * @param {groupId} params.groupId - groupId of the mls conversation
+   * @param {previousUpdateDate} params.previousUpdateDate - date of the previous key material update
+   */
+  public async storeLastKeyMaterialUpdateDate(params: LastKeyMaterialUpdateParams) {
+    await this.storeEngine.updateOrCreate(STORES.LAST_KEY_MATERIAL_UPDATE_DATES, `${params.groupId}`, params);
+    return true;
+  }
+
+  /**
+   * ## MLS only ##
+   * Delete stored entries for last key materials update dates.
+   *
+   * @param {groupId} groupId - of the mls conversation
+   */
+  public async deleteLastKeyMaterialUpdateDate({groupId}: CommonMLS) {
+    await this.storeEngine.delete(STORES.LAST_KEY_MATERIAL_UPDATE_DATES, `${groupId}`);
+    return true;
+  }
+
+  /**
+   * ## MLS only ##
+   * Get all stored entries for last key materials update dates.
+   *
+   */
+  public async getStoredLastKeyMaterialUpdateDates() {
+    return this.storeEngine.readAll<LastKeyMaterialUpdateParams>(STORES.LAST_KEY_MATERIAL_UPDATE_DATES);
   }
 }

--- a/packages/core/src/main/notification/NotificationService.test.browser.js
+++ b/packages/core/src/main/notification/NotificationService.test.browser.js
@@ -49,7 +49,7 @@ describe('NotificationService', () => {
         urls: APIClient.BACKEND.STAGING,
       });
 
-      const notificationService = new NotificationService(apiClient, {}, engine);
+      const notificationService = new NotificationService(apiClient, {}, {}, engine);
       spyOn(notificationService.database, 'getLastEventDate').and.callThrough();
       spyOn(engine, 'read').and.callThrough();
       spyOn(engine, 'update').and.callThrough();
@@ -77,7 +77,7 @@ describe('NotificationService', () => {
         urls: APIClient.BACKEND.STAGING,
       });
 
-      const notificationService = new NotificationService(apiClient, {}, engine);
+      const notificationService = new NotificationService(apiClient, {}, {}, engine);
       await notificationService.setLastEventDate(new Date(0));
 
       spyOn(notificationService.database, 'getLastEventDate').and.callThrough();
@@ -108,7 +108,7 @@ describe('NotificationService', () => {
       urls: APIClient.BACKEND.STAGING,
     });
 
-    const notificationService = new NotificationService(apiClient, {}, engine);
+    const notificationService = new NotificationService(apiClient, {}, {}, engine);
     const greaterDate = new Date(1);
     const lesserDate = new Date(0);
 
@@ -142,7 +142,7 @@ describe('NotificationService', () => {
       urls: APIClient.BACKEND.STAGING,
     });
 
-    const notificationService = new NotificationService(apiClient, {}, engine);
+    const notificationService = new NotificationService(apiClient, {}, {}, engine);
     spyOn(notificationService.database, 'getLastNotificationId').and.callThrough();
     spyOn(engine, 'read').and.callThrough();
     spyOn(engine, 'update').and.callThrough();
@@ -165,7 +165,7 @@ describe('NotificationService', () => {
       urls: APIClient.BACKEND.STAGING,
     });
 
-    const notificationService = new NotificationService(apiClient, {}, engine);
+    const notificationService = new NotificationService(apiClient, {}, {}, engine);
     await notificationService.setLastNotificationId({id: '12'});
 
     spyOn(notificationService.database, 'getLastNotificationId').and.callThrough();

--- a/packages/core/src/main/notification/NotificationService.test.node.ts
+++ b/packages/core/src/main/notification/NotificationService.test.node.ts
@@ -23,6 +23,7 @@ import {MemoryEngine} from '@wireapp/store-engine';
 import {PayloadBundleSource} from '../conversation';
 import {CryptographyService} from '../cryptography';
 import {NotificationService} from './NotificationService';
+import {MLSService} from '../mls/MLSService/MLSService';
 
 const BASE_URL = 'mock-backend.wire.com';
 const MOCK_BACKEND = {
@@ -30,6 +31,9 @@ const MOCK_BACKEND = {
   rest: `https://${BASE_URL}`,
   ws: `wss://${BASE_URL}`,
 };
+
+const mockedMLSService = {} as unknown as MLSService;
+const mockedCryptographyService = {} as unknown as CryptographyService;
 
 describe('NotificationService', () => {
   describe('handleEvent', () => {
@@ -39,8 +43,13 @@ describe('NotificationService', () => {
 
       const apiClient = new APIClient({urls: MOCK_BACKEND});
 
-      const cryptographyService = {} as unknown as CryptographyService;
-      const notificationService = new NotificationService(apiClient, cryptographyService, storeEngine, () => undefined);
+      const notificationService = new NotificationService(
+        apiClient,
+        mockedCryptographyService,
+        mockedMLSService,
+        storeEngine,
+        () => undefined,
+      );
 
       spyOn<any>(notificationService, 'handleEvent').and.throwError('Test error');
 
@@ -73,7 +82,8 @@ describe('NotificationService', () => {
       const apiClient = new APIClient({urls: MOCK_BACKEND});
       const notificationService = new NotificationService(
         apiClient,
-        {} as unknown as CryptographyService,
+        mockedCryptographyService,
+        mockedMLSService,
         storeEngine,
         () => undefined,
       );
@@ -105,6 +115,7 @@ describe('NotificationService', () => {
       const notificationService = new NotificationService(
         apiClient,
         {} as unknown as CryptographyService,
+        mockedMLSService,
         storeEngine,
         () => undefined,
       );
@@ -133,7 +144,8 @@ describe('NotificationService', () => {
       const apiClient = new APIClient({urls: MOCK_BACKEND});
       const notificationService = new NotificationService(
         apiClient,
-        {} as unknown as CryptographyService,
+        mockedCryptographyService,
+        mockedMLSService,
         storeEngine,
         () => undefined,
       );

--- a/packages/core/src/main/notification/NotificationService.test.node.ts
+++ b/packages/core/src/main/notification/NotificationService.test.node.ts
@@ -48,7 +48,6 @@ describe('NotificationService', () => {
         mockedCryptographyService,
         mockedMLSService,
         storeEngine,
-        () => undefined,
       );
 
       spyOn<any>(notificationService, 'handleEvent').and.throwError('Test error');
@@ -85,7 +84,6 @@ describe('NotificationService', () => {
         mockedCryptographyService,
         mockedMLSService,
         storeEngine,
-        () => undefined,
       );
 
       spyOn<any>(notificationService, 'handleEvent').and.returnValue({});
@@ -117,7 +115,6 @@ describe('NotificationService', () => {
         {} as unknown as CryptographyService,
         mockedMLSService,
         storeEngine,
-        () => undefined,
       );
 
       spyOn<any>(notificationService, 'handleEvent').and.returnValue({});
@@ -147,7 +144,6 @@ describe('NotificationService', () => {
         mockedCryptographyService,
         mockedMLSService,
         storeEngine,
-        () => undefined,
       );
       notificationService.on(NotificationService.TOPIC.NOTIFICATION_ERROR, notificationError => {
         expect(notificationError.error.message).toBe('Test error');

--- a/packages/core/src/main/notification/NotificationService.test.node.ts
+++ b/packages/core/src/main/notification/NotificationService.test.node.ts
@@ -23,7 +23,7 @@ import {MemoryEngine} from '@wireapp/store-engine';
 import {PayloadBundleSource} from '../conversation';
 import {CryptographyService} from '../cryptography';
 import {NotificationService} from './NotificationService';
-import {MLSService} from '../mls/MLSService/MLSService';
+import type {MLSService} from '../mls';
 
 const BASE_URL = 'mock-backend.wire.com';
 const MOCK_BACKEND = {

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -51,7 +51,7 @@ enum TOPIC {
   NOTIFICATION_ERROR = 'NotificationService.TOPIC.NOTIFICATION_ERROR',
 }
 
-const KEYING_MATERIAL_UPDATE_THRESHOLD = 1000 * 60 * 60 * 24 * 90; //90 days
+const DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD = 1000 * 60 * 60 * 24 * 30; //30 days
 
 export type NotificationHandler = (
   notification: Notification,
@@ -480,8 +480,12 @@ export class NotificationService extends EventEmitter {
   }
 
   private scheduleTaskToRenewKeyMaterial({groupId, previousUpdateDate}: LastKeyMaterialUpdateParams) {
-    //90 days after last update date renew key material
-    const firingDate = previousUpdateDate + KEYING_MATERIAL_UPDATE_THRESHOLD;
+    //given period of time (30 days by default) after last update date renew key material
+    const keyingMaterialUpdateThreshold =
+      this.mlsService.config?.keyingMaterialUpdateThreshold || DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD;
+
+    const firingDate = previousUpdateDate + keyingMaterialUpdateThreshold;
+
     const key = this.createKeyMaterialUpdateTaskSchedulerId(groupId);
 
     TaskScheduler.addTask({

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -465,8 +465,7 @@ export class NotificationService extends EventEmitter {
   private async renewKeyMaterial({groupId}: Omit<LastKeyMaterialUpdateParams, 'previousUpdateDate'>) {
     try {
       const groupIdDecodedFromBase64 = Decoder.fromBase64(groupId).asBytes;
-      const commitBundle = await this.mlsService.updateKeyingMaterial(groupIdDecodedFromBase64);
-      await this.mlsService.uploadCoreCryptoCommitBundle(groupIdDecodedFromBase64, commitBundle);
+      await this.mlsService.updateKeyingMaterial(groupIdDecodedFromBase64);
 
       const keyRenewalTime = new Date().getTime();
       const keyMaterialUpdateDate = {groupId, previousUpdateDate: keyRenewalTime};

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -521,7 +521,7 @@ export class NotificationService extends EventEmitter {
       const keyMaterialUpdateDates = await this.database.getStoredLastKeyMaterialUpdateDates();
       keyMaterialUpdateDates.forEach(this.scheduleTaskToRenewKeyMaterial);
     } catch (error) {
-      this.logger.error('Could not get pending proposals', error);
+      this.logger.error('Could not get last key material update dates', error);
     }
   }
 }

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -467,7 +467,8 @@ export class NotificationService extends EventEmitter {
       const commitBundle = await this.mlsService.updateKeyingMaterial(Decoder.fromBase64(groupId).asBytes);
       await this.mlsService.uploadCoreCryptoCommitBundle(Decoder.fromBase64(groupId).asBytes, commitBundle);
 
-      const keyMaterialUpdateDate = {groupId, previousUpdateDate: new Date().getTime()};
+      const keyRenewalTime = new Date().getTime();
+      const keyMaterialUpdateDate = {groupId, previousUpdateDate: keyRenewalTime};
       await this.database.storeLastKeyMaterialUpdateDate(keyMaterialUpdateDate);
       this.scheduleTaskToRenewKeyMaterial(keyMaterialUpdateDate);
     } catch (error) {

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -485,8 +485,8 @@ export class NotificationService extends EventEmitter {
     const keyingMaterialUpdateThreshold =
       this.mlsService.config?.keyingMaterialUpdateThreshold || DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD;
 
-    try {
-      setInterval(async () => {
+    setInterval(async () => {
+      try {
         const keyMaterialUpdateDates = await this.database.getStoredLastKeyMaterialUpdateDates();
 
         const keyMaterialUpdateDatesPromises = await keyMaterialUpdateDates.reduce(
@@ -516,9 +516,9 @@ export class NotificationService extends EventEmitter {
         );
 
         await Promise.all(keyMaterialUpdateDatesPromises);
-      }, TimeUtil.TimeInMillis.MINUTE);
-    } catch (error) {
-      this.logger.error('Could not get last key material update dates', error);
-    }
+      } catch (error) {
+        this.logger.error('Could not get last key material update dates', error);
+      }
+    }, TimeUtil.TimeInMillis.MINUTE);
   }
 }

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -38,7 +38,7 @@ import {QualifiedId} from '@wireapp/api-client/src/user';
 import {Conversation} from '@wireapp/api-client/src/conversation';
 import {CommitPendingProposalsParams, HandlePendingProposalsParams, LastKeyMaterialUpdateParams} from './types';
 import {TaskScheduler} from '../util/TaskScheduler/TaskScheduler';
-import {MLSService} from '../mls/MLSService/MLSService';
+import type {MLSService} from '../mls';
 
 export type HandledEventPayload = {
   event: Events.BackendEvent;

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -478,7 +478,7 @@ export class NotificationService extends EventEmitter {
 
       const keyRenewalTime = new Date().getTime();
       const keyMaterialUpdateDate = {groupId, previousUpdateDate: keyRenewalTime};
-      await this.database.storeLastKeyMaterialUpdateDate(keyMaterialUpdateDate);
+      await this.storeLastKeyMaterialUpdateDate(keyMaterialUpdateDate);
     } catch (error) {
       this.logger.error(`Error while renewing key material for groupId ${groupId}`, error);
     }

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -455,6 +455,7 @@ export class NotificationService extends EventEmitter {
    */
   public async storeLastKeyMaterialUpdateDate(params: LastKeyMaterialUpdateParams) {
     await this.database.storeLastKeyMaterialUpdateDate(params);
+    await this.scheduleTaskToRenewKeyMaterial(params);
   }
 
   /**

--- a/packages/core/src/main/notification/types.ts
+++ b/packages/core/src/main/notification/types.ts
@@ -38,3 +38,7 @@ export type CommitPendingProposalsParams = {
 export type StorePendingProposalsParams = {
   firingDate: number;
 } & CommonMLS;
+
+export type LastKeyMaterialUpdateParams = {
+  previousUpdateDate: number;
+} & CommonMLS;

--- a/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.node.ts
+++ b/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.node.ts
@@ -1,0 +1,130 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {LowPrecisionTaskScheduler} from './LowPrecisionTaskScheduler';
+
+describe('LowPrecisionTaskScheduler', () => {
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(0));
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it("task won't run again after it was executed previously", async () => {
+    const mockedTask = jasmine.createSpy('mockedTask', () => Promise.resolve('hello task'));
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'test-key',
+      firingDate: 0,
+      intervalDelay: 2000,
+      task: mockedTask,
+    });
+
+    jasmine.clock().tick(2001);
+    await Promise.resolve();
+
+    jasmine.clock().tick(2001);
+    await Promise.resolve();
+
+    expect(mockedTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds single task to schedule and runs it after given delay', async () => {
+    const mockedTask = jasmine.createSpy('mockedTask', () => Promise.resolve('hello task'));
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'test-key',
+      firingDate: 0,
+      intervalDelay: 1000,
+      task: mockedTask,
+    });
+
+    jasmine.clock().tick(1001);
+    await Promise.resolve();
+
+    expect(mockedTask).toHaveBeenCalled();
+  });
+
+  it('adds multiple tasks to schedule and runs it after given delay', async done => {
+    const mockedTask1 = jasmine.createSpy('mockedTask1').and.returnValue(Promise.resolve('hello task 1'));
+    const mockedTask2 = jasmine.createSpy('mockedTask2').and.returnValue(Promise.resolve('hello task 2'));
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'test1-key',
+      firingDate: 0,
+      intervalDelay: 5000,
+      task: mockedTask1,
+    });
+
+    jasmine.clock().tick(1000);
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'test2-key',
+      firingDate: 0,
+      intervalDelay: 5000,
+      task: mockedTask2,
+    });
+
+    jasmine.clock().tick(4001);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockedTask1).toHaveBeenCalled();
+    expect(mockedTask2).toHaveBeenCalled();
+
+    done();
+  });
+
+  it('cancels tasks', async () => {
+    const mockedTask3 = jasmine.createSpy('mockedTask3').and.returnValue(Promise.resolve('hello task 3'));
+    const mockedTask4 = jasmine.createSpy('mockedTask4').and.returnValue(Promise.resolve('hello task 4'));
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'test3-key',
+      firingDate: 0,
+      intervalDelay: 4000,
+      task: mockedTask3,
+    });
+
+    jasmine.clock().tick(1000);
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'test4-key',
+      firingDate: 0,
+      intervalDelay: 4000,
+      task: mockedTask4,
+    });
+
+    LowPrecisionTaskScheduler.cancelTask({
+      intervalDelay: 4000,
+      key: 'test4-key',
+    });
+
+    jasmine.clock().tick(3001);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockedTask3).toHaveBeenCalled();
+    expect(mockedTask4).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.node.ts
+++ b/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.node.ts
@@ -63,7 +63,7 @@ describe('LowPrecisionTaskScheduler', () => {
     expect(mockedTask).toHaveBeenCalled();
   });
 
-  it('adds multiple tasks to schedule and runs it after given delay', async done => {
+  it('adds multiple tasks to schedule and runs it after given delay', async () => {
     const mockedTask1 = jasmine.createSpy('mockedTask1').and.returnValue(Promise.resolve('hello task 1'));
     const mockedTask2 = jasmine.createSpy('mockedTask2').and.returnValue(Promise.resolve('hello task 2'));
 
@@ -83,15 +83,13 @@ describe('LowPrecisionTaskScheduler', () => {
       task: mockedTask2,
     });
 
-    jasmine.clock().tick(4001);
+    jasmine.clock().tick(5001);
 
     await Promise.resolve();
     await Promise.resolve();
 
     expect(mockedTask1).toHaveBeenCalled();
     expect(mockedTask2).toHaveBeenCalled();
-
-    done();
   });
 
   it('cancels tasks', async () => {
@@ -116,15 +114,15 @@ describe('LowPrecisionTaskScheduler', () => {
 
     LowPrecisionTaskScheduler.cancelTask({
       intervalDelay: 4000,
-      key: 'test4-key',
+      key: 'test3-key',
     });
 
-    jasmine.clock().tick(3001);
+    jasmine.clock().tick(4001);
 
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(mockedTask3).toHaveBeenCalled();
-    expect(mockedTask4).not.toHaveBeenCalled();
+    expect(mockedTask3).not.toHaveBeenCalled();
+    expect(mockedTask4).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.ts
+++ b/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.ts
@@ -1,0 +1,81 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+interface IntervalTask {
+  key: string;
+  firingDate: number;
+  task: () => Promise<any>;
+}
+
+interface ScheduleLowPrecisionTaskParams extends IntervalTask {
+  intervalDelay: number;
+}
+
+interface CancelLowPrecisionTaskParams {
+  key: string;
+  intervalDelay: number;
+}
+
+const intervals: Record<number, {timeoutId: NodeJS.Timeout; tasks: IntervalTask[]}> = {};
+
+const addTask = ({key, firingDate, task, intervalDelay}: ScheduleLowPrecisionTaskParams) => {
+  const tasks = intervals[intervalDelay]?.tasks || [];
+  tasks.push({key, firingDate, task});
+
+  const timeoutId = setInterval(async () => {
+    const nowTime = new Date().getTime();
+
+    const tasks = intervals[intervalDelay]?.tasks;
+    if (tasks?.length !== 0) {
+      const tasksToExecute = await tasks.reduce(async (accPromise, {firingDate, task}) => {
+        const acc = await accPromise;
+
+        if (nowTime >= firingDate) {
+          const taskPromise = task();
+          acc.push(taskPromise);
+          cancelTask({intervalDelay, key});
+        }
+        return acc;
+      }, Promise.resolve([] as Promise<void>[]));
+
+      await Promise.all(tasksToExecute);
+    }
+  }, intervalDelay);
+
+  intervals[intervalDelay] = {timeoutId, tasks};
+};
+
+interface CancelLowPrecisionTaskParams {
+  key: string;
+  intervalDelay: number;
+}
+
+const cancelTask = ({intervalDelay, key}: CancelLowPrecisionTaskParams) => {
+  if (intervals[intervalDelay]) {
+    const tasks = intervals[intervalDelay].tasks || [];
+    const newTasks = tasks.filter(task => task.key !== key);
+    intervals[intervalDelay].tasks = newTasks;
+    if (newTasks.length === 0) {
+      clearInterval(intervals[intervalDelay].timeoutId);
+      delete intervals[intervalDelay];
+    }
+  }
+};
+
+export const LowPrecisionTaskScheduler = {addTask, cancelTask};

--- a/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.ts
+++ b/packages/core/src/main/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.ts
@@ -35,6 +35,11 @@ interface CancelLowPrecisionTaskParams {
 const intervals: Record<number, {timeoutId: NodeJS.Timeout; tasks: IntervalTask[]}> = {};
 
 const addTask = ({key, firingDate, task, intervalDelay}: ScheduleLowPrecisionTaskParams) => {
+  const existingIntervalId = intervals[intervalDelay]?.timeoutId;
+  if (existingIntervalId) {
+    clearInterval(existingIntervalId);
+  }
+
   const tasks = intervals[intervalDelay]?.tasks || [];
   tasks.push({key, firingDate, task});
 
@@ -71,6 +76,7 @@ const cancelTask = ({intervalDelay, key}: CancelLowPrecisionTaskParams) => {
     const tasks = intervals[intervalDelay].tasks || [];
     const newTasks = tasks.filter(task => task.key !== key);
     intervals[intervalDelay].tasks = newTasks;
+
     if (newTasks.length === 0) {
       clearInterval(intervals[intervalDelay].timeoutId);
       delete intervals[intervalDelay];

--- a/packages/core/src/main/util/TaskScheduler/TaskScheduler.ts
+++ b/packages/core/src/main/util/TaskScheduler/TaskScheduler.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {TimeUtil} from '@wireapp/commons';
 import logdown from 'logdown';
 
 const logger = logdown('@wireapp/core/util/TaskScheduler/TaskScheduler', {
@@ -30,8 +29,6 @@ type ScheduleTaskParams = {
   firingDate: number;
   key: string;
 };
-
-const MAX_TIMEOUT_DELAY_VALUE = 0x7fffffff; //maximum setTimeout delay value
 
 const activeTimeouts: Record<string, NodeJS.Timeout> = {};
 
@@ -51,26 +48,13 @@ const addTask = ({task, firingDate, key}: ScheduleTaskParams) => {
     cancelTask(key);
   }
 
-  let timeout: ReturnType<typeof setTimeout>;
-
-  if (delay <= MAX_TIMEOUT_DELAY_VALUE) {
-    timeout = setTimeout(
-      async () => {
-        await task();
-        delete activeTimeouts[key];
-      },
-      delay > 0 ? delay : 0,
-    );
-  } else {
-    timeout = setInterval(async () => {
-      const shouldRun = new Date().getTime() >= execute.getTime();
-      if (shouldRun) {
-        await task();
-        clearTimeout(timeout);
-        delete activeTimeouts[key];
-      }
-    }, TimeUtil.TimeInMillis.MINUTE);
-  }
+  const timeout = setTimeout(
+    async () => {
+      await task();
+      delete activeTimeouts[key];
+    },
+    delay > 0 ? delay : 0,
+  );
 
   // add the task to the list of active tasks
   activeTimeouts[key] = timeout;

--- a/packages/core/src/main/util/TaskScheduler/TaskScheduler.ts
+++ b/packages/core/src/main/util/TaskScheduler/TaskScheduler.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {TimeUtil} from '@wireapp/commons';
 import logdown from 'logdown';
 
 const logger = logdown('@wireapp/core/util/TaskScheduler/TaskScheduler', {
@@ -29,6 +30,8 @@ type ScheduleTaskParams = {
   firingDate: number;
   key: string;
 };
+
+const MAX_TIMEOUT_DELAY_VALUE = 0x7fffffff; //maximum setTimeout delay value
 
 const activeTimeouts: Record<string, NodeJS.Timeout> = {};
 
@@ -48,13 +51,26 @@ const addTask = ({task, firingDate, key}: ScheduleTaskParams) => {
     cancelTask(key);
   }
 
-  const timeout = setTimeout(
-    async () => {
-      await task();
-      delete activeTimeouts[key];
-    },
-    delay > 0 ? delay : 0,
-  );
+  let timeout: ReturnType<typeof setTimeout>;
+
+  if (delay <= MAX_TIMEOUT_DELAY_VALUE) {
+    timeout = setTimeout(
+      async () => {
+        await task();
+        delete activeTimeouts[key];
+      },
+      delay > 0 ? delay : 0,
+    );
+  } else {
+    timeout = setInterval(async () => {
+      const shouldRun = new Date().getTime() >= execute.getTime();
+      if (shouldRun) {
+        await task();
+        clearTimeout(timeout);
+        delete activeTimeouts[key];
+      }
+    }, TimeUtil.TimeInMillis.MINUTE);
+  }
 
   // add the task to the list of active tasks
   activeTimeouts[key] = timeout;


### PR DESCRIPTION
[link to confluence use case](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/611910060/Use+case+periodic+update+of+key+material+MLS)

Each user periodically updates their key material for each MLS group they're in.

Goals:

(1)
Store the date (timestamp) of group creation / welcome message as last-kay-material:
 - [x] when creating a group - after conversation is successfully created in `createMLSConversation` (`ConversationService.ts`)
 - [x] when being added to a group (welcome message) - after user is successfully added in `sendExternalJoinProposal` (ConversationService.ts)

Dates are stored in indexedDB's `last_key_material_update_dates` table as objects ({groupId:string, previousUpdateDate: number})

(2)
 - [x] After 30 days (likely to change) since creating/being added to a group - renew keying material for each mls group - achieved with `TaskScheduler` - each time app is launched it gets the dates of last key update and schedules tasks to renew key material (3) for `> 30 days` old dates.

(3)
 - [x] For each group calculate the key material update (core crypto `updateKeyingMaterial(groupId)`) - returns a commit
 - [x] Send commit message and accept it.
 - [x] Update last-key-material timestamp for each group and schedule new renewal task

(4)
- [x] Every time you (as a group admin) remove somebody else from the conversation, your keying material gets updated, so we should update current group's the timer (indexDB entry) with user-removal date.

(5)
- [x] threshold (`<timer>`) value should be configurable per environment to make it easy for QA to change the time after which keys should get updated (not to make them wait 30 days 😆) - we're passing threshold value (`number` - milliseconds) value via `mlsConfig` object using optional `FEATURE_MLS_CONFIG_KEYING_MATERIAL_UPDATE_THRESHOLD` env variable.

This pull request also adds new `MLSService` class which contains mls-related methods shared between conversation and notification services. This is the only service that has access to coreCryptoClient (which is lazy-initialised and possible `undefined` - proteus case). All other services should call coreCrypto methods indirectly through `MLSService` - this way we're sure coreCryptoProvider exists (an error would be thrown otherwise).

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
