### PR TITLE
runfix(store-engine-web-storage): fix package entry point

### DIFF
--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -18,7 +18,7 @@
     "!src/**/!(*.d).ts"
   ],
   "license": "GPL-3.0",
-  "main": "src/LocalStorageEngine",
+  "main": "src/WebStorageEngine",
   "name": "@wireapp/store-engine-web-storage",
   "peerDependencies": {
     "@wireapp/store-engine": "4.x.x"


### PR DESCRIPTION
`@wireapp/store-engine-web-storage` package had wrong (non-existing) entry file defined in `package.json` `main` field, what resulted in `cannot find module and its type declarations` ts error.
