### PR TITLE
runfix(core): address dexie error on deleting all stores on login 

### DIFF
--- a/packages/core/src/main/cryptography/CryptographyDatabaseRepository.ts
+++ b/packages/core/src/main/cryptography/CryptographyDatabaseRepository.ts
@@ -37,9 +37,7 @@ export class CryptographyDatabaseRepository {
 
   public deleteStores(): Promise<boolean[]> {
     return Promise.all(
-      (
-        Object.keys(CryptographyDatabaseRepository.STORES) as (keyof typeof CryptographyDatabaseRepository.STORES)[]
-      ).map(store => this.storeEngine.deleteAll(store)),
+      Object.values(CryptographyDatabaseRepository.STORES).map(store => this.storeEngine.deleteAll(store)),
     );
   }
 }

--- a/packages/core/src/main/cryptography/CryptographyDatabaseRepository.ts
+++ b/packages/core/src/main/cryptography/CryptographyDatabaseRepository.ts
@@ -37,6 +37,7 @@ export class CryptographyDatabaseRepository {
 
   public deleteStores(): Promise<boolean[]> {
     return Promise.all(
+      //make sure we use enum's lowercase values, not uppercase keys
       Object.values(CryptographyDatabaseRepository.STORES).map(store => this.storeEngine.deleteAll(store)),
     );
   }


### PR DESCRIPTION
Client was not able to delete all stores on login from a fresh (deleted) device.

`Object.keys` (eg. `"AMPLIFY"`) was used instead of `Object.values` (eg. `"amplify"`) for table names, so the client was not able to find the tables and showed `unexpected error` message on client's side. 
