### PR TITLE
runfix: correct typo for Link focus state

### DIFF
--- a/packages/react-ui-kit/src/Text/Link.tsx
+++ b/packages/react-ui-kit/src/Text/Link.tsx
@@ -54,7 +54,7 @@ export const linkStyle: <T>(theme: Theme, props: LinkProps<T>) => CSSObject = (
       color: color,
     },
     ...(variant === LinkVariant.PRIMARY && {
-      '&:hover, &:visited:hover, &:focus:active': {
+      '&:hover, &:visited:hover, &:focus-visible': {
         color: theme.general.primaryColor,
       },
       fontSize: '16px',


### PR DESCRIPTION
- corect `focus:active` to `focus-visible`
