### PR TITLE
feat: leave mls conversation (FS-683)

### DIFF
--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -1329,4 +1329,9 @@ export class ConversationService {
     const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationGroupId!).asBytes;
     return this.mlsService.conversationExists(groupIdDecodedFromBase64);
   }
+
+  public async wipeMLSConversation(conversationId: QualifiedId): Promise<void> {
+    const conversationGroupId = await this.notificationService.getUint8ArrayFromConversationGroupId(conversationId);
+    await this.mlsService.wipeConversation(conversationGroupId);
+  }
 }

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -888,6 +888,11 @@ export class ConversationService {
       ),
     );
   }
+
+  public async wipeMLSConversation(conversationId: string): Promise<void> {
+    const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationId).asBytes;
+    return this.mlsService.wipeConversation(groupIdDecodedFromBase64);
+  }
   /**
    * Create a group conversation.
    * @param  {string} name

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -1330,8 +1330,7 @@ export class ConversationService {
     return this.mlsService.conversationExists(groupIdDecodedFromBase64);
   }
 
-  public async wipeMLSConversation(conversationId: QualifiedId): Promise<void> {
-    const conversationGroupId = await this.notificationService.getUint8ArrayFromConversationGroupId(conversationId);
-    await this.mlsService.wipeConversation(conversationGroupId);
+  public async wipeMLSConversation(conversationId: Uint8Array): Promise<void> {
+    return this.mlsService.wipeConversation(conversationId);
   }
 }

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -1329,9 +1329,4 @@ export class ConversationService {
     const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationGroupId!).asBytes;
     return this.mlsService.conversationExists(groupIdDecodedFromBase64);
   }
-
-  public async wipeMLSConversation(conversationId: string): Promise<void> {
-    const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationId).asBytes;
-    return this.mlsService.wipeConversation(groupIdDecodedFromBase64);
-  }
 }

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -867,10 +867,6 @@ export class ConversationService {
     });
   }
 
-  public leaveMLSConversation(conversationId: QualifiedId): Promise<ConversationMemberLeaveEvent> {
-    return this.leaveConversation(conversationId);
-  }
-
   /**
    * @depricated seems not to be used and is outdated. use leaveConversation instead
    */
@@ -889,10 +885,6 @@ export class ConversationService {
     );
   }
 
-  public async wipeMLSConversation(conversationId: string): Promise<void> {
-    const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationId).asBytes;
-    return this.mlsService.wipeConversation(groupIdDecodedFromBase64);
-  }
   /**
    * Create a group conversation.
    * @param  {string} name
@@ -1336,5 +1328,10 @@ export class ConversationService {
   public async isMLSConversationEstablished(conversationGroupId: string) {
     const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationGroupId!).asBytes;
     return this.mlsService.conversationExists(groupIdDecodedFromBase64);
+  }
+
+  public async wipeMLSConversation(conversationId: string): Promise<void> {
+    const groupIdDecodedFromBase64 = Decoder.fromBase64(conversationId).asBytes;
+    return this.mlsService.wipeConversation(groupIdDecodedFromBase64);
   }
 }

--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -202,4 +202,8 @@ export class MLSService {
       keypackages.map(keypackage => btoa(Converter.arrayBufferViewToBaselineString(keypackage))),
     );
   }
+
+  public async wipeConversation(conversationId: ConversationId): Promise<void> {
+    return this.getCoreCryptoClient().wipeConversation(conversationId);
+  }
 }


### PR DESCRIPTION
[Use case: leaving a conversation (MLS)](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/617382226/Use+case+leaving+a+conversation+MLS)

Removes `leaveMLSConversation` wrapper method (we use `leaveMLSConversation` - it works for both mls and proteus protocols).

Adds `wipeMLSConversation` core-crypto method to conversation service (which will be used in `wire-webapp` to wipe conversation after client receives `conversation.member-leave` event.
