### PR TITLE
feat: Update getAllParticipantsClients to use better endpoints without a hack

### DIFF
--- a/packages/api-client/src/conversation/Member.ts
+++ b/packages/api-client/src/conversation/Member.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {QualifiedId} from '../user';
 import type {DefaultConversationRoleName, MutedStatus, ServiceRef} from './';
 
 export interface Member {
@@ -40,4 +41,5 @@ export interface Member {
   service: ServiceRef | null;
   status_ref: string;
   status_time: string;
+  qualified_id?: QualifiedId;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

This PR will change getAllParticipantsClients, basically previously we used to send an empty message to backend to get a list of missing clients as a hacky way to get a list of user clients in a conversation (**BROKEN FOR MLS CONVERSATIONS**), in this PR the logic is slightly changed without a breaking change, what is done is instead of calling an endpoint with empty message we first fetch the conversation from the backend and extract a fresh list of users in it then make a request to another endpoint we have which if we give it a list of user ids it'll return a list of clients.

## Pull Request Checklist

- [X] My code is covered by tests
- [X] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
