### PR TITLE
runfix(store-engine-web-storage): set web storage package main file to root

### DIFF
--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -18,7 +18,7 @@
     "!src/**/!(*.d).ts"
   ],
   "license": "GPL-3.0",
-  "main": "src/LocalStorageEngine",
+  "main": "src/WebStorageEngine",
   "name": "@wireapp/store-engine-web-storage",
   "peerDependencies": {
     "@wireapp/store-engine": "4.x.x"

--- a/packages/store-engine-web-storage/package.json
+++ b/packages/store-engine-web-storage/package.json
@@ -18,7 +18,7 @@
     "!src/**/!(*.d).ts"
   ],
   "license": "GPL-3.0",
-  "main": "src/WebStorageEngine",
+  "main": "src/index",
   "name": "@wireapp/store-engine-web-storage",
   "peerDependencies": {
     "@wireapp/store-engine": "4.x.x"

--- a/packages/store-engine-web-storage/src/index.ts
+++ b/packages/store-engine-web-storage/src/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2022 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './WebStorageEngine';


### PR DESCRIPTION
Change `@wireapp/store-engine-web-storage` package's entry point to root (`index.ts`)