### PR TITLE
feat: Always send OTR messages using protobuf

### DIFF
--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -21,7 +21,7 @@ import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
 import type {AxiosRequestConfig} from 'axios';
 
 import {ValidationError} from '../validation/';
-import type {ClientMismatch, MessageSendingStatus, NewOTRMessage} from '../conversation/';
+import type {ClientMismatch, MessageSendingStatus} from '../conversation/';
 import type {HttpClient} from '../http/';
 
 export class BroadcastAPI {
@@ -45,48 +45,6 @@ export class BroadcastAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postOtrBroadcast
    */
   public async postBroadcastMessage(
-    sendingClientId: string,
-    messageData: NewOTRMessage<string>,
-    ignoreMissing?: boolean | string[],
-  ): Promise<ClientMismatch> {
-    if (!sendingClientId) {
-      throw new ValidationError('Unable to send OTR message without client ID.');
-    }
-
-    const config: AxiosRequestConfig = {
-      data: messageData,
-      method: 'post',
-      url: BroadcastAPI.URL.BROADCAST,
-    };
-
-    if (typeof ignoreMissing !== 'undefined') {
-      const ignore_missing = Array.isArray(ignoreMissing) ? ignoreMissing.join(',') : ignoreMissing;
-      config.params = {ignore_missing};
-      // `ignore_missing` takes precedence on the server so we can remove
-      // `report_missing` to save some bandwidth.
-      delete messageData.report_missing;
-    } else if (typeof messageData.report_missing === 'undefined') {
-      // both `ignore_missing` and `report_missing` are undefined
-      config.params = {ignore_missing: !!messageData.data};
-    }
-
-    const response = await this.client.sendJSON<ClientMismatch>(config);
-    return response.data;
-  }
-
-  /**
-   * Broadcast an encrypted message to all team members and all contacts (accepts Protobuf).
-   * @param sendingClientId The sender's client ID
-   * @param messageData The message content
-   * @param ignoreMissing Whether to report missing clients or not:
-   * `false`: Report about all missing clients
-   * `true`: Ignore all missing clients and force sending
-   * Array: User IDs specifying which user IDs are allowed to have
-   * missing clients
-   * `undefined`: Default to setting of `report_missing` in `NewOTRMessage`
-   * @see https://staging-nginz-https.zinfra.io/swagger-ui/tab.html#!/postOtrBroadcast
-   */
-  public async postBroadcastProtobufMessage(
     sendingClientId: string,
     messageData: ProtobufOTR.NewOtrMessage,
     ignoreMissing?: boolean | string[],

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.test.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.test.ts
@@ -19,8 +19,9 @@
 
 import {HttpClient} from '../../http';
 import {ConversationAPI} from './ConversationAPI';
+import {proteus} from '@wireapp/protocol-messaging/web/otr';
 
-const httpClientMock = jasmine.createSpyObj('httpClient', {sendJSON: () => ({data: ''})});
+const httpClientMock = jasmine.createSpyObj('httpClient', {sendProtocolBuffer: () => ({data: ''})});
 
 describe('ConversationAPI', () => {
   const conversationApi = new ConversationAPI(httpClientMock as HttpClient, {
@@ -30,22 +31,26 @@ describe('ConversationAPI', () => {
   });
   describe('postORTMessage', () => {
     it('add ignore_missing and report_missing parameters', async () => {
-      await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, false);
-      expect(httpClientMock.sendJSON).toHaveBeenCalledWith(
+      const message = new proteus.NewOtrMessage({sender: {client: 1e6}});
+      await conversationApi.postOTRMessage('conv-id', message, false);
+      expect(httpClientMock.sendProtocolBuffer).toHaveBeenCalledWith(
         jasmine.objectContaining({
           params: {ignore_missing: false},
         }),
         true,
       );
 
-      await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, true);
-      expect(httpClientMock.sendJSON).toHaveBeenCalledWith(
+      await conversationApi.postOTRMessage('conv-id', new proteus.NewOtrMessage({sender: {client: 1e6}}), true);
+      expect(httpClientMock.sendProtocolBuffer).toHaveBeenCalledWith(
         jasmine.objectContaining({params: {ignore_missing: true}}),
         true,
       );
 
-      await conversationApi.postOTRMessage('client-id', 'conv-id', undefined, ['user1', 'user2']);
-      expect(httpClientMock.sendJSON).toHaveBeenCalledWith(
+      await conversationApi.postOTRMessage('conv-id', new proteus.NewOtrMessage({sender: {client: 1e6}}), [
+        'user1',
+        'user2',
+      ]);
+      expect(httpClientMock.sendProtocolBuffer).toHaveBeenCalledWith(
         jasmine.objectContaining({
           params: {ignore_missing: 'user1,user2'},
         }),

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -31,9 +31,7 @@ import {
   DefaultConversationRoleName,
   Invite,
   Member,
-  MessageSendingStatus,
   NewConversation,
-  NewOTRMessage,
   QualifiedConversationIds,
   RemoteConversations,
 } from '..';
@@ -672,96 +670,6 @@ export class ConversationAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/postOtrMessage
    */
   public async postOTRMessage(
-    sendingClientId: string,
-    conversationId: string,
-    messageData?: NewOTRMessage<string>,
-    ignoreMissing?: boolean | string[],
-  ): Promise<ClientMismatch> {
-    if (!sendingClientId) {
-      throw new ValidationError('Unable to send OTR message without client ID.');
-    }
-
-    messageData ||= {
-      recipients: {},
-      sender: sendingClientId,
-    };
-
-    const config: AxiosRequestConfig = {
-      data: messageData,
-      method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.OTR}/${ConversationAPI.URL.MESSAGES}`,
-    };
-
-    if (typeof ignoreMissing !== 'undefined') {
-      const ignore_missing = Array.isArray(ignoreMissing) ? ignoreMissing.join(',') : ignoreMissing;
-      config.params = {ignore_missing};
-      // `ignore_missing` takes precedence on the server so we can remove
-      // `report_missing` to save some bandwidth.
-      delete messageData.report_missing;
-    } else if (typeof messageData.report_missing === 'undefined' || !messageData.report_missing.length) {
-      // both `ignore_missing` and `report_missing` are undefined
-      config.params = {ignore_missing: !!messageData.data};
-    }
-
-    const response = await this.client.sendJSON<ClientMismatch>(config, true);
-    return response.data;
-  }
-
-  /**
-   * This endpoint ensures that the list of clients is correct and only sends the message if the list is correct.
-   * To override this, the endpoint accepts `client_mismatch_strategy` in the body. It can have these values:
-   *
-   * - `report_all`: When set, the message is not sent if any clients are missing. The missing clients are reported
-   * in the response.
-   * - `ignore_all`: When set, no checks about missing clients are carried out.
-   * - `report_only`: Takes a list of qualified UserIDs. If any clients of the listed users are missing, the message is
-   * not sent. The missing clients are reported in the response.
-   * - `ignore_only`: Takes a list of qualified UserIDs. If any clients of the non-listed users are missing, the message
-   * is not sent. The missing clients are reported in the response.
-   *
-   * The sending of messages in a federated conversation could theorectically fail partially. To make this case
-   * unlikely, the backend first gets a list of clients from all the involved backends and then tries to send a message.
-   * So, if any backend is down, the message is not propagated to anyone. But the actual message fan out to multiple
-   * backends could still fail partially. This type of failure is reported as a 201, the clients for which the message
-   * sending failed are part of the response body.
-   *
-   * This endpoint can lead to OtrMessageAdd event being sent to the recipients.
-   *
-   * @see https://nginz-https.anta.wire.link/api/swagger-ui/#/default/post_conversations__cnv_domain___cnv__proteus_messages
-   */
-  public async postOTRMessageV2(
-    conversationId: string,
-    domain: string,
-    messageData: ProtobufOTR.QualifiedNewOtrMessage,
-  ): Promise<MessageSendingStatus> {
-    const config: AxiosRequestConfig = {
-      /*
-       * We need to slice the content of what protobuf has generated in order for Axios to send the correct data (see https://github.com/axios/axios/issues/4068)
-       * FIXME: The `slice` can be removed as soon as Axios publishes a version with the dataview issue fixed.
-       */
-      data: ProtobufOTR.QualifiedNewOtrMessage.encode(messageData).finish().slice(),
-      method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${domain}/${conversationId}/${ConversationAPI.URL.PROTEUS}/${ConversationAPI.URL.MESSAGES}`,
-    };
-
-    const response = await this.client.sendProtocolBuffer<MessageSendingStatus>(config, true);
-    return response.data;
-  }
-
-  /**
-   * Post an encrypted message to a conversation.
-   * @param sendingClientId The sender's client ID
-   * @param conversationId The conversation ID
-   * @param messageData The message content
-   * @param ignoreMissing Whether to report missing clients or not:
-   * `false`: Report about all missing clients
-   * `true`: Ignore all missing clients and force sending.
-   * Array: User IDs specifying which user IDs are allowed to have
-   * missing clients
-   * `undefined`: Default to setting of `report_missing` in `NewOTRMessage`
-   * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/postOtrMessage
-   */
-  public async postOTRProtobufMessage(
     sendingClientId: string,
     conversationId: string,
     messageData: ProtobufOTR.NewOtrMessage,

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -31,6 +31,7 @@ import {
   DefaultConversationRoleName,
   Invite,
   Member,
+  MessageSendingStatus,
   NewConversation,
   QualifiedConversationIds,
   RemoteConversations,
@@ -669,12 +670,12 @@ export class ConversationAPI {
    * `undefined`: Default to setting of `report_missing` in `NewOTRMessage`
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/postOtrMessage
    */
-  public async postOTRMessage(
+  public async postOTRMessage<T extends string | QualifiedId>(
     sendingClientId: string,
-    conversationId: string | QualifiedId,
+    conversationId: T,
     messageData: ProtobufOTR.NewOtrMessage,
     ignoreMissing?: boolean | string[],
-  ): Promise<ClientMismatch> {
+  ): Promise<T extends string ? ClientMismatch : MessageSendingStatus> {
     if (!sendingClientId) {
       throw new ValidationError('Unable to send OTR message without client ID.');
     }
@@ -703,7 +704,10 @@ export class ConversationAPI {
       config.params = {ignore_missing: !!messageData.blob};
     }
 
-    const response = await this.client.sendProtocolBuffer<ClientMismatch>(config, true);
+    const response = await this.client.sendProtocolBuffer<T extends string ? ClientMismatch : MessageSendingStatus>(
+      config,
+      true,
+    );
     return response.data;
   }
 

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -18,7 +18,7 @@
  */
 
 import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
-import type {AxiosError, AxiosRequestConfig} from 'axios';
+import type {AxiosRequestConfig} from 'axios';
 
 import {ValidationError} from '../../validation';
 import {
@@ -827,15 +827,6 @@ export class ConversationAPI {
     };
 
     await this.client.sendProtocolMls<void>(config, true);
-  }
-
-  public async postForClients(clientId: string, conversationId: string): Promise<ClientMismatch> {
-    try {
-      await this.postOTRMessage(clientId, conversationId);
-      throw new Error(`Expected backend to throw error.`);
-    } catch (error) {
-      return (error as AxiosError).response!.data;
-    }
   }
 
   /**

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -671,7 +671,7 @@ export class ConversationAPI {
    */
   public async postOTRMessage(
     sendingClientId: string,
-    conversationId: string,
+    conversationId: string | QualifiedId,
     messageData: ProtobufOTR.NewOtrMessage,
     ignoreMissing?: boolean | string[],
   ): Promise<ClientMismatch> {
@@ -686,7 +686,10 @@ export class ConversationAPI {
        */
       data: ProtobufOTR.NewOtrMessage.encode(messageData).finish().slice(),
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.OTR}/${ConversationAPI.URL.MESSAGES}`,
+      url:
+        typeof conversationId === 'string'
+          ? `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.OTR}/${ConversationAPI.URL.MESSAGES}`
+          : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.PROTEUS}/${ConversationAPI.URL.MESSAGES}`,
     };
 
     if (typeof ignoreMissing !== 'undefined') {

--- a/packages/core/src/demo/sender.ts
+++ b/packages/core/src/demo/sender.ts
@@ -61,7 +61,6 @@ const {
 
 (async () => {
   const MESSAGE_TIMER = TimeUtil.TimeInMillis.SECOND * 5;
-  const useProtobuf = false;
 
   ['WIRE_EMAIL', 'WIRE_PASSWORD', 'WIRE_CONVERSATION_ID', 'WIRE_BACKEND'].forEach((envVar, _, array) => {
     if (!process.env[envVar]) {
@@ -101,7 +100,6 @@ const {
     }).build();
     const {id: messageId} = await account.service!.conversation.send({
       payloadBundle: deleteTextPayload,
-      sendAsProtobuf: useProtobuf,
     });
 
     const fiveSecondsInMillis = TimeUtil.TimeInMillis.SECOND * 5;
@@ -123,14 +121,14 @@ const {
       from: account.userId,
       text: `Expires after ${expiry}ms ...`,
     }).build();
-    await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: payload});
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, 0);
   }
 
   async function sendPing(expiry = MESSAGE_TIMER): Promise<void> {
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, expiry);
     const payload = MessageBuilder.createPing(WIRE_CONVERSATION_ID);
-    await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: payload});
     account.service!.conversation.messageTimer.setMessageLevelTimer(WIRE_CONVERSATION_ID, 0);
   }
 
@@ -140,7 +138,7 @@ const {
       from: account.userId,
       text: 'Hello, World!',
     }).build();
-    await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: payload});
   }
 
   async function sendAndEdit(): Promise<void> {
@@ -151,7 +149,6 @@ const {
     }).build();
     const {id: originalMessageId} = await account.service!.conversation.send({
       payloadBundle: payload,
-      sendAsProtobuf: useProtobuf,
     });
     setInterval(async () => {
       const editedPayload = MessageBuilder.createEditedText({
@@ -160,7 +157,7 @@ const {
         newMessageText: 'Hello, World!',
         originalMessageId,
       }).build();
-      await account.service!.conversation.send({payloadBundle: editedPayload, sendAsProtobuf: useProtobuf});
+      await account.service!.conversation.send({payloadBundle: editedPayload});
     }, TimeUtil.TimeInMillis.SECOND * 2);
   }
 
@@ -178,7 +175,7 @@ const {
       image,
       asset: await (await account.service!.asset.uploadAsset(image.data)).response,
     });
-    await account.service!.conversation.send({payloadBundle: imagePayload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: imagePayload});
   }
 
   async function sendFile(): Promise<void> {
@@ -193,7 +190,7 @@ const {
         type: 'image/png',
       },
     });
-    await account.service!.conversation.send({payloadBundle: metadataPayload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: metadataPayload});
 
     const file = {data};
     const filePayload = await MessageBuilder.createFileData({
@@ -203,7 +200,7 @@ const {
       asset: await (await account.service.asset.uploadAsset(file.data)).response,
       originalMessageId: metadataPayload.id,
     });
-    await account.service!.conversation.send({payloadBundle: filePayload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: filePayload});
   }
 
   async function clearConversation(): Promise<void> {
@@ -233,7 +230,7 @@ const {
       .withMentions(mentions)
       .build();
 
-    await account.service!.conversation.send({payloadBundle: payload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: payload});
   }
 
   async function sendQuote(): Promise<void> {
@@ -247,7 +244,6 @@ const {
 
     const {id: messageId} = await account.service!.conversation.send({
       payloadBundle: textPayload,
-      sendAsProtobuf: useProtobuf,
     });
 
     const quoteText = 'Hello again';
@@ -265,7 +261,7 @@ const {
       .withQuote(quote)
       .build();
 
-    await account.service!.conversation.send({payloadBundle: quotePayload, sendAsProtobuf: useProtobuf});
+    await account.service!.conversation.send({payloadBundle: quotePayload});
   }
 
   const methods = [

--- a/packages/core/src/main/broadcast/BroadcastService.ts
+++ b/packages/core/src/main/broadcast/BroadcastService.ts
@@ -78,7 +78,6 @@ export class BroadcastService {
   public async broadcastGenericMessage(
     genericMessage: GenericMessage,
     recipients: UserPreKeyBundleMap | UserClients | QualifiedUserClients,
-    sendAsProtobuf?: boolean,
     onClientMismatch?: (mismatch: ClientMismatch | MessageSendingStatus) => void | boolean | Promise<boolean>,
   ) {
     const plainTextArray = GenericMessage.encode(genericMessage).finish();
@@ -88,7 +87,6 @@ export class BroadcastService {
           onClientMismatch,
         })
       : this.messageService.sendMessage(this.apiClient.validatedClientId, recipients, plainTextArray, {
-          sendAsProtobuf,
           reportMissing: Object.keys(recipients),
           onClientMismatch,
         });

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -235,7 +235,6 @@ describe('MessageService', () => {
 
       await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
         conversationId,
-        sendAsProtobuf: true,
       });
       expect(apiClient.api.conversation.postOTRProtobufMessage).toHaveBeenCalledWith(
         clientId,
@@ -259,9 +258,7 @@ describe('MessageService', () => {
         Promise.resolve({} as ClientMismatch),
       );
 
-      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
-        sendAsProtobuf: true,
-      });
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {});
 
       expect(apiClient.api.broadcast.postBroadcastProtobufMessage).toHaveBeenCalledWith(
         clientId,

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -114,7 +114,7 @@ describe('MessageService', () => {
           deleted: {[user1.domain]: {[user1.id]: [user1.clients[0]]}},
           missing: {'2.wire.test': {[user2.id]: ['client22']}},
         };
-        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake((): any => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -141,7 +141,7 @@ describe('MessageService', () => {
         const onClientMismatch = jasmine.createSpy('onClientMismatch').and.returnValue(true);
         const clientMismatch = {...baseMessageSendingStatus, missing: {'2.wire.test': {[user2.id]: ['client22']}}};
         let spyCounter = 0;
-        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake((): any => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -220,7 +220,6 @@ describe('MessageService', () => {
         conversationId,
       });
       expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledWith(
-        clientId,
         conversationId,
         jasmine.any(Object),
         false,
@@ -252,9 +251,8 @@ describe('MessageService', () => {
         conversationId,
       });
       expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledWith(
-        clientId,
         conversationId,
-        jasmine.objectContaining({data: undefined}),
+        jasmine.objectContaining({blob: jasmine.objectContaining({length: 0})}),
         false,
       );
     });
@@ -273,9 +271,8 @@ describe('MessageService', () => {
         },
       );
       expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledWith(
-        clientId,
         conversationId,
-        jasmine.objectContaining({data: jasmine.any(String)}),
+        jasmine.objectContaining({blob: jasmine.any(Uint8Array)}),
         false,
       );
     });
@@ -295,7 +292,7 @@ describe('MessageService', () => {
           deleted: {[user1.id]: [user1.clients[0]]},
           missing: {[user2.id]: ['client22']},
         };
-        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake((): any => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -322,7 +319,7 @@ describe('MessageService', () => {
         const onClientMismatch = jasmine.createSpy().and.returnValue(Promise.resolve(true));
         const clientMismatch = {...baseClientMismatch, missing: {[user2.id]: ['client22']}};
         let spyCounter = 0;
-        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake((): any => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -97,13 +97,13 @@ describe('MessageService', () => {
 
   describe('sendFederatedMessage', () => {
     it('sends a message', async () => {
-      spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.returnValue(Promise.resolve(baseMessageSendingStatus));
+      spyOn(apiClient.api.conversation, 'postOTRMessage').and.returnValue(Promise.resolve(baseMessageSendingStatus));
       const recipients = generateQualifiedRecipients([user1, user2]);
 
       await messageService.sendFederatedMessage('senderclientid', recipients, new Uint8Array(), {
         conversationId: {id: 'convid', domain: ''},
       });
-      expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalled();
+      expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalled();
     });
 
     describe('client mismatch', () => {
@@ -114,7 +114,7 @@ describe('MessageService', () => {
           deleted: {[user1.domain]: {[user1.id]: [user1.clients[0]]}},
           missing: {'2.wire.test': {[user2.id]: ['client22']}},
         };
-        spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -134,14 +134,14 @@ describe('MessageService', () => {
           reportMissing: true,
           conversationId: {id: 'convid', domain: ''},
         });
-        expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalledTimes(2);
+        expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledTimes(2);
       });
 
       it('continues message sending if onClientMismatch returns true', async () => {
         const onClientMismatch = jasmine.createSpy('onClientMismatch').and.returnValue(true);
         const clientMismatch = {...baseMessageSendingStatus, missing: {'2.wire.test': {[user2.id]: ['client22']}}};
         let spyCounter = 0;
-        spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
           spyCounter++;
           if (spyCounter === 1) {
             const error = new Error();
@@ -162,14 +162,14 @@ describe('MessageService', () => {
           onClientMismatch,
           conversationId: {id: 'convid', domain: ''},
         });
-        expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalledTimes(2);
+        expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledTimes(2);
         expect(onClientMismatch).toHaveBeenCalledWith(clientMismatch);
       });
 
       it('stops message sending if onClientMismatch returns false', async () => {
         const onClientMismatch = jasmine.createSpy('onClientMismatch').and.returnValue(false);
         const clientMismatch = {...baseMessageSendingStatus, missing: {'2.wire.test': {[user2.id]: ['client22']}}};
-        spyOn(apiClient.api.conversation, 'postOTRMessageV2').and.callFake(() => {
+        spyOn(apiClient.api.conversation, 'postOTRMessage').and.callFake(() => {
           const error = new Error();
           (error as any).response = {
             status: StatusCodes.PRECONDITION_FAILED,
@@ -186,7 +186,7 @@ describe('MessageService', () => {
           onClientMismatch,
           conversationId: {id: 'convid', domain: ''},
         });
-        expect(apiClient.api.conversation.postOTRMessageV2).toHaveBeenCalledTimes(1);
+        expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalledTimes(1);
         expect(onClientMismatch).toHaveBeenCalledWith(clientMismatch);
       });
     });

--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -227,23 +227,6 @@ describe('MessageService', () => {
       );
     });
 
-    it('should send protobuf message to conversation', async () => {
-      const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.api.conversation, 'postOTRProtobufMessage').and.returnValue(
-        Promise.resolve({} as ClientMismatch),
-      );
-
-      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {
-        conversationId,
-      });
-      expect(apiClient.api.conversation.postOTRProtobufMessage).toHaveBeenCalledWith(
-        clientId,
-        conversationId,
-        jasmine.any(Object),
-        false,
-      );
-    });
-
     it('should broadcast regular message if no conversationId is given', async () => {
       const message = 'Lorem ipsum dolor sit amet';
       spyOn(apiClient.api.broadcast, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
@@ -254,17 +237,11 @@ describe('MessageService', () => {
 
     it('should broadcast protobuf message if no conversationId is given', async () => {
       const message = 'Lorem ipsum dolor sit amet';
-      spyOn(apiClient.api.broadcast, 'postBroadcastProtobufMessage').and.returnValue(
-        Promise.resolve({} as ClientMismatch),
-      );
+      spyOn(apiClient.api.broadcast, 'postBroadcastMessage').and.returnValue(Promise.resolve({} as ClientMismatch));
 
-      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message), {});
+      await messageService.sendMessage(clientId, generateRecipients(generateUsers(3, 3)), createMessage(message));
 
-      expect(apiClient.api.broadcast.postBroadcastProtobufMessage).toHaveBeenCalledWith(
-        clientId,
-        jasmine.any(Object),
-        false,
-      );
+      expect(apiClient.api.broadcast.postBroadcastMessage).toHaveBeenCalledWith(clientId, jasmine.any(Object), false);
     });
 
     it('should not send as external if payload small', async () => {

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -220,7 +220,7 @@ export class MessageService {
 
     const {id, domain} = options.conversationId;
 
-    return this.apiClient.api.conversation.postOTRMessageV2(id, domain, protoMessage);
+    return this.apiClient.api.conversation.postOTRMessage(id, domain, protoMessage);
   }
 
   private async generateExternalPayload(plainText: Uint8Array): Promise<{text: Uint8Array; cipherText: Uint8Array}> {

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -220,7 +220,7 @@ export class MessageService {
 
     const {id, domain} = options.conversationId;
 
-    return this.apiClient.api.conversation.postOTRMessage(id, domain, protoMessage);
+    return this.apiClient.api.conversation.postOTRMessage({id, domain}, protoMessage);
   }
 
   private async generateExternalPayload(plainText: Uint8Array): Promise<{text: Uint8Array; cipherText: Uint8Array}> {
@@ -360,11 +360,6 @@ export class MessageService {
 
     return !options.conversationId
       ? this.apiClient.api.broadcast.postBroadcastMessage(sendingClientId, protoMessage, ignoreMissing)
-      : this.apiClient.api.conversation.postOTRMessage(
-          sendingClientId,
-          options.conversationId,
-          protoMessage,
-          ignoreMissing,
-        );
+      : this.apiClient.api.conversation.postOTRMessage(options.conversationId, protoMessage, ignoreMissing);
   }
 }

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -359,8 +359,8 @@ export class MessageService {
     }
 
     return !options.conversationId
-      ? this.apiClient.api.broadcast.postBroadcastProtobufMessage(sendingClientId, protoMessage, ignoreMissing)
-      : this.apiClient.api.conversation.postOTRProtobufMessage(
+      ? this.apiClient.api.broadcast.postBroadcastMessage(sendingClientId, protoMessage, ignoreMissing)
+      : this.apiClient.api.conversation.postOTRMessage(
           sendingClientId,
           options.conversationId,
           protoMessage,

--- a/packages/core/src/main/user/UserService.ts
+++ b/packages/core/src/main/user/UserService.ts
@@ -65,13 +65,8 @@ export class UserService {
    * @param teamId
    * @param type
    * @param options.sendAll=false will broadcast the message to all the members of the team (instead of just direct connections). Should be avoided in a big team
-   * @param options.sendAsProtobuf=false
    */
-  public async setAvailability(
-    teamId: string,
-    type: AvailabilityType,
-    {sendAll = false, sendAsProtobuf = false} = {},
-  ): Promise<void> {
+  public async setAvailability(teamId: string, type: AvailabilityType, {sendAll = false} = {}): Promise<void> {
     // Get pre-key bundles for members of your own team
     const preKeyBundlesFromTeam = await this.broadcastService.getPreKeyBundlesFromTeam(teamId, false, !sendAll);
 
@@ -104,6 +99,6 @@ export class UserService {
     });
 
     // Broadcast availability status to your team members & external 1:1 connections
-    await this.broadcastService.broadcastGenericMessage(genericMessage, allPreKeyBundles, sendAsProtobuf);
+    await this.broadcastService.broadcastGenericMessage(genericMessage, allPreKeyBundles);
   }
 }


### PR DESCRIPTION
using JSON to send proteus message payload is deprecated and protobuf is the new way to do thing. 

Protobuf has been battle tested with the federation env, we can now get rid of the old JSON API and remove some dead code

BREAKING CHANGE: the `sendAsProtobuf` option for sending message has disappeared. All messages will be sent using protobuf from now one