### PR TITLE
feat: Clear created databases when logging out

### DIFF
--- a/packages/core/src/main/util/encryptedStore.ts
+++ b/packages/core/src/main/util/encryptedStore.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {DBSchema, IDBPDatabase, openDB} from 'idb';
+import {DBSchema, IDBPDatabase, openDB, deleteDB} from 'idb';
 
 interface DefaultEncryptedPayload {
   iv: Uint8Array;
@@ -132,4 +132,8 @@ export async function createCustomEncryptedStore<EncryptedPayload>(
   });
 
   return new EncryptedStore(db, config);
+}
+
+export async function deleteEncryptedStore(dbName: string) {
+  return deleteDB(dbName);
 }


### PR DESCRIPTION
When logging out, if the user wants to clear the data, we also need to clear any database that was created on the account of the core. 

This PR adds the `clearData` param to the `logout` method in order to do this