### PR TITLE
runfix(promise-queue): downgrade ts version to 4.4.2

### DIFF
--- a/packages/promise-queue/package.json
+++ b/packages/promise-queue/package.json
@@ -5,7 +5,7 @@
     "jest": "29.0.2",
     "jest-environment-jsdom": "29.0.2",
     "rimraf": "3.0.2",
-    "typescript": "4.8.2"
+    "typescript": "4.4.2"
   },
   "description": "A Promise-based dynamic queue runner.",
   "license": "GPL-3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17223,11 +17223,6 @@ typescript@4.4.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
-typescript@4.8.2:
-  version "4.8.2"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
-
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"
   resolved "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz#9e0f5aabd5eebfcffd65a796487541196f4b1211"


### PR DESCRIPTION
Downgrade `typescript` version to `4.4.2` as it caused compilation errors in `@wireapp/core` package.