### PR TITLE
refactor: replace lerna with maintained fork lerna-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "devDependencies": {
     "@babel/eslint-parser": "7.17.0",
+    "@lerna-lite/changed": "^1.11.3",
+    "@lerna-lite/cli": "^1.11.3",
+    "@lerna-lite/run": "^1.11.3",
     "@types/rimraf": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "4.29.0",
     "@typescript-eslint/parser": "4.29.0",
@@ -19,7 +22,6 @@
     "eslint-plugin-unused-imports": "1.1.2",
     "husky": "4.3.8",
     "jest": "^29.0.3",
-    "lerna": "5.5.1",
     "lint-staged": "11.1.1",
     "prettier": "2.3.2",
     "tsconfig-paths": "3.10.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "jest": "^29.0.3",
     "lint-staged": "11.1.1",
     "prettier": "2.3.2",
-    "tsconfig-paths": "3.10.1"
+    "tsconfig-paths": "3.10.1",
+    "typescript": "^4.8.3"
   },
   "engines": {
     "node": ">= 14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,13 +2978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/string-locale-compare@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@isaacs/string-locale-compare@npm:1.1.0"
-  checksum: 7287da5d11497b82c542d3c2abe534808015be4f4883e71c26853277b5456f6bbe4108535db847a29f385ad6dc9318ffb0f55ee79bb5f39993233d7dccf8751d
-  languageName: node
-  linkType: hard
-
 "@istanbuljs/load-nyc-config@npm:^1.0.0":
   version: 1.0.0
   resolution: "@istanbuljs/load-nyc-config@npm:1.0.0"
@@ -3368,806 +3361,236 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna/add@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/add@npm:5.5.1"
+"@lerna-lite/changed@npm:^1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/changed@npm:1.11.3"
   dependencies:
-    "@lerna/bootstrap": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/filter-options": 5.5.1
-    "@lerna/npm-conf": 5.5.1
-    "@lerna/validation-error": 5.5.1
+    "@lerna-lite/core": 1.11.3
+    "@lerna-lite/list": 1.11.3
+    "@lerna-lite/listable": 1.11.3
+  checksum: 7f801a625e0fe716ecc84979200d68fa0f9be56856a8dbc2c89a4c283fda9896e5f9eea6666cba03e966c330561555ce78e0cf5c29384d72f2d564a677484d53
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/cli@npm:^1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/cli@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    "@lerna-lite/info": 1.11.3
+    "@lerna-lite/init": 1.11.3
+    "@lerna-lite/listable": 1.11.3
+    "@lerna-lite/publish": 1.11.3
+    "@lerna-lite/version": 1.11.3
     dedent: ^0.7.0
-    npm-package-arg: 8.1.1
-    p-map: ^4.0.0
-    pacote: ^13.6.1
-    semver: ^7.3.4
-  checksum: 1d2ad9eff8fcce5167dc9204d379d91e1ac86ddfc18ef8f12c106a9c2f59dac33371a0aa47678fd10183849570b8b68aa21a7b563b42c711067c89e980fdae7e
-  languageName: node
-  linkType: hard
-
-"@lerna/bootstrap@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/bootstrap@npm:5.5.1"
-  dependencies:
-    "@lerna/command": 5.5.1
-    "@lerna/filter-options": 5.5.1
-    "@lerna/has-npm-version": 5.5.1
-    "@lerna/npm-install": 5.5.1
-    "@lerna/package-graph": 5.5.1
-    "@lerna/pulse-till-done": 5.5.1
-    "@lerna/rimraf-dir": 5.5.1
-    "@lerna/run-lifecycle": 5.5.1
-    "@lerna/run-topologically": 5.5.1
-    "@lerna/symlink-binary": 5.5.1
-    "@lerna/symlink-dependencies": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    "@npmcli/arborist": 5.3.0
-    dedent: ^0.7.0
-    get-port: ^5.1.1
-    multimatch: ^5.0.0
-    npm-package-arg: 8.1.1
+    dotenv: ^16.0.2
+    import-local: ^3.1.0
+    load-json-file: ^6.2.0
     npmlog: ^6.0.2
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-    p-waterfall: ^2.1.1
-    semver: ^7.3.4
-  checksum: 4c91e8e37fa1164142274bc546cc9981824a2754a2f2514fa4c95cc01e74a48f55e71b914fa6ab4c10a9cee044bf11491285982640ce552a4f1664febbcfedbb
+    path: ^0.12.7
+    yargs: ^17.5.1
+  bin:
+    lerna: dist/cli.js
+  checksum: 3aec9952088c5b394c75ea792d03f26edbbd9c55b9320fe0d03a6b4dd0f3abd7223f6b3838286c28dc8a4923b13138c4d53106c56e7e0083c4a9b352544f0c04
   languageName: node
   linkType: hard
 
-"@lerna/changed@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/changed@npm:5.5.1"
+"@lerna-lite/core@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/core@npm:1.11.3"
   dependencies:
-    "@lerna/collect-updates": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/listable": 5.5.1
-    "@lerna/output": 5.5.1
-  checksum: 42b09adcc1a25e839171cab46487081f2d266b1f74afc385ec43595e73c931c7edadceae6df21a37d5a1c32e34970906e64b946dd327eac09b8c23748f648f0e
-  languageName: node
-  linkType: hard
-
-"@lerna/check-working-tree@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/check-working-tree@npm:5.5.1"
-  dependencies:
-    "@lerna/collect-uncommitted": 5.5.1
-    "@lerna/describe-ref": 5.5.1
-    "@lerna/validation-error": 5.5.1
-  checksum: fdd3404d86491724bb993e85fe18138cf40e8d9cbe921558cdd9e849f79417338b495697f84ded620cf19c0b7f1e5a8364b0382d06cf0ae2cdfc8b0384d527fa
-  languageName: node
-  linkType: hard
-
-"@lerna/child-process@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/child-process@npm:5.5.1"
-  dependencies:
-    chalk: ^4.1.0
-    execa: ^5.0.0
-    strong-log-transformer: ^2.1.0
-  checksum: 4d54201c3cdee513c0bb5884531b1c1992dae6c1a47587879db8d6b7bb5991b92853a4ee7cffb40928be317188c8c3578f70e24f36b93635bcd99740aa3a80eb
-  languageName: node
-  linkType: hard
-
-"@lerna/clean@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/clean@npm:5.5.1"
-  dependencies:
-    "@lerna/command": 5.5.1
-    "@lerna/filter-options": 5.5.1
-    "@lerna/prompt": 5.5.1
-    "@lerna/pulse-till-done": 5.5.1
-    "@lerna/rimraf-dir": 5.5.1
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-    p-waterfall: ^2.1.1
-  checksum: 2d2c23ef1308bbae292ff68f546590c5d5ac20c0bdfb3ab5ba29d2a6e941e716dc2c391adca89adee184e9c4663a4b85287e00458a52b7d0e68986ba419a5f06
-  languageName: node
-  linkType: hard
-
-"@lerna/cli@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/cli@npm:5.5.1"
-  dependencies:
-    "@lerna/global-options": 5.5.1
-    dedent: ^0.7.0
-    npmlog: ^6.0.2
-    yargs: ^16.2.0
-  checksum: f708f274b11bbdfdbb9b1838c24eb6eeb59774ab7921cb52facfc1d736a024ac44782bd0ad496a322b5a8c575c5f8cccb0b6f250b9bb3f1f4d9a80ac5839140d
-  languageName: node
-  linkType: hard
-
-"@lerna/collect-uncommitted@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/collect-uncommitted@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    chalk: ^4.1.0
-    npmlog: ^6.0.2
-  checksum: ab1e2c414db4fda1bcf32d05995fab6d7fbf83cc46aa795283168cf506fd54cf361bcef783fbccc7669f73ec967f2e58eb4327f890430cc4517402c7937a5a0d
-  languageName: node
-  linkType: hard
-
-"@lerna/collect-updates@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/collect-updates@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/describe-ref": 5.5.1
-    minimatch: ^3.0.4
-    npmlog: ^6.0.2
-    slash: ^3.0.0
-  checksum: 49cca60b349ec6f3631a258f017cb90dc6a3f1bacddfeac52f8cdd43afb773db5fe9d94bb3f848ef526d92a55f868758be9d40ee2677497bce77e8aea46fda37
-  languageName: node
-  linkType: hard
-
-"@lerna/command@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/command@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/package-graph": 5.5.1
-    "@lerna/project": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    "@lerna/write-log-file": 5.5.1
-    clone-deep: ^4.0.1
-    dedent: ^0.7.0
-    execa: ^5.0.0
-    is-ci: ^2.0.0
-    npmlog: ^6.0.2
-  checksum: a3a3d37f21f7976bec34419d0a32e2d70e9fb30c4f5ab4ff38a88e23121897a9aac87c0f1cf403e90a7e39c06aeb22d0de95c72063baafa9d04fe73f5a32bd52
-  languageName: node
-  linkType: hard
-
-"@lerna/conventional-commits@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/conventional-commits@npm:5.5.1"
-  dependencies:
-    "@lerna/validation-error": 5.5.1
-    conventional-changelog-angular: ^5.0.12
-    conventional-changelog-core: ^4.2.4
-    conventional-recommended-bump: ^6.1.0
-    fs-extra: ^9.1.0
-    get-stream: ^6.0.0
-    npm-package-arg: 8.1.1
-    npmlog: ^6.0.2
-    pify: ^5.0.0
-    semver: ^7.3.4
-  checksum: 289f47573e434435f4930109dd4ca8ed255f6c3ac23f40fe9a6b4f51865943bd96af5a3be59d8787cc80b81fdf65edbc0e993bdab491212d7d40524a6b378d00
-  languageName: node
-  linkType: hard
-
-"@lerna/create-symlink@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/create-symlink@npm:5.5.1"
-  dependencies:
-    cmd-shim: ^5.0.0
-    fs-extra: ^9.1.0
-    npmlog: ^6.0.2
-  checksum: 8e979aa09cdc8e8c9928bc57f74759c64b68b306618feeb223449fa344e15fbd4ee8fe528d54e7aa17213f758458c9dcab9799883f738b2405d9506a1fc6ec27
-  languageName: node
-  linkType: hard
-
-"@lerna/create@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/create@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/npm-conf": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    dedent: ^0.7.0
-    fs-extra: ^9.1.0
-    globby: ^11.0.2
-    init-package-json: ^3.0.2
-    npm-package-arg: 8.1.1
-    p-reduce: ^2.1.0
-    pacote: ^13.6.1
-    pify: ^5.0.0
-    semver: ^7.3.4
-    slash: ^3.0.0
-    validate-npm-package-license: ^3.0.4
-    validate-npm-package-name: ^4.0.0
-    yargs-parser: 20.2.4
-  checksum: 7810656e89a0fdecd41913b491e1b9ea47c1837d7452964357473894747c2131ab970bfa1016253e9f7e62662bbc5e1c53e242ed7c33f7a9354aef4d2505c920
-  languageName: node
-  linkType: hard
-
-"@lerna/describe-ref@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/describe-ref@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    npmlog: ^6.0.2
-  checksum: 5ae36ddd3b6ef0b91d62599aac6adb643baa5616b3e732a7828e20dfe028c6d7958ab367e7ea3418c8405a91bf51549b6cedeba8caaf1c02de8ad56c8ab121ee
-  languageName: node
-  linkType: hard
-
-"@lerna/diff@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/diff@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    npmlog: ^6.0.2
-  checksum: 198f450e88bccb0c06a61467b94be43337c1cf9e32687e97d0f6d5d14ef0e81d627d652aee7d1fc7be115b7aa05a2688f2656fae0cdf0b1bb77f837d4ca58cd2
-  languageName: node
-  linkType: hard
-
-"@lerna/exec@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/exec@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/filter-options": 5.5.1
-    "@lerna/profiler": 5.5.1
-    "@lerna/run-topologically": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    p-map: ^4.0.0
-  checksum: ec212fbc5d1ce9c4d9a2e598cf507b5af19fcb082b398fb84354fd1c8834b0c0c4247e239e5c789d615538935bd2b12ad57354d13fba84572d39c77959c69243
-  languageName: node
-  linkType: hard
-
-"@lerna/filter-options@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/filter-options@npm:5.5.1"
-  dependencies:
-    "@lerna/collect-updates": 5.5.1
-    "@lerna/filter-packages": 5.5.1
-    dedent: ^0.7.0
-    npmlog: ^6.0.2
-  checksum: cbf66924e6ab950c7824c7bcb85f034c3fa430180ee59081be426e644c80264d7dab7078ee3f8d044503b978e1f45f0211a28e61f382bb7639e7f4bfc481e0ad
-  languageName: node
-  linkType: hard
-
-"@lerna/filter-packages@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/filter-packages@npm:5.5.1"
-  dependencies:
-    "@lerna/validation-error": 5.5.1
-    multimatch: ^5.0.0
-    npmlog: ^6.0.2
-  checksum: be84dd416b9835c7195c1d5e53181fd945e72edca5375fdd0657539453d2283267f204e2ecab2e9e1dd13f3470e9f2361fc1d0f766dab7b3f775254df875de90
-  languageName: node
-  linkType: hard
-
-"@lerna/get-npm-exec-opts@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/get-npm-exec-opts@npm:5.5.1"
-  dependencies:
-    npmlog: ^6.0.2
-  checksum: 74ce72b2fdc93d7ed06cb98e3675e0fcfe38ef168f042ed14eac00ed5819a889f906d7847e4d905419351aa3ae2a345d8f2f9e151a8db6631e1c97f26c417115
-  languageName: node
-  linkType: hard
-
-"@lerna/get-packed@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/get-packed@npm:5.5.1"
-  dependencies:
-    fs-extra: ^9.1.0
-    ssri: ^9.0.1
-    tar: ^6.1.0
-  checksum: f8d1803c391447528837709a92c605272b22077d7232b0db3d1c02f2681caaf630572f4f7d58c06f8aaca0a106b30f1cab57fcfefcece944bce880fa9aae4f78
-  languageName: node
-  linkType: hard
-
-"@lerna/github-client@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/github-client@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
+    "@npmcli/run-script": ^4.2.1
     "@octokit/plugin-enterprise-rest": ^6.0.1
-    "@octokit/rest": ^19.0.3
-    git-url-parse: ^12.0.0
-    npmlog: ^6.0.2
-  checksum: 4be00f52ebf7b1417a4032325e9b1463db383c8649ea392d255ab787341129ab09b23481eebccb599cb0fec3539fb3d91a98465b99ba109e02433cb0e6286d70
-  languageName: node
-  linkType: hard
-
-"@lerna/gitlab-client@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/gitlab-client@npm:5.5.1"
-  dependencies:
-    node-fetch: ^2.6.1
-    npmlog: ^6.0.2
-  checksum: 7f803ffeba206e64254e1188732a335a0f8b5f6237a817824678c6fa7774398d0052ff7fd038372459d4a9cdb9cd53d136f483fdabe37160247e9fc335ec56a8
-  languageName: node
-  linkType: hard
-
-"@lerna/global-options@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/global-options@npm:5.5.1"
-  checksum: dda0e53b7e9af9425a6d1b3e03d23c270b5d5232ffe67288d54f641d5a8fcaaf29b7fdca4e35c20f114246ee3cc6ad06942798c27fd2d987c0bd41925a8d57b0
-  languageName: node
-  linkType: hard
-
-"@lerna/has-npm-version@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/has-npm-version@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    semver: ^7.3.4
-  checksum: 3fcc5b96a870f5c8c351d2fde1770c50a8127edfe6f2bc76bd9e5fb696acc9625a762401694d0dc0d4f259a800f91f5fc26c9ed4c02daa915247055aad7849b7
-  languageName: node
-  linkType: hard
-
-"@lerna/import@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/import@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/prompt": 5.5.1
-    "@lerna/pulse-till-done": 5.5.1
-    "@lerna/validation-error": 5.5.1
+    "@octokit/rest": ^19.0.4
+    async: ^3.2.4
+    chalk: ^4.1.2
+    clone-deep: ^4.0.1
+    config-chain: ^1.1.13
+    conventional-changelog-angular: ^5.0.13
+    conventional-changelog-core: ^4.2.4
+    conventional-changelog-writer: ^5.0.1
+    conventional-commits-parser: ^3.2.4
+    conventional-recommended-bump: ^6.1.0
+    cosmiconfig: ^7.0.1
     dedent: ^0.7.0
-    fs-extra: ^9.1.0
-    p-map-series: ^2.1.0
-  checksum: ee62a0d3c58a153930b11bc55b95769c29e3a7f4f5c87c80ff480d97606151916ed724b13b33b28c9091edb552d5226c94fdaad9bb0fa0d04d7f9312557477db
-  languageName: node
-  linkType: hard
-
-"@lerna/info@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/info@npm:5.5.1"
-  dependencies:
-    "@lerna/command": 5.5.1
-    "@lerna/output": 5.5.1
-    envinfo: ^7.7.4
-  checksum: 6a22f0d08033fa7a42ba2ba6cfd2806977110b194549bf3ccb122f4fdb653a88bc0c03bbdde5dc9c1f1b6775ceaa48faaa463a191a1fcf5a02086bc97defc71f
-  languageName: node
-  linkType: hard
-
-"@lerna/init@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/init@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/project": 5.5.1
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-    write-json-file: ^4.3.0
-  checksum: 42361e202cb4ce771f7b5dd956df114248299c2abdd8e12befa1a86242db48a562aa3a2f48e4248b24fe748818a506095fb983bfcc01a07bc27db28b92b3b8b1
-  languageName: node
-  linkType: hard
-
-"@lerna/link@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/link@npm:5.5.1"
-  dependencies:
-    "@lerna/command": 5.5.1
-    "@lerna/package-graph": 5.5.1
-    "@lerna/symlink-dependencies": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    p-map: ^4.0.0
-    slash: ^3.0.0
-  checksum: 7b4ebe516b5690db8b34accc50026ec369fe3e1c9ca2f43a02779f5b9e73ac0d49416161a6f3217378802b361538bf1b1b252e24b00c06422ec2c9f810379c3a
-  languageName: node
-  linkType: hard
-
-"@lerna/list@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/list@npm:5.5.1"
-  dependencies:
-    "@lerna/command": 5.5.1
-    "@lerna/filter-options": 5.5.1
-    "@lerna/listable": 5.5.1
-    "@lerna/output": 5.5.1
-  checksum: c75b040f3966e758f33432b9edabdbaf7f56d1a9dd6c02ea4004f5e0b441507d19b6d447cc34189445ba94d6adc077c8c7ac92b4d7e9bc4dc1d808e0a50424c7
-  languageName: node
-  linkType: hard
-
-"@lerna/listable@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/listable@npm:5.5.1"
-  dependencies:
-    "@lerna/query-graph": 5.5.1
-    chalk: ^4.1.0
-    columnify: ^1.6.0
-  checksum: c8b1305e987df91277a6173a6bb9d3f53e89aa760d0822cecce88fc70637554b497e2a86a21579dd93945d3d77fe2eec75ca3be5c7cd373e345523741d90a591
-  languageName: node
-  linkType: hard
-
-"@lerna/log-packed@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/log-packed@npm:5.5.1"
-  dependencies:
-    byte-size: ^7.0.0
-    columnify: ^1.6.0
-    has-unicode: ^2.0.1
-    npmlog: ^6.0.2
-  checksum: 64ea67001d96533bfcea82ce92a2a888cb6df9194c044df6e14bd4608a66944f318a7a8ac1b445f635019d1f4f9f90ffa82ba8ea64e56b938fb0b1de9f8aa090
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-conf@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/npm-conf@npm:5.5.1"
-  dependencies:
-    config-chain: ^1.1.12
-    pify: ^5.0.0
-  checksum: 1a2891f71c2008bb31a66bbd133d87612de587108e86fbbab818e2890bc60188f729bda7a2b415e9566ca41985f111219f78b13c44b50176a9dfc45ab1be0ab4
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-dist-tag@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/npm-dist-tag@npm:5.5.1"
-  dependencies:
-    "@lerna/otplease": 5.5.1
-    npm-package-arg: 8.1.1
-    npm-registry-fetch: ^13.3.0
-    npmlog: ^6.0.2
-  checksum: 6fca7f59fe15176646b53678bde3d87ca36444d1fa73caffc669ed22368b2225ea2f07b60bd3418428b613109457df862b95b7dc5e0a7cd4f22710ad653cf976
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-install@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/npm-install@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/get-npm-exec-opts": 5.5.1
-    fs-extra: ^9.1.0
-    npm-package-arg: 8.1.1
-    npmlog: ^6.0.2
-    signal-exit: ^3.0.3
-    write-pkg: ^4.0.0
-  checksum: fd2beac2c9b770bc773d5dd7e658b95810447e0048346f92448bfad7feadcb27490111513f1a438628f5b0c794d7465b44f13f3a87775f34bf39477aaa416886
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-publish@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/npm-publish@npm:5.5.1"
-  dependencies:
-    "@lerna/otplease": 5.5.1
-    "@lerna/run-lifecycle": 5.5.1
-    fs-extra: ^9.1.0
-    libnpmpublish: ^6.0.4
-    npm-package-arg: 8.1.1
-    npmlog: ^6.0.2
-    pify: ^5.0.0
-    read-package-json: ^5.0.1
-  checksum: 9395eb2af134532be9887a956440ddaf43d25c670b681e0f82fefc6690be75ac655f5afd7deffffcff9916275a11d6145eaa72315719f2ef2734f678365368a1
-  languageName: node
-  linkType: hard
-
-"@lerna/npm-run-script@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/npm-run-script@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    "@lerna/get-npm-exec-opts": 5.5.1
-    npmlog: ^6.0.2
-  checksum: 25ca80c2eb708fca0f1847a96792be641fb6e2bef39849166edd46bc16e0d8a72c8173162ac891ede73427f28813195ea216cc85bd3103d28349613372e4ca70
-  languageName: node
-  linkType: hard
-
-"@lerna/otplease@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/otplease@npm:5.5.1"
-  dependencies:
-    "@lerna/prompt": 5.5.1
-  checksum: 32fb629e4eacba6ddb06ab14473a83b256f0fa5ed6e1f7adeb8c76f75ea2c944cf9c76d215fcce621508dea0d64d99149847099634315afb9547c4491a4d5d96
-  languageName: node
-  linkType: hard
-
-"@lerna/output@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/output@npm:5.5.1"
-  dependencies:
-    npmlog: ^6.0.2
-  checksum: 159f0abf790fc885891018cd6ea0588c0666e9629ca93fcfb5c8d5083cdf3ada202a3fce2930b70818a2087f33fee07e3c930c068d4cefc1d0181bbc4ca7030c
-  languageName: node
-  linkType: hard
-
-"@lerna/pack-directory@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/pack-directory@npm:5.5.1"
-  dependencies:
-    "@lerna/get-packed": 5.5.1
-    "@lerna/package": 5.5.1
-    "@lerna/run-lifecycle": 5.5.1
-    "@lerna/temp-write": 5.5.1
-    npm-packlist: ^5.1.1
-    npmlog: ^6.0.2
-    tar: ^6.1.0
-  checksum: 43b239cf494572d42076da784704642faae4bec4a0d9a25f4e689ce60e6e81341e9e79140ebc8879b0759ef1ccde4e2e68a487a16e5aa4cf945b9716251324e5
-  languageName: node
-  linkType: hard
-
-"@lerna/package-graph@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/package-graph@npm:5.5.1"
-  dependencies:
-    "@lerna/prerelease-id-from-version": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    npm-package-arg: 8.1.1
-    npmlog: ^6.0.2
-    semver: ^7.3.4
-  checksum: 8be31873eda828a067baaeaaede413020bbe65647eb933743306b9a5ee0e0959a2e99faf81f9189ce994ea3fdce199642da30ddc7976dd30e8a5cc205266fd76
-  languageName: node
-  linkType: hard
-
-"@lerna/package@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/package@npm:5.5.1"
-  dependencies:
-    load-json-file: ^6.2.0
-    npm-package-arg: 8.1.1
-    write-pkg: ^4.0.0
-  checksum: 7d123fd8ef4a53fed312df0d4efaae7d953a9b0f7464f0dda5e2d1c1541799c8490cad1a0637041a6e73db4105d5f07f703e513145f443c38d2a9d2a39b5c68e
-  languageName: node
-  linkType: hard
-
-"@lerna/prerelease-id-from-version@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/prerelease-id-from-version@npm:5.5.1"
-  dependencies:
-    semver: ^7.3.4
-  checksum: e67abce9054fd4efd8ab9c93ad4ef53444f7053f3747fbeb549dc738da940893bd32f521ac81bfa23afe164e513958dae19b4618e3349e08e920d8e942886cf8
-  languageName: node
-  linkType: hard
-
-"@lerna/profiler@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/profiler@npm:5.5.1"
-  dependencies:
-    fs-extra: ^9.1.0
-    npmlog: ^6.0.2
-    upath: ^2.0.1
-  checksum: 90c50ebbfe01eaf9faf5dc3c7ce1778c1a1739cd187edc06ee6be570bd6b48c9a87a8f95962198e0476bf64d21f5791fe59321a24331a872eb43eb9d9d473a11
-  languageName: node
-  linkType: hard
-
-"@lerna/project@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/project@npm:5.5.1"
-  dependencies:
-    "@lerna/package": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    cosmiconfig: ^7.0.0
-    dedent: ^0.7.0
-    dot-prop: ^6.0.1
-    glob-parent: ^5.1.1
-    globby: ^11.0.2
-    js-yaml: ^4.1.0
-    load-json-file: ^6.2.0
-    npmlog: ^6.0.2
-    p-map: ^4.0.0
-    resolve-from: ^5.0.0
-    write-json-file: ^4.3.0
-  checksum: 2a7ad3a8c60efacdc1e4949a7daeb9f97b458cef64c47a61677cb9b2e87844e3816f73bf344e51535f000eefcfbea592718c928e17a4ca5d7788ea3e64cb764b
-  languageName: node
-  linkType: hard
-
-"@lerna/prompt@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/prompt@npm:5.5.1"
-  dependencies:
+    execa: ^5.1.1
+    fs-extra: ^10.1.0
+    get-stream: ^6.0.1
+    git-url-parse: ^13.1.0
+    glob-parent: ^6.0.2
+    globby: ^11.1.0
+    graceful-fs: ^4.2.10
     inquirer: ^8.2.4
+    is-ci: ^3.0.1
+    is-stream: ^2.0.1
+    libnpmaccess: ^6.0.4
+    libnpmpublish: ^6.0.5
+    load-json-file: ^6.2.0
+    make-dir: ^3.1.0
+    minimatch: ^5.1.0
+    node-fetch: ^2.6.7
+    npm-package-arg: ^9.1.0
+    npm-packlist: ^5.1.3
+    npm-registry-fetch: ^13.3.1
     npmlog: ^6.0.2
-  checksum: 0ad61187431218551cb2e0ecd4826a270f78baac56817bba145787a386923dc22824ab1584c5598020f322fc619d55a1e65a81d5e340af560c83a89fd1225a58
-  languageName: node
-  linkType: hard
-
-"@lerna/publish@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/publish@npm:5.5.1"
-  dependencies:
-    "@lerna/check-working-tree": 5.5.1
-    "@lerna/child-process": 5.5.1
-    "@lerna/collect-updates": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/describe-ref": 5.5.1
-    "@lerna/log-packed": 5.5.1
-    "@lerna/npm-conf": 5.5.1
-    "@lerna/npm-dist-tag": 5.5.1
-    "@lerna/npm-publish": 5.5.1
-    "@lerna/otplease": 5.5.1
-    "@lerna/output": 5.5.1
-    "@lerna/pack-directory": 5.5.1
-    "@lerna/prerelease-id-from-version": 5.5.1
-    "@lerna/prompt": 5.5.1
-    "@lerna/pulse-till-done": 5.5.1
-    "@lerna/run-lifecycle": 5.5.1
-    "@lerna/run-topologically": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    "@lerna/version": 5.5.1
-    fs-extra: ^9.1.0
-    libnpmaccess: ^6.0.3
-    npm-package-arg: 8.1.1
-    npm-registry-fetch: ^13.3.0
-    npmlog: ^6.0.2
+    os: ^0.1.2
     p-map: ^4.0.0
     p-pipe: ^3.1.0
-    pacote: ^13.6.1
-    semver: ^7.3.4
-  checksum: b6e785497d2bc4014a3a692ef795d0390c34806e5b6b8019693f35621d07429d441b49168a42bbdc297df1e02f7c27e03907b4b0c4e7456680f3b3851635089b
-  languageName: node
-  linkType: hard
-
-"@lerna/pulse-till-done@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/pulse-till-done@npm:5.5.1"
-  dependencies:
-    npmlog: ^6.0.2
-  checksum: efd2dd8036bb1750417ac438d75512f7554a2b04e3a411e2646cd20749024c89d8e8ca6e1d5955777f3d0cd459fed4eb73893be8e3347d57e23c74ed52481c6d
-  languageName: node
-  linkType: hard
-
-"@lerna/query-graph@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/query-graph@npm:5.5.1"
-  dependencies:
-    "@lerna/package-graph": 5.5.1
-  checksum: b8d2443ca392e357fd9e13948408692f4f5b80231187e4231c9ba2aeb6fd8ac9704494854ad856bcdf3de715bb0ef8917da2e8806e4e1d91f4dd8ebdf85bb767
-  languageName: node
-  linkType: hard
-
-"@lerna/resolve-symlink@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/resolve-symlink@npm:5.5.1"
-  dependencies:
-    fs-extra: ^9.1.0
-    npmlog: ^6.0.2
-    read-cmd-shim: ^3.0.0
-  checksum: 63453f484927b739935c7b4cef0af8009800cc907a9801e1777d436e26eb08808dddca93c2bdfba64e933e80553c3c813e7c838f91269eea71c12ffc11e1630b
-  languageName: node
-  linkType: hard
-
-"@lerna/rimraf-dir@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/rimraf-dir@npm:5.5.1"
-  dependencies:
-    "@lerna/child-process": 5.5.1
-    npmlog: ^6.0.2
-    path-exists: ^4.0.0
-    rimraf: ^3.0.2
-  checksum: 1dec92e74d8d14bc2be81cec5fa837269a47c7c7c9342b564aeea7d322e1ca30b3bbe36dafd55a7a33d70b73764b934b5181670effe94670332343ee2b122bdf
-  languageName: node
-  linkType: hard
-
-"@lerna/run-lifecycle@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/run-lifecycle@npm:5.5.1"
-  dependencies:
-    "@lerna/npm-conf": 5.5.1
-    "@npmcli/run-script": ^4.1.7
-    npmlog: ^6.0.2
     p-queue: ^6.6.2
-  checksum: f37f44de09d797c8372895567c03f450e56bf86a88efddb644a5beee5c91a6ab3f23f9418153fc3d4a06780d2f1d51f0e50830f1b5fb93f032409b8404010219
-  languageName: node
-  linkType: hard
-
-"@lerna/run-topologically@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/run-topologically@npm:5.5.1"
-  dependencies:
-    "@lerna/query-graph": 5.5.1
-    p-queue: ^6.6.2
-  checksum: 93d79c8c5f541c599d3d15e96ebc30bae931ab30d42148ceaa83b044fa9fb422fc3ee4a1237545d6f0c01a8d8b5dd4faf436d522118910ecd8210509ffb784ae
-  languageName: node
-  linkType: hard
-
-"@lerna/run@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/run@npm:5.5.1"
-  dependencies:
-    "@lerna/command": 5.5.1
-    "@lerna/filter-options": 5.5.1
-    "@lerna/npm-run-script": 5.5.1
-    "@lerna/output": 5.5.1
-    "@lerna/profiler": 5.5.1
-    "@lerna/run-topologically": 5.5.1
-    "@lerna/timer": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    p-map: ^4.0.0
-  checksum: 95277368b02248bc88d28e931b89924f5c469cf153225111ef41e03ae465e23dcad1b9a9dffd2036d441be12b9b727a7c2aef79886175694ae3918e984bd92f8
-  languageName: node
-  linkType: hard
-
-"@lerna/symlink-binary@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/symlink-binary@npm:5.5.1"
-  dependencies:
-    "@lerna/create-symlink": 5.5.1
-    "@lerna/package": 5.5.1
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-  checksum: 563da703f55aba863e5e5d40e75acd5cf55403ec115e1b1d9f3301d8e872878e4616ede21fd4aeb2dcea6455a6ba492bd1cd16fb47e1e0dd5ec93312b1843995
-  languageName: node
-  linkType: hard
-
-"@lerna/symlink-dependencies@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/symlink-dependencies@npm:5.5.1"
-  dependencies:
-    "@lerna/create-symlink": 5.5.1
-    "@lerna/resolve-symlink": 5.5.1
-    "@lerna/symlink-binary": 5.5.1
-    fs-extra: ^9.1.0
-    p-map: ^4.0.0
-    p-map-series: ^2.1.0
-  checksum: 95c655fc964859450639398f664c7780f0bae16a4fd6167ff054d8b8e1414fa1fd786c65560fa4116a57bd27c567b61b710365f01d20fa8790faae8ab5e81270
-  languageName: node
-  linkType: hard
-
-"@lerna/temp-write@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/temp-write@npm:5.5.1"
-  dependencies:
-    graceful-fs: ^4.1.15
-    is-stream: ^2.0.0
-    make-dir: ^3.0.0
+    p-reduce: ^2.1.0
+    pacote: ^13.6.2
+    path: ^0.12.7
+    pify: ^5.0.0
+    resolve-from: ^5.0.0
+    semver: ^7.3.7
+    slash: ^3.0.0
+    ssri: ^9.0.1
+    strong-log-transformer: ^2.1.0
+    tar: ^6.1.11
     temp-dir: ^1.0.0
-    uuid: ^8.3.2
-  checksum: d86e932360aff3f591e5564af4ee08eca1cbd0790f7cd6c1ffc90ac0d3f227dc44465e1f65ccada1e2a720edc21406c19b911a2a7e6ba2a26ae05e87fcaf1752
+    uuid: ^9.0.0
+    write-file-atomic: ^4.0.2
+    write-json-file: ^4.3.0
+    write-pkg: ^4.0.0
+    yargs: ^17.5.1
+  checksum: 33ec8f1f8ed0ce5ccefb61326f198323025dc75a9c6e928481fa2a2d2648e49c59df382a0d3a4edd4e7ae58a7c01262b639ff46ace83d1eddad0eaf2ae4b45f6
   languageName: node
   linkType: hard
 
-"@lerna/timer@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/timer@npm:5.5.1"
-  checksum: f0416d02b865a87ef74bdcde0dc4bb8fb4e0e751ebc73a86ae0851f778b8b091976408fa2f3517c241a53cda7d921030ecdc09c93d409b753ffe1e834d8fbc45
-  languageName: node
-  linkType: hard
-
-"@lerna/validation-error@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/validation-error@npm:5.5.1"
+"@lerna-lite/info@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/info@npm:1.11.3"
   dependencies:
+    "@lerna-lite/core": 1.11.3
+    dedent: ^0.7.0
+    envinfo: ^7.8.1
+    yargs: ^17.5.1
+  checksum: 2a96f5ec5946cc3b8707700fe1d361450f94576955afec4a04d1249ed059c35cfb3eb8560787b1e7f285c9fb73a067516f2fd21a632a8badd474b7ebcffcc0be
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/init@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/init@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    fs-extra: ^10.1.0
+    p-map: ^4.0.0
+    write-json-file: ^4.3.0
+  checksum: cb263f198e42f873141489bd30d967bfcf5b7bd4713e521872eb12a2528482746938c2e9a86ca18f47aa85e4ff46e5f4636664ed820bced14e11df400f8ec542
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/list@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/list@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    "@lerna-lite/listable": 1.11.3
+    "@lerna-lite/optional-cmd-common": 1.11.3
+  checksum: f9d0b0fba6f244b5cb328dafe816d512398048f87f555e37df24f60d5ff50055791e249ef47e0a10a0708be79cfbd662ae6c0c3c955062c6f9db584357e5fdcf
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/listable@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/listable@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    chalk: ^4.1.2
+    columnify: ^1.6.0
+  checksum: a198d8c9873d2f2774cd92ee6f6383843913d98c51f66a3fc1c3bdd666dfefe2f7cdfcee2ee145cc955c2885932efd22ac04f03cf968f57e0d698f7bfa2ba405
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/optional-cmd-common@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/optional-cmd-common@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    fs-extra: ^10.1.0
+    multimatch: ^5.0.0
     npmlog: ^6.0.2
-  checksum: ef648c28b0ede8cbd3bb06ec7d8f76bf06ffd56a3a6502a93458ffdf9891c414720c8fa1d0aa9ad468e66b88c402c59ec2f256d354657f5a48d84fbab0e94fe7
+    p-map: ^4.0.0
+    upath: ^2.0.1
+    yargs: ^17.5.1
+  checksum: d283f0778629232ba2085cb4b3d584a39a19f5e54c1fb8320bea5f45059b95651c9a3018a765ad73d1571d4b72b74510bf741ccbc7cde691823aa69b51b945d8
   languageName: node
   linkType: hard
 
-"@lerna/version@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/version@npm:5.5.1"
+"@lerna-lite/publish@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/publish@npm:1.11.3"
   dependencies:
-    "@lerna/check-working-tree": 5.5.1
-    "@lerna/child-process": 5.5.1
-    "@lerna/collect-updates": 5.5.1
-    "@lerna/command": 5.5.1
-    "@lerna/conventional-commits": 5.5.1
-    "@lerna/github-client": 5.5.1
-    "@lerna/gitlab-client": 5.5.1
-    "@lerna/output": 5.5.1
-    "@lerna/prerelease-id-from-version": 5.5.1
-    "@lerna/prompt": 5.5.1
-    "@lerna/run-lifecycle": 5.5.1
-    "@lerna/run-topologically": 5.5.1
-    "@lerna/temp-write": 5.5.1
-    "@lerna/validation-error": 5.5.1
-    chalk: ^4.1.0
+    "@lerna-lite/core": 1.11.3
+    "@lerna-lite/version": 1.11.3
+    byte-size: ^7.0.1
+    columnify: ^1.6.0
+    fs-extra: ^10.1.0
+    has-unicode: ^2.0.1
+    libnpmaccess: ^6.0.4
+    libnpmpublish: ^6.0.5
+    npm-package-arg: ^9.1.0
+    npm-packlist: ^5.1.3
+    npm-registry-fetch: ^13.3.1
+    npmlog: ^6.0.2
+    os: ^0.1.2
+    p-map: ^4.0.0
+    p-pipe: ^3.1.0
+    pacote: ^13.6.2
+    path: ^0.12.7
+    pify: ^5.0.0
+    read-package-json: ^5.0.2
+    resolve-from: ^5.0.0
+    semver: ^7.3.7
+    slash: ^3.0.0
+    ssri: ^9.0.1
+    strong-log-transformer: ^2.1.0
+    tar: ^6.1.11
+    write-file-atomic: ^4.0.2
+    write-json-file: ^4.3.0
+    write-pkg: ^4.0.0
+    yargs: ^17.5.1
+  checksum: 9b0a6344dcc517a8b31eead42b8e6fa461cf2098db2a78b04edb84d1295d44b51486c7b773f47b777488783116f18cebddfce91211d2d3f84399120dae3dc230
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/run@npm:^1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/run@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    "@lerna-lite/optional-cmd-common": 1.11.3
+    fs-extra: ^10.1.0
+    multimatch: ^5.0.0
+    npmlog: ^6.0.2
+    p-map: ^4.0.0
+    upath: ^2.0.1
+    yargs: ^17.5.1
+  checksum: 17000c0b41a50e4de294479334f36b7f65dca8bc06e7db3eeba8e7abf74b219f06c9d65f8ad0166375e68e285968c6dbd0664d3d8a0fd88bfee9b9b1064c9e2e
+  languageName: node
+  linkType: hard
+
+"@lerna-lite/version@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@lerna-lite/version@npm:1.11.3"
+  dependencies:
+    "@lerna-lite/core": 1.11.3
+    chalk: ^4.1.2
     dedent: ^0.7.0
     load-json-file: ^6.2.0
-    minimatch: ^3.0.4
+    minimatch: ^5.1.0
     npmlog: ^6.0.2
+    os: ^0.1.2
     p-map: ^4.0.0
     p-pipe: ^3.1.0
     p-reduce: ^2.1.0
-    p-waterfall: ^2.1.1
-    semver: ^7.3.4
+    path: ^0.12.7
+    semver: ^7.3.7
     slash: ^3.0.0
     write-json-file: ^4.3.0
-  checksum: 4e9c1d3f709de6dbafa088076b82861774f357a68af22999285047bc1759bf71633366694b2e3178fc88069b00877e6450b5bf012cf8d8d080d858ba2b972e8b
-  languageName: node
-  linkType: hard
-
-"@lerna/write-log-file@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@lerna/write-log-file@npm:5.5.1"
-  dependencies:
-    npmlog: ^6.0.2
-    write-file-atomic: ^4.0.1
-  checksum: 618b8350d436e1bcca1b040562ca5d7784dbacdb0b73c4eb5bb829a2cbe02cb7260516179f7b3af472385daa43e906a9e5866d21aea10911acec14ac90089106
+    yargs: ^17.5.1
+  checksum: 272e72d6e1156671500218809203da724e1ab82f9b1d978cb683e93b0312f548ad7f5d69ba652a61a6eb1d747d99522a0271515e1f39e5109fbfd7e8537d973a
   languageName: node
   linkType: hard
 
@@ -4236,50 +3659,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/arborist@npm:5.3.0":
-  version: 5.3.0
-  resolution: "@npmcli/arborist@npm:5.3.0"
-  dependencies:
-    "@isaacs/string-locale-compare": ^1.1.0
-    "@npmcli/installed-package-contents": ^1.0.7
-    "@npmcli/map-workspaces": ^2.0.3
-    "@npmcli/metavuln-calculator": ^3.0.1
-    "@npmcli/move-file": ^2.0.0
-    "@npmcli/name-from-folder": ^1.0.1
-    "@npmcli/node-gyp": ^2.0.0
-    "@npmcli/package-json": ^2.0.0
-    "@npmcli/run-script": ^4.1.3
-    bin-links: ^3.0.0
-    cacache: ^16.0.6
-    common-ancestor-path: ^1.0.1
-    json-parse-even-better-errors: ^2.3.1
-    json-stringify-nice: ^1.1.4
-    mkdirp: ^1.0.4
-    mkdirp-infer-owner: ^2.0.0
-    nopt: ^5.0.0
-    npm-install-checks: ^5.0.0
-    npm-package-arg: ^9.0.0
-    npm-pick-manifest: ^7.0.0
-    npm-registry-fetch: ^13.0.0
-    npmlog: ^6.0.2
-    pacote: ^13.6.1
-    parse-conflict-json: ^2.0.1
-    proc-log: ^2.0.0
-    promise-all-reject-late: ^1.0.0
-    promise-call-limit: ^1.0.1
-    read-package-json-fast: ^2.0.2
-    readdir-scoped-modules: ^1.1.0
-    rimraf: ^3.0.2
-    semver: ^7.3.7
-    ssri: ^9.0.0
-    treeverse: ^2.0.0
-    walk-up-path: ^1.0.0
-  bin:
-    arborist: bin/index.js
-  checksum: 7f99f451ba625dd3532e7a69b27cc399cab1e7ef2a069bbc04cf22ef9d16a0076f8f5fb92c4cd146c256cd8a41963b2e417684f063a108e96939c440bad0e95e
-  languageName: node
-  linkType: hard
-
 "@npmcli/fs@npm:^2.1.0":
   version: 2.1.2
   resolution: "@npmcli/fs@npm:2.1.2"
@@ -4319,30 +3698,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/map-workspaces@npm:^2.0.3":
-  version: 2.0.4
-  resolution: "@npmcli/map-workspaces@npm:2.0.4"
-  dependencies:
-    "@npmcli/name-from-folder": ^1.0.1
-    glob: ^8.0.1
-    minimatch: ^5.0.1
-    read-package-json-fast: ^2.0.3
-  checksum: cc8d662ac5115ad9822742a11e11d2d32eda74214bd0f4efec30c9cd833975b5b4c8409fe54ddbb451b040b17a943f770976506cba0f26cfccd58d99b5880d6f
-  languageName: node
-  linkType: hard
-
-"@npmcli/metavuln-calculator@npm:^3.0.1":
-  version: 3.1.1
-  resolution: "@npmcli/metavuln-calculator@npm:3.1.1"
-  dependencies:
-    cacache: ^16.0.0
-    json-parse-even-better-errors: ^2.3.1
-    pacote: ^13.0.3
-    semver: ^7.3.5
-  checksum: dc9846fdb82a1f4274ff8943f81452c75615bd9bca523c862956ea2c32e18c5a4be5572e169104d3a0eb262b7ede72c8dbbc202a4ab3b3f4946fa55f226dcc64
-  languageName: node
-  linkType: hard
-
 "@npmcli/move-file@npm:^1.0.1":
   version: 1.0.1
   resolution: "@npmcli/move-file@npm:1.0.1"
@@ -4362,26 +3717,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/name-from-folder@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@npmcli/name-from-folder@npm:1.0.1"
-  checksum: 67339f4096e32b712d2df0250cc95c087569f09e657d7f81a1760fa2cc5123e29c3c3e1524388832310ba2d96ec4679985b643b44627f6a51f4a00c3b0075de9
-  languageName: node
-  linkType: hard
-
 "@npmcli/node-gyp@npm:^2.0.0":
   version: 2.0.0
   resolution: "@npmcli/node-gyp@npm:2.0.0"
   checksum: b6bbf0015000f9b64d31aefdc30f244b0348c57adb64017667e0304e96c38644d83da46a4581252652f5d606268df49118f9c9993b41d8020f62b7b15dd2c8d8
-  languageName: node
-  linkType: hard
-
-"@npmcli/package-json@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@npmcli/package-json@npm:2.0.0"
-  dependencies:
-    json-parse-even-better-errors: ^2.3.1
-  checksum: 7a598e42d2778654ec87438ebfafbcbafbe5a5f5e89ed2ca1db6ca3f94ef14655e304aa41f77632a2a3f5c66b6bd5960bd9370e0ceb4902ea09346720364f9e4
   languageName: node
   linkType: hard
 
@@ -4394,7 +3733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/run-script@npm:^4.1.0, @npmcli/run-script@npm:^4.1.3, @npmcli/run-script@npm:^4.1.7":
+"@npmcli/run-script@npm:^4.1.0, @npmcli/run-script@npm:^4.2.1":
   version: 4.2.1
   resolution: "@npmcli/run-script@npm:4.2.1"
   dependencies:
@@ -4404,26 +3743,6 @@ __metadata:
     read-package-json-fast: ^2.0.3
     which: ^2.0.2
   checksum: 7b8d6676353f157e68b26baf848e01e5d887bcf90ce81a52f23fc9a5d93e6ffb60057532d664cfd7aeeb76d464d0c8b0d314ee6cccb56943acb3b6c570b756c8
-  languageName: node
-  linkType: hard
-
-"@nrwl/cli@npm:14.7.6":
-  version: 14.7.6
-  resolution: "@nrwl/cli@npm:14.7.6"
-  dependencies:
-    nx: 14.7.6
-  checksum: fd51a4e57c7bce0c803163aed4cbdcb24ce67bc7c4c118e39b8c86bba8f4f9bfad9e1425a3bd90a7221337871946e7e0e285973845ace764711e371d37a0e8dd
-  languageName: node
-  linkType: hard
-
-"@nrwl/tao@npm:14.7.6":
-  version: 14.7.6
-  resolution: "@nrwl/tao@npm:14.7.6"
-  dependencies:
-    nx: 14.7.6
-  bin:
-    tao: index.js
-  checksum: a94ad95829f5803c86aa2d6339ca6fb9fe39b98e180e65d55b184a36776cef5bc11e392f34810ba8df276ae2eec9194172960630c0cc2a8224ced014cd3f5cf8
   languageName: node
   linkType: hard
 
@@ -4544,7 +3863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/rest@npm:^19.0.3":
+"@octokit/rest@npm:^19.0.4":
   version: 19.0.4
   resolution: "@octokit/rest@npm:19.0.4"
   dependencies:
@@ -4569,17 +3888,6 @@ __metadata:
   version: 0.4.7
   resolution: "@open-wc/webpack-import-meta-loader@npm:0.4.7"
   checksum: 25ba5a12eb191d11e4a21db26dabf4956aa50cc7fe42c5308eda75b2d8211937d97b5de490994108b56afca49110c53802fb008bd3efcd462c0c12bbe3b1c0dc
-  languageName: node
-  linkType: hard
-
-"@parcel/watcher@npm:2.0.4":
-  version: 2.0.4
-  resolution: "@parcel/watcher@npm:2.0.4"
-  dependencies:
-    node-addon-api: ^3.2.1
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 890bdc69a52942791b276caa2cd65ef816576d6b5ada91aa28cf302b35d567c801dafe167f2525dcb313f5b420986ea11bd56228dd7ddde1116944d8f924a0a1
   languageName: node
   linkType: hard
 
@@ -5314,16 +4622,16 @@ __metadata:
   linkType: hard
 
 "@types/minimatch@npm:^3.0.3":
-  version: 3.0.4
-  resolution: "@types/minimatch@npm:3.0.4"
-  checksum: 583a174116b56f405e8f45680fd06ee674442543cd875b8570a046bd2695fdcfb84ffd8b7ef4c84e11e2ba0fe7e467fc6fd95e134d389ebcefc2ddefd01ea9c8
+  version: 3.0.5
+  resolution: "@types/minimatch@npm:3.0.5"
+  checksum: c41d136f67231c3131cf1d4ca0b06687f4a322918a3a5adddc87ce90ed9dbd175a3610adee36b106ae68c0b92c637c35e02b58c8a56c424f71d30993ea220b92
   languageName: node
   linkType: hard
 
 "@types/minimist@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "@types/minimist@npm:1.2.1"
-  checksum: 02631cdd79d346ed6838f5443767b5218a0d915fd0529d4a8840c4eba942d7f6906f0056686dd5a119d42528bed0bee5767ebef7667fdca6fcb95411bb56084e
+  version: 1.2.2
+  resolution: "@types/minimist@npm:1.2.2"
+  checksum: b8da83c66eb4aac0440e64674b19564d9d86c80ae273144db9681e5eeff66f238ade9515f5006ffbfa955ceff8b89ad2bd8ec577d7caee74ba101431fb07045d
   languageName: node
   linkType: hard
 
@@ -6424,7 +5732,7 @@ __metadata:
     "@wireapp/protocol-messaging": 1.38.0
     "@wireapp/store-engine-dexie": "workspace:^"
     axios: ^0.27.2
-    bazinga64: 5.10.0
+    bazinga64: 5.11.0
     commander: 8.0.0
     cross-env: 7.0.3
     dotenv-defaults: 2.0.2
@@ -6613,7 +5921,7 @@ __metadata:
     "@types/webpack-env": 1.16.2
     babel-jest: 27.0.6
     babel-loader: 8.2.2
-    bazinga64: 5.10.0
+    bazinga64: 5.11.0
     color: 3.1.3
     emotion-normalize: 11.0.1
     jest: 29.0.3
@@ -6723,7 +6031,7 @@ __metadata:
     "@wireapp/store-engine": "workspace:^"
     "@wireapp/websql": 0.0.17
     babel-loader: 8.2.2
-    bazinga64: 5.10.0
+    bazinga64: 5.11.0
     jasmine: 3.8.0
     karma: 6.4.1
     karma-chrome-launcher: 3.1.1
@@ -7329,13 +6637,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "argparse@npm:2.0.1"
-  checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
-  languageName: node
-  linkType: hard
-
 "aria-query@npm:^5.0.0":
   version: 5.0.0
   resolution: "aria-query@npm:5.0.0"
@@ -7604,6 +6905,13 @@ __metadata:
   version: 3.1.0
   resolution: "async@npm:3.1.0"
   checksum: 2602938fbd317c7311807934ab49e3f26ef88d71d2c19f7bbd84bcaadd4c98f564c57caa6b4a4563527ffc6929b0be8142cca7240def8bf4e946bce376d2cade
+  languageName: node
+  linkType: hard
+
+"async@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "async@npm:3.2.4"
+  checksum: 43d07459a4e1d09b84a20772414aa684ff4de085cbcaec6eea3c7a8f8150e8c62aa6cd4e699fe8ee93c3a5b324e777d34642531875a0817a35697522c1b02e89
   languageName: node
   linkType: hard
 
@@ -8080,7 +7388,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bazinga64@5.10.0, bazinga64@workspace:packages/bazinga64":
+"bazinga64@5.11.0, bazinga64@workspace:packages/bazinga64":
   version: 0.0.0-use.local
   resolution: "bazinga64@workspace:packages/bazinga64"
   dependencies:
@@ -8097,10 +7405,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"bazinga64@npm:5.10.0":
+  version: 5.10.0
+  resolution: "bazinga64@npm:5.10.0"
+  checksum: 26444dfd5e6abdb62ab7b6fd7fb7155651e5fd0884a30008b33693593c5838b4f5d213101751c55a6646e146d802f0783aa2b92d41f2165f1cd30568c6f6ac75
+  languageName: node
+  linkType: hard
+
 "before-after-hook@npm:^2.2.0":
-  version: 2.2.1
-  resolution: "before-after-hook@npm:2.2.1"
-  checksum: 2562bdcc2e4e53365fb97674410580c40b73db0c0137def18af93332ef4dd16db150c0670d0d986328cb8b0b05f4f58906895ba406ece294817f28540e19aba5
+  version: 2.2.2
+  resolution: "before-after-hook@npm:2.2.2"
+  checksum: dc2e1ffe389e5afbef2a46790b1b5a50247ed57aba67649cfa9ec2552d248cc9278f222e72fb5a8ff59bbb39d78fbaa97e7234ead0c6b5e8418b67a8644ce207
   languageName: node
   linkType: hard
 
@@ -8108,20 +7423,6 @@ __metadata:
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
   checksum: b89b6e8419b097a8fb4ed2399a1931a68c612bce3cfd5ca8c214b2d017531191070f990598de2fc6f3f993d91c0f08aa82697717f6b3b8732c9731866d233c9e
-  languageName: node
-  linkType: hard
-
-"bin-links@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "bin-links@npm:3.0.3"
-  dependencies:
-    cmd-shim: ^5.0.0
-    mkdirp-infer-owner: ^2.0.0
-    npm-normalize-package-bin: ^2.0.0
-    read-cmd-shim: ^3.0.0
-    rimraf: ^3.0.0
-    write-file-atomic: ^4.0.0
-  checksum: ea2dc6f91a6ef8b3840ceb48530bbeb8d6d1c6f7985fe1409b16d7e7db39432f0cb5ce15cc2788bb86d989abad6e2c7fba3500996a210a682eec18fb26a66e72
   languageName: node
   linkType: hard
 
@@ -8139,7 +7440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.0.3, bl@npm:^4.1.0":
+"bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -8583,13 +7884,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builtins@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "builtins@npm:1.0.3"
-  checksum: 47ce94f7eee0e644969da1f1a28e5f29bd2e48b25b2bbb61164c345881086e29464ccb1fb88dbc155ea26e8b1f5fc8a923b26c8c1ed0935b67b644d410674513
-  languageName: node
-  linkType: hard
-
 "builtins@npm:^5.0.0":
   version: 5.0.1
   resolution: "builtins@npm:5.0.1"
@@ -8599,7 +7893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"byte-size@npm:^7.0.0":
+"byte-size@npm:^7.0.1":
   version: 7.0.1
   resolution: "byte-size@npm:7.0.1"
   checksum: 6791663a6d53bf950e896f119d3648fe8d7e8ae677e2ccdae84d0e5b78f21126e25f9d73aa19be2a297cb27abd36b6f5c361c0de36ebb2f3eb8a853f2ac99a4a
@@ -8668,7 +7962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^16.0.0, cacache@npm:^16.0.6, cacache@npm:^16.1.0":
+"cacache@npm:^16.0.0, cacache@npm:^16.1.0":
   version: 16.1.3
   resolution: "cacache@npm:16.1.3"
   dependencies:
@@ -8797,16 +8091,6 @@ __metadata:
   version: 1.0.1
   resolution: "capture-stack-trace@npm:1.0.1"
   checksum: 493668211de1307009589aeba5c382dc8b1011a41ca02f033b5f5a489ee174323a4b31d5afdc4bd48f64e1dd23b2521ddda4dbdcd382767e140f94b555f8f332
-  languageName: node
-  linkType: hard
-
-"chalk@npm:4.1.0":
-  version: 4.1.0
-  resolution: "chalk@npm:4.1.0"
-  dependencies:
-    ansi-styles: ^4.1.0
-    supports-color: ^7.1.0
-  checksum: 5561c7b4c063badee3e16d04bce50bd033e1be1bf4c6948639275683ffa7a1993c44639b43c22b1c505f0f813a24b1889037eb182546b48946f9fe7cdd0e7d13
   languageName: node
   linkType: hard
 
@@ -9065,19 +8349,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-cursor@npm:3.1.0, cli-cursor@npm:^3.1.0":
+"cli-cursor@npm:^3.1.0":
   version: 3.1.0
   resolution: "cli-cursor@npm:3.1.0"
   dependencies:
     restore-cursor: ^3.1.0
   checksum: 2692784c6cd2fd85cfdbd11f53aea73a463a6d64a77c3e098b2b4697a20443f430c220629e1ca3b195ea5ac4a97a74c2ee411f3807abf6df2b66211fec0c0a29
-  languageName: node
-  linkType: hard
-
-"cli-spinners@npm:2.6.1":
-  version: 2.6.1
-  resolution: "cli-spinners@npm:2.6.1"
-  checksum: 423409baaa7a58e5104b46ca1745fbfc5888bbd0b0c5a626e052ae1387060839c8efd512fb127e25769b3dc9562db1dc1b5add6e0b93b7ef64f477feb6416a45
   languageName: node
   linkType: hard
 
@@ -9192,15 +8469,6 @@ __metadata:
   version: 1.1.0
   resolution: "clsx@npm:1.1.0"
   checksum: 50e889839a557b8a2fca063ee7ea22ba8c261e7f9f7aadc257065fc77f16fa0a98ce826fb2b126d05fb736560333971dbb882874054df7bb8f4317e224ec1978
-  languageName: node
-  linkType: hard
-
-"cmd-shim@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "cmd-shim@npm:5.0.0"
-  dependencies:
-    mkdirp-infer-owner: ^2.0.0
-  checksum: 83d2a46cdf4adbb38d3d3184364b2df0e4c001ac770f5ca94373825d7a48838b4cb8a59534ef48f02b0d556caa047728589ca65c640c17c0b417b3afb34acfbb
   languageName: node
   linkType: hard
 
@@ -9390,13 +8658,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"common-ancestor-path@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "common-ancestor-path@npm:1.0.1"
-  checksum: 1d2e4186067083d8cc413f00fc2908225f04ae4e19417ded67faa6494fb313c4fcd5b28a52326d1a62b466e2b3a4325e92c31133c5fee628cdf8856b3a57c3d7
-  languageName: node
-  linkType: hard
-
 "common-dir@npm:^3.0.0":
   version: 3.0.0
   resolution: "common-dir@npm:3.0.0"
@@ -9546,13 +8807,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"config-chain@npm:^1.1.12":
-  version: 1.1.12
-  resolution: "config-chain@npm:1.1.12"
+"config-chain@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "config-chain@npm:1.1.13"
   dependencies:
     ini: ^1.3.4
     proto-list: ~1.2.1
-  checksum: a16332f87212b4015afcdfc95fe42b40b162e7f10b4f4370ab3239979b6e69a41b4e6fb34d7891aa028a557f2340da236f810df433b18dfa5c408b2eb8489bf7
+  checksum: 828137a28e7c2fc4b7fb229bd0cd6c1397bcf83434de54347e608154008f411749041ee392cbe42fab6307e02de4c12480260bf769b7d44b778fdea3839eafab
   languageName: node
   linkType: hard
 
@@ -9655,13 +8916,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "conventional-changelog-angular@npm:5.0.12"
+"conventional-changelog-angular@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "conventional-changelog-angular@npm:5.0.13"
   dependencies:
     compare-func: ^2.0.0
     q: ^1.5.1
-  checksum: 552db8762d210a5172b1ad8cd95312e2e2a0483ba43f8d30b075a56ccf05231fdca1d4d5843028d43bec6bc7f903f480005efc5386587321a15a1fc4d2b73016
+  checksum: 6ed4972fce25a50f9f038c749cc9db501363131b0fb2efc1fccecba14e4b1c80651d0d758d4c350a609f32010c66fa343eefd49c02e79e911884be28f53f3f90
   languageName: node
   linkType: hard
 
@@ -9694,7 +8955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-writer@npm:^5.0.0":
+"conventional-changelog-writer@npm:^5.0.0, conventional-changelog-writer@npm:^5.0.1":
   version: 5.0.1
   resolution: "conventional-changelog-writer@npm:5.0.1"
   dependencies:
@@ -9723,9 +8984,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-commits-parser@npm:^3.2.0":
-  version: 3.2.1
-  resolution: "conventional-commits-parser@npm:3.2.1"
+"conventional-commits-parser@npm:^3.2.0, conventional-commits-parser@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "conventional-commits-parser@npm:3.2.4"
   dependencies:
     JSONStream: ^1.0.4
     is-text-path: ^1.0.1
@@ -9733,10 +8994,9 @@ __metadata:
     meow: ^8.0.0
     split2: ^3.0.0
     through2: ^4.0.0
-    trim-off-newlines: ^1.0.0
   bin:
     conventional-commits-parser: cli.js
-  checksum: 01b83c625ac3d8f9dca0510a5e21385c9bb410b80bcb60dcfdef20e1fa7fe7fad5a280aa5e1dff8ac32ea0aea5966fa973696557d38f831f8630d4fcf31756d5
+  checksum: 1627ff203bc9586d89e47a7fe63acecf339aba74903b9114e23d28094f79d4e2d6389bf146ae561461dcba8fc42e7bc228165d2b173f15756c43f1d32bc50bfd
   languageName: node
   linkType: hard
 
@@ -9942,6 +9202,19 @@ __metadata:
     path-type: ^4.0.0
     yaml: ^1.7.2
   checksum: 8eed7c854b91643ecb820767d0deb038b50780ecc3d53b0b19e03ed8aabed4ae77271198d1ae3d49c3b110867edf679f5faad924820a8d1774144a87cb6f98fc
+  languageName: node
+  linkType: hard
+
+"cosmiconfig@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "cosmiconfig@npm:7.0.1"
+  dependencies:
+    "@types/parse-json": ^4.0.0
+    import-fresh: ^3.2.1
+    parse-json: ^5.0.0
+    path-type: ^4.0.0
+    yaml: ^1.10.0
+  checksum: 4be63e7117955fd88333d7460e4c466a90f556df6ef34efd59034d2463484e339666c41f02b523d574a797ec61f4a91918c5b89a316db2ea2f834e0d2d09465b
   languageName: node
   linkType: hard
 
@@ -10499,9 +9772,9 @@ __metadata:
   linkType: hard
 
 "detect-indent@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "detect-indent@npm:6.0.0"
-  checksum: 0c38f362016e2d07af1c65b1ecd6ad8a91f06bfdd11383887c867a495ad286d04be2ab44027ac42444704d523982013115bd748c1541df7c9396ad76b22aaf5d
+  version: 6.1.0
+  resolution: "detect-indent@npm:6.1.0"
+  checksum: ab953a73c72dbd4e8fc68e4ed4bfd92c97eb6c43734af3900add963fd3a9316f3bc0578b018b24198d4c31a358571eff5f0656e81a1f3b9ad5c547d58b2d093d
   languageName: node
   linkType: hard
 
@@ -10773,15 +10046,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "dot-prop@npm:6.0.1"
-  dependencies:
-    is-obj: ^2.0.0
-  checksum: 0f47600a4b93e1dc37261da4e6909652c008832a5d3684b5bf9a9a0d3f4c67ea949a86dceed9b72f5733ed8e8e6383cc5958df3bbd0799ee317fd181f2ece700
-  languageName: node
-  linkType: hard
-
 "dotenv-defaults@npm:2.0.2":
   version: 2.0.2
   resolution: "dotenv-defaults@npm:2.0.2"
@@ -10791,10 +10055,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:10.0.0, dotenv@npm:~10.0.0":
+"dotenv@npm:10.0.0":
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
   checksum: f412c5fe8c24fbe313d302d2500e247ba8a1946492db405a4de4d30dd0eb186a88a43f13c958c5a7de303938949c4231c56994f97d05c4bc1f22478d631b4005
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.0.2":
+  version: 16.0.2
+  resolution: "dotenv@npm:16.0.2"
+  checksum: ca8f9ca2d67929c7771069f4c31b4e46b9932621009e658e5afd655dde2d69b77642bf36dbc9e72bc170523dfd908a9ee41c26f034c1fdc605ace3b1b4b10faf
   languageName: node
   linkType: hard
 
@@ -10955,7 +10226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+"end-of-stream@npm:^1.0.0, end-of-stream@npm:^1.1.0":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
@@ -11083,7 +10354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.5, enquirer@npm:^2.3.6, enquirer@npm:~2.3.6":
+"enquirer@npm:^2.3.5, enquirer@npm:^2.3.6":
   version: 2.3.6
   resolution: "enquirer@npm:2.3.6"
   dependencies:
@@ -11122,7 +10393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"envinfo@npm:^7.7.4":
+"envinfo@npm:^7.8.1":
   version: 7.8.1
   resolution: "envinfo@npm:7.8.1"
   bin:
@@ -11846,6 +11117,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "execa@npm:5.1.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.0
+    human-signals: ^2.1.0
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^4.0.1
+    onetime: ^5.1.2
+    signal-exit: ^3.0.3
+    strip-final-newline: ^2.0.0
+  checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
+  languageName: node
+  linkType: hard
+
 "exit@npm:^0.1.2":
   version: 0.1.2
   resolution: "exit@npm:0.1.2"
@@ -12011,19 +11299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:3.2.7":
-  version: 3.2.7
-  resolution: "fast-glob@npm:3.2.7"
-  dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.2
-    merge2: ^1.3.0
-    micromatch: ^4.0.4
-  checksum: 2f4708ff112d2b451888129fdd9a0938db88b105b0ddfd043c064e3c4d3e20eed8d7c7615f7565fee660db34ddcf08a2db1bf0ab3c00b87608e4719694642d78
-  languageName: node
-  linkType: hard
-
 "fast-glob@npm:^3.1.1":
   version: 3.2.5
   resolution: "fast-glob@npm:3.2.5"
@@ -12120,7 +11395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:3.2.0, figures@npm:^3.0.0, figures@npm:^3.2.0":
+"figures@npm:^3.0.0, figures@npm:^3.2.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
   dependencies:
@@ -12390,15 +11665,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "flat@npm:5.0.2"
-  bin:
-    flat: cli.js
-  checksum: 12a1536ac746db74881316a181499a78ef953632ddd28050b7a3a43c62ef5462e3357c8c29d76072bb635f147f7a9a1f0c02efef6b4be28f8db62ceb3d5c7f5d
-  languageName: node
-  linkType: hard
-
 "flatted@npm:^3.1.0, flatted@npm:^3.2.4":
   version: 3.2.4
   resolution: "flatted@npm:3.2.4"
@@ -12535,13 +11801,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-constants@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fs-constants@npm:1.0.0"
-  checksum: 18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
-  languageName: node
-  linkType: hard
-
 "fs-exists-sync@npm:^0.1.0":
   version: 0.1.0
   resolution: "fs-exists-sync@npm:0.1.0"
@@ -12582,7 +11841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^9.0.0, fs-extra@npm:^9.1.0":
+"fs-extra@npm:^9.0.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
   dependencies:
@@ -12829,13 +12088,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-port@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "get-port@npm:5.1.1"
-  checksum: 0162663ffe5c09e748cd79d97b74cd70e5a5c84b760a475ce5767b357fb2a57cb821cee412d646aa8a156ed39b78aab88974eddaa9e5ee926173c036c0713787
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^4.0.0":
   version: 4.1.0
   resolution: "get-stream@npm:4.1.0"
@@ -12852,6 +12104,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-stream@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "get-stream@npm:6.0.1"
+  checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
+  languageName: node
+  linkType: hard
+
 "get-value@npm:^2.0.3, get-value@npm:^2.0.6":
   version: 2.0.6
   resolution: "get-value@npm:2.0.6"
@@ -12860,8 +12119,8 @@ __metadata:
   linkType: hard
 
 "git-raw-commits@npm:^2.0.8":
-  version: 2.0.10
-  resolution: "git-raw-commits@npm:2.0.10"
+  version: 2.0.11
+  resolution: "git-raw-commits@npm:2.0.11"
   dependencies:
     dargs: ^7.0.0
     lodash: ^4.17.15
@@ -12870,7 +12129,7 @@ __metadata:
     through2: ^4.0.0
   bin:
     git-raw-commits: cli.js
-  checksum: 66e2d7b4cdeff946ac639e1bba37f5dcbd9f5c9245348b31e027e4529f6b6733d23f75768d285d5f29c1f08d3485705a4932300a81a45b77b660fe3ce6089c29
+  checksum: c178af43633684106179793b6e3473e1d2bb50bb41d04e2e285ea4eef342ca4090fee6bc8a737552fde879d22346c90de5c49f18c719a0f38d4c934f258a0f79
   languageName: node
   linkType: hard
 
@@ -12896,22 +12155,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"git-up@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "git-up@npm:6.0.0"
+"git-up@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "git-up@npm:7.0.0"
   dependencies:
     is-ssh: ^1.4.0
-    parse-url: ^7.0.2
-  checksum: 145a1f546d7a078cdfc2616556e518e634d134e34a31c6bf2ed89e44158659cb525dbd451c338121f7107f55cef066d0b37a7bbf178555befc9304b3940b435e
+    parse-url: ^8.1.0
+  checksum: 2faadbab51e94d2ffb220e426e950087cc02c15d664e673bd5d1f734cfa8196fed8b19493f7bf28fe216d087d10e22a7fd9b63687e0ba7d24f0ddcfb0a266d6e
   languageName: node
   linkType: hard
 
-"git-url-parse@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "git-url-parse@npm:12.0.0"
+"git-url-parse@npm:^13.1.0":
+  version: 13.1.0
+  resolution: "git-url-parse@npm:13.1.0"
   dependencies:
-    git-up: ^6.0.0
-  checksum: b4c8530b816202ecf9d4dabf755f785a314a096b56145018385b3d7171e862f9d0d9b38cce620c0af354b269750fe7b2d9aa95815c7150922090a11dac4ab1e6
+    git-up: ^7.0.0
+  checksum: 212a9b0343e9199998b6a532efe2014476a7a1283af393663ca49ac28d4768929aad16d3322e2685236065ee394dbc93e7aa63a48956531e984c56d8b5edb54d
   languageName: node
   linkType: hard
 
@@ -12975,24 +12234,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: ^4.0.3
+  checksum: c13ee97978bef4f55106b71e66428eb1512e71a7466ba49025fc2aec59a5bfb0954d5abd58fc5ee6c9b076eef4e1f6d3375c2e964b88466ca390da4419a786a8
+  languageName: node
+  linkType: hard
+
 "glob-to-regexp@npm:^0.4.1":
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
   checksum: e795f4e8f06d2a15e86f76e4d92751cf8bbfcf0157cea5c2f0f35678a8195a750b34096b1256e436f0cebc1883b5ff0888c47348443e69546a5a87f9e1eb1167
-  languageName: node
-  linkType: hard
-
-"glob@npm:7.1.4":
-  version: 7.1.4
-  resolution: "glob@npm:7.1.4"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^3.0.4
-    once: ^1.3.0
-    path-is-absolute: ^1.0.0
-  checksum: f52480fc82b1e66e52990f0f2e7306447d12294c83fbbee0395e761ad1178172012a7cc0673dbf4810baac400fc09bf34484c08b5778c216403fd823db281716
   languageName: node
   linkType: hard
 
@@ -13125,7 +12379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.2, globby@npm:^11.0.3":
+"globby@npm:^11.0.3":
   version: 11.0.3
   resolution: "globby@npm:11.0.3"
   dependencies:
@@ -13139,7 +12393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.4":
+"globby@npm:^11.0.4, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -13214,7 +12468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
@@ -13486,30 +12740,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:^3.0.6":
-  version: 3.0.8
-  resolution: "hosted-git-info@npm:3.0.8"
-  dependencies:
-    lru-cache: ^6.0.0
-  checksum: 5af7a69581acb84206a7b8e009f4680c36396814e92c8a83973dfb3b87e44e44d1f7b8eaf3e4a953686482770ecb78406a4ce4666bfdfe447762434127871d8d
-  languageName: node
-  linkType: hard
-
-"hosted-git-info@npm:^4.0.0":
+"hosted-git-info@npm:^4.0.0, hosted-git-info@npm:^4.0.1":
   version: 4.1.0
   resolution: "hosted-git-info@npm:4.1.0"
   dependencies:
     lru-cache: ^6.0.0
   checksum: c3f87b3c2f7eb8c2748c8f49c0c2517c9a95f35d26f4bf54b2a8cba05d2e668f3753548b6ea366b18ec8dadb4e12066e19fa382a01496b0ffa0497eb23cbe461
-  languageName: node
-  linkType: hard
-
-"hosted-git-info@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "hosted-git-info@npm:4.0.2"
-  dependencies:
-    lru-cache: ^6.0.0
-  checksum: d1b2d7720398ce96a788bd38d198fbddce089a2381f63cfb01743e6c7e5aed656e5547fe74090fb9fe53b2cb785b0e8c9ebdddadff48ed26bb471dd23cd25458
   languageName: node
   linkType: hard
 
@@ -13805,17 +13041,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "ignore@npm:5.2.0"
-  checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
-  languageName: node
-  linkType: hard
-
 "ignore@npm:^5.1.4":
   version: 5.1.8
   resolution: "ignore@npm:5.1.8"
   checksum: 967abadb61e2cb0e5c5e8c4e1686ab926f91bc1a4680d994b91947d3c65d04c3ae126dcdf67f08e0feeb8ff8407d453e641aeeddcc47a3a3cca359f283cf6121
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "ignore@npm:5.2.0"
+  checksum: 6b1f926792d614f64c6c83da3a1f9c83f6196c2839aa41e1e32dd7b8d174cef2e329d75caabb62cb61ce9dc432f75e67d07d122a037312db7caa73166a1bdb77
   languageName: node
   linkType: hard
 
@@ -13871,6 +13107,18 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: c74d9f9484c878cda1de3434613c7ff72d5dadcf20e5482542232d7c2575b713ff88701d6675fcf09a3684cb23fb407c8b333b9cbc59438712723d058d8e976c
+  languageName: node
+  linkType: hard
+
+"import-local@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "import-local@npm:3.1.0"
+  dependencies:
+    pkg-dir: ^4.2.0
+    resolve-cwd: ^3.0.0
+  bin:
+    import-local-fixture: fixtures/cli.js
+  checksum: bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
   languageName: node
   linkType: hard
 
@@ -13933,32 +13181,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.2, ini@npm:^1.3.4, ini@npm:~1.3.0":
-  version: 1.3.7
-  resolution: "ini@npm:1.3.7"
-  checksum: f8f3801e8eb039f9e03cdc27ceb494a7ac6e6ca7b2dd8394a9ef97ed5ae66930fadefd5ec908e41e4b103d3c9063b5788d47de5e8e892083c7a67b489f3b962d
-  languageName: node
-  linkType: hard
-
-"ini@npm:^1.3.5":
+"ini@npm:^1.3.2, ini@npm:^1.3.5":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: dfd98b0ca3a4fc1e323e38a6c8eb8936e31a97a918d3b377649ea15bdb15d481207a0dda1021efbd86b464cae29a0d33c1d7dcaf6c5672bee17fa849bc50a1b3
   languageName: node
   linkType: hard
 
-"init-package-json@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "init-package-json@npm:3.0.2"
-  dependencies:
-    npm-package-arg: ^9.0.1
-    promzard: ^0.3.0
-    read: ^1.0.7
-    read-package-json: ^5.0.0
-    semver: ^7.3.5
-    validate-npm-package-license: ^3.0.4
-    validate-npm-package-name: ^4.0.0
-  checksum: e027f60e4a1564809eee790d5a842341c784888fd7c7ace5f9a34ea76224c0adb6f3ab3bf205cf1c9c877a6e1a76c68b00847a984139f60813125d7b42a23a13
+"ini@npm:^1.3.4, ini@npm:~1.3.0":
+  version: 1.3.7
+  resolution: "ini@npm:1.3.7"
+  checksum: f8f3801e8eb039f9e03cdc27ceb494a7ac6e6ca7b2dd8394a9ef97ed5ae66930fadefd5ec908e41e4b103d3c9063b5788d47de5e8e892083c7a67b489f3b962d
   languageName: node
   linkType: hard
 
@@ -14229,17 +13462,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-ci@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "is-ci@npm:2.0.0"
-  dependencies:
-    ci-info: ^2.0.0
-  bin:
-    is-ci: bin.js
-  checksum: 77b869057510f3efa439bbb36e9be429d53b3f51abd4776eeea79ab3b221337fe1753d1e50058a9e2c650d38246108beffb15ccfd443929d77748d8c0cc90144
-  languageName: node
-  linkType: hard
-
 "is-ci@npm:^3.0.0":
   version: 3.0.0
   resolution: "is-ci@npm:3.0.0"
@@ -14248,6 +13470,17 @@ __metadata:
   bin:
     is-ci: bin.js
   checksum: 4b45aef32dd42dcb1f6fb3cd4b3a7ee7e18ea47516d2129005f46c3f36983506bb471382bac890973cf48a2f60d926a24461674ca2d9dc10744d82d4a876c26b
+  languageName: node
+  linkType: hard
+
+"is-ci@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "is-ci@npm:3.0.1"
+  dependencies:
+    ci-info: ^3.2.0
+  bin:
+    is-ci: bin.js
+  checksum: 192c66dc7826d58f803ecae624860dccf1899fc1f3ac5505284c0a5cf5f889046ffeb958fa651e5725d5705c5bcb14f055b79150ea5fcad7456a9569de60260e
   languageName: node
   linkType: hard
 
@@ -14260,7 +13493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.8.1":
+"is-core-module@npm:^2.5.0, is-core-module@npm:^2.8.1":
   version: 2.10.0
   resolution: "is-core-module@npm:2.10.0"
   dependencies:
@@ -14441,6 +13674,15 @@ __metadata:
   dependencies:
     is-extglob: ^2.1.1
   checksum: 84627cad11b4e745f5db5a163f32c47b711585a5ff6e14f8f8d026db87f4cdd3e2c95f6fa1f94ad22e469f36d819ae2814f03f9c668b164422ac3354a94672d3
+  languageName: node
+  linkType: hard
+
+"is-glob@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "is-glob@npm:4.0.3"
+  dependencies:
+    is-extglob: ^2.1.1
+  checksum: d381c1319fcb69d341cc6e6c7cd588e17cd94722d9a32dbd60660b993c4fb7d0f19438674e68dfec686d09b7c73139c9166b47597f846af387450224a8101ab4
   languageName: node
   linkType: hard
 
@@ -14723,6 +13965,13 @@ __metadata:
   version: 2.0.0
   resolution: "is-stream@npm:2.0.0"
   checksum: 4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
   languageName: node
   linkType: hard
 
@@ -15758,17 +15007,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.0, js-yaml@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "js-yaml@npm:4.1.0"
-  dependencies:
-    argparse: ^2.0.1
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
-  languageName: node
-  linkType: hard
-
 "jsdoc-type-pratt-parser@npm:1.1.1, jsdoc-type-pratt-parser@npm:^1.1.1":
   version: 1.1.1
   resolution: "jsdoc-type-pratt-parser@npm:1.1.1"
@@ -15887,13 +15125,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stringify-nice@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "json-stringify-nice@npm:1.1.4"
-  checksum: 6ddf781148b46857ab04e97f47be05f14c4304b86eb5478369edbeacd070c21c697269964b982fc977e8989d4c59091103b1d9dc291aba40096d6cbb9a392b72
-  languageName: node
-  linkType: hard
-
 "json-stringify-safe@npm:^5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
@@ -15936,13 +15167,6 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 74b8a23b102a6f2bf2d224797ae553a75488b5adbaee9c9b6e5ab8b510a2fc6e38f876d4c77dea672d4014a44b2399e15f2051ac2b37b87f74c0c7602003543b
-  languageName: node
-  linkType: hard
-
-"jsonc-parser@npm:3.0.0":
-  version: 3.0.0
-  resolution: "jsonc-parser@npm:3.0.0"
-  checksum: 1df2326f1f9688de30c70ff19c5b2a83ba3b89a1036160da79821d1361090775e9db502dc57a67c11b56e1186fc1ed70b887f25c5febf9a3ec4f91435836c99d
   languageName: node
   linkType: hard
 
@@ -16080,20 +15304,6 @@ __metadata:
     readable-stream: ~2.3.6
     set-immediate-shim: ~1.0.1
   checksum: 10b8c6a8406c0ac559353bb8b8946a55432ccfda27bc98e539156301ec78a26cd4e7dc4288e9863796e9f30a6924910cefa7bb12bda1338cf71e522133abb370
-  languageName: node
-  linkType: hard
-
-"just-diff-apply@npm:^5.2.0":
-  version: 5.4.1
-  resolution: "just-diff-apply@npm:5.4.1"
-  checksum: e324ccfdb5df174e3ec30751f6b7e8d84a75a1c559c7b294ccba79c94390b424cc84714cb2dc72cef41e0ba0cf5ecce33e5d6dedd14f5700285de38892d81cce
-  languageName: node
-  linkType: hard
-
-"just-diff@npm:^5.0.1":
-  version: 5.1.1
-  resolution: "just-diff@npm:5.1.1"
-  checksum: a6dfd778658c56c0144a22a435dd0a1cae890c4c7a973dbc1c16be0b092cfb5c8ac2d42d608d9713c3fc83683722ecb1585f67c30205f2836bfbe61022bd6999
   languageName: node
   linkType: hard
 
@@ -16373,36 +15583,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lerna@npm:5.5.1":
-  version: 5.5.1
-  resolution: "lerna@npm:5.5.1"
-  dependencies:
-    "@lerna/add": 5.5.1
-    "@lerna/bootstrap": 5.5.1
-    "@lerna/changed": 5.5.1
-    "@lerna/clean": 5.5.1
-    "@lerna/cli": 5.5.1
-    "@lerna/create": 5.5.1
-    "@lerna/diff": 5.5.1
-    "@lerna/exec": 5.5.1
-    "@lerna/import": 5.5.1
-    "@lerna/info": 5.5.1
-    "@lerna/init": 5.5.1
-    "@lerna/link": 5.5.1
-    "@lerna/list": 5.5.1
-    "@lerna/publish": 5.5.1
-    "@lerna/run": 5.5.1
-    "@lerna/version": 5.5.1
-    import-local: ^3.0.2
-    npmlog: ^6.0.2
-    nx: ">=14.6.1 < 16"
-    typescript: ^3 || ^4
-  bin:
-    lerna: cli.js
-  checksum: 3f06c4ad9c9fd4e06a8c3653e4feb93ad26de555a0ac94b262901b55f673d14cfa07822a6e0ef28f5ebd672e916c0b878ea24f70dd7d0504b3eef53bdf1f4110
-  languageName: node
-  linkType: hard
-
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -16430,7 +15610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libnpmaccess@npm:^6.0.3":
+"libnpmaccess@npm:^6.0.4":
   version: 6.0.4
   resolution: "libnpmaccess@npm:6.0.4"
   dependencies:
@@ -16442,7 +15622,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libnpmpublish@npm:^6.0.4":
+"libnpmpublish@npm:^6.0.5":
   version: 6.0.5
   resolution: "libnpmpublish@npm:6.0.5"
   dependencies:
@@ -17000,9 +16180,9 @@ __metadata:
   linkType: hard
 
 "map-obj@npm:^4.0.0":
-  version: 4.2.1
-  resolution: "map-obj@npm:4.2.1"
-  checksum: 2745227b11ba6e6ddc5927b555a8f317aa33886fcd12806193f3e3c6f201eb24c9cff44bf932b1113a1ba461755a479b22439d0d670380330325164ed0e99547
+  version: 4.3.0
+  resolution: "map-obj@npm:4.3.0"
+  checksum: fbc554934d1a27a1910e842bc87b177b1a556609dd803747c85ece420692380827c6ae94a95cce4407c054fa0964be3bf8226f7f2cb2e9eeee432c7c1985684e
   languageName: node
   linkType: hard
 
@@ -17348,16 +16528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.0.5":
-  version: 3.0.5
-  resolution: "minimatch@npm:3.0.5"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: a3b84b426eafca947741b864502cee02860c4e7b145de11ad98775cfcf3066fef422583bc0ffce0952ddf4750c1ccf4220b1556430d4ce10139f66247d87d69e
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^5.0.1":
+"minimatch@npm:^5.0.1, minimatch@npm:^5.1.0":
   version: 5.1.0
   resolution: "minimatch@npm:5.1.0"
   dependencies:
@@ -17536,17 +16707,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp-infer-owner@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "mkdirp-infer-owner@npm:2.0.0"
-  dependencies:
-    chownr: ^2.0.0
-    infer-owner: ^1.0.4
-    mkdirp: ^1.0.3
-  checksum: d8f4ecd32f6762459d6b5714eae6487c67ae9734ab14e26d14377ddd9b2a1bf868d8baa18c0f3e73d3d513f53ec7a698e0f81a9367102c870a55bef7833880f7
-  languageName: node
-  linkType: hard
-
 "mkdirp@npm:0.5.x, mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3, mkdirp@npm:^0.5.5, mkdirp@npm:~0.5.1":
   version: 0.5.5
   resolution: "mkdirp@npm:0.5.5"
@@ -17678,7 +16838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mute-stream@npm:0.0.8, mute-stream@npm:~0.0.4":
+"mute-stream@npm:0.0.8":
   version: 0.0.8
   resolution: "mute-stream@npm:0.0.8"
   checksum: ff48d251fc3f827e5b1206cda0ffdaec885e56057ee86a3155e1951bc940fd5f33531774b1cc8414d7668c10a8907f863f6561875ee6e8768931a62121a531a1
@@ -17811,15 +16971,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "node-addon-api@npm:3.2.1"
-  dependencies:
-    node-gyp: latest
-  checksum: 2369986bb0881ccd9ef6bacdf39550e07e089a9c8ede1cbc5fc7712d8e2faa4d50da0e487e333d4125f8c7a616c730131d1091676c9d499af1d74560756b4a18
-  languageName: node
-  linkType: hard
-
 "node-cmake@npm:2.3.2":
   version: 2.3.2
   resolution: "node-cmake@npm:2.3.2"
@@ -17842,7 +16993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:
@@ -17860,17 +17011,6 @@ __metadata:
   version: 0.10.0
   resolution: "node-forge@npm:0.10.0"
   checksum: 5aa6dc9922e424a20ef101d2f517418e2bc9cfc0255dd22e0701c0fad1568445f510ee67f6f3fcdf085812c4ca1b847b8ba45683b34776828e41f5c1794e42e1
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:^4.3.0":
-  version: 4.5.0
-  resolution: "node-gyp-build@npm:4.5.0"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: d888bae0fb88335f69af1b57a2294a931c5042f36e413d8d364c992c9ebfa0b96ffe773179a5a2c8f04b73856e8634e09cce108dbb9804396d3cc8c5455ff2db
   languageName: node
   linkType: hard
 
@@ -18079,14 +17219,14 @@ __metadata:
   linkType: hard
 
 "normalize-package-data@npm:^3.0.0":
-  version: 3.0.2
-  resolution: "normalize-package-data@npm:3.0.2"
+  version: 3.0.3
+  resolution: "normalize-package-data@npm:3.0.3"
   dependencies:
     hosted-git-info: ^4.0.1
-    resolve: ^1.20.0
+    is-core-module: ^2.5.0
     semver: ^7.3.4
     validate-npm-package-license: ^3.0.1
-  checksum: b50e26f2c81c51ddf6b5a04f731ddc2fc409ef114d44b5e2e4a7cfaa2d45cb86f76fea0c3a57a41e106f71c777124f93b4a75fe1c4b3aa4844971a30a30d94c9
+  checksum: bbcee00339e7c26fdbc760f9b66d429258e2ceca41a5df41f5df06cc7652de8d82e8679ff188ca095cad8eff2b6118d7d866af2b68400f74602fbcbce39c160a
   languageName: node
   linkType: hard
 
@@ -18118,13 +17258,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "normalize-url@npm:6.1.0"
-  checksum: 4a4944631173e7d521d6b80e4c85ccaeceb2870f315584fa30121f505a6dfd86439c5e3fdd8cd9e0e291290c41d0c3599f0cb12ab356722ed242584c30348e50
-  languageName: node
-  linkType: hard
-
 "npm-bundled@npm:^1.0.1":
   version: 1.0.6
   resolution: "npm-bundled@npm:1.0.6"
@@ -18133,11 +17266,11 @@ __metadata:
   linkType: hard
 
 "npm-bundled@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "npm-bundled@npm:1.1.1"
+  version: 1.1.2
+  resolution: "npm-bundled@npm:1.1.2"
   dependencies:
     npm-normalize-package-bin: ^1.0.1
-  checksum: da5c227ff6aa32de84f728225fd2671ae4611d8d6e5dfb15d146353e48f644ec8dfb0b030760c359c00a8b9d5417b6b93843529e639d4583ce5adb8cece639da
+  checksum: 6e599155ef28d0b498622f47f1ba189dfbae05095a1ed17cb3a5babf961e965dd5eab621f0ec6f0a98de774e5836b8f5a5ee639010d64f42850a74acec3d4d09
   languageName: node
   linkType: hard
 
@@ -18192,18 +17325,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-package-arg@npm:8.1.1":
-  version: 8.1.1
-  resolution: "npm-package-arg@npm:8.1.1"
-  dependencies:
-    hosted-git-info: ^3.0.6
-    semver: ^7.0.0
-    validate-npm-package-name: ^3.0.0
-  checksum: 406c59f92d8fac5acbd1df62f4af8075e925af51131b6bc66245641ea71ddb0e60b3e2c56fafebd4e8ffc3ba0453e700a221a36a44740dc9f7488cec97ae4c55
-  languageName: node
-  linkType: hard
-
-"npm-package-arg@npm:^9.0.0, npm-package-arg@npm:^9.0.1":
+"npm-package-arg@npm:^9.0.0, npm-package-arg@npm:^9.0.1, npm-package-arg@npm:^9.1.0":
   version: 9.1.0
   resolution: "npm-package-arg@npm:9.1.0"
   dependencies:
@@ -18225,7 +17347,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-packlist@npm:^5.1.0, npm-packlist@npm:^5.1.1":
+"npm-packlist@npm:^5.1.0, npm-packlist@npm:^5.1.3":
   version: 5.1.3
   resolution: "npm-packlist@npm:5.1.3"
   dependencies:
@@ -18251,7 +17373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-registry-fetch@npm:^13.0.0, npm-registry-fetch@npm:^13.0.1, npm-registry-fetch@npm:^13.3.0":
+"npm-registry-fetch@npm:^13.0.0, npm-registry-fetch@npm:^13.0.1, npm-registry-fetch@npm:^13.3.1":
   version: 13.3.1
   resolution: "npm-registry-fetch@npm:13.3.1"
   dependencies:
@@ -18352,54 +17474,6 @@ __metadata:
   version: 2.2.0
   resolution: "nwsapi@npm:2.2.0"
   checksum: 5ef4a9bc0c1a5b7f2e014aa6a4b359a257503b796618ed1ef0eb852098f77e772305bb0e92856e4bbfa3e6c75da48c0113505c76f144555ff38867229c2400a7
-  languageName: node
-  linkType: hard
-
-"nx@npm:14.7.6, nx@npm:>=14.6.1 < 16":
-  version: 14.7.6
-  resolution: "nx@npm:14.7.6"
-  dependencies:
-    "@nrwl/cli": 14.7.6
-    "@nrwl/tao": 14.7.6
-    "@parcel/watcher": 2.0.4
-    chalk: 4.1.0
-    chokidar: ^3.5.1
-    cli-cursor: 3.1.0
-    cli-spinners: 2.6.1
-    cliui: ^7.0.2
-    dotenv: ~10.0.0
-    enquirer: ~2.3.6
-    fast-glob: 3.2.7
-    figures: 3.2.0
-    flat: ^5.0.2
-    fs-extra: ^10.1.0
-    glob: 7.1.4
-    ignore: ^5.0.4
-    js-yaml: 4.1.0
-    jsonc-parser: 3.0.0
-    minimatch: 3.0.5
-    npm-run-path: ^4.0.1
-    open: ^8.4.0
-    semver: 7.3.4
-    string-width: ^4.2.3
-    tar-stream: ~2.2.0
-    tmp: ~0.2.1
-    tsconfig-paths: ^3.9.0
-    tslib: ^2.3.0
-    v8-compile-cache: 2.3.0
-    yargs: ^17.4.0
-    yargs-parser: 21.0.1
-  peerDependencies:
-    "@swc-node/register": ^1.4.2
-    "@swc/core": ^1.2.173
-  peerDependenciesMeta:
-    "@swc-node/register":
-      optional: true
-    "@swc/core":
-      optional: true
-  bin:
-    nx: bin/nx.js
-  checksum: 245a8a25b0185c1e0470c15915e8065dbe6ee2938028b5fbb6e2d67c987dc2c3f36fdf43d25ac26c951e403387f56ae4a35169a15d5e3da58c97eb36d3d3bdc9
   languageName: node
   linkType: hard
 
@@ -18783,6 +17857,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"os@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "os@npm:0.1.2"
+  checksum: dc2d99759eef13f5dc47ddb12c67b9760a7196fd83a35a7aec2d75b82f91163ca1d4e8872238f8c2a35f4cddd5adf5ce6638a234c0563c748d3cd1d69a9f7153
+  languageName: node
+  linkType: hard
+
 "osenv@npm:^0.1.0, osenv@npm:^0.1.4":
   version: 0.1.5
   resolution: "osenv@npm:0.1.5"
@@ -18863,13 +17944,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map-series@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "p-map-series@npm:2.1.0"
-  checksum: 69d4efbb6951c0dd62591d5a18c3af0af78496eae8b55791e049da239d70011aa3af727dece3fc9943e0bb3fd4fa64d24177cfbecc46efaf193179f0feeac486
-  languageName: node
-  linkType: hard
-
 "p-map@npm:^2.0.0":
   version: 2.1.0
   resolution: "p-map@npm:2.1.0"
@@ -18912,7 +17986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-reduce@npm:^2.0.0, p-reduce@npm:^2.1.0":
+"p-reduce@npm:^2.1.0":
   version: 2.1.0
   resolution: "p-reduce@npm:2.1.0"
   checksum: 99b26d36066a921982f25c575e78355824da0787c486e3dd9fc867460e8bf17d5fb3ce98d006b41bdc81ffc0aa99edf5faee53d11fe282a20291fb721b0cb1c7
@@ -18951,15 +18025,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-waterfall@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "p-waterfall@npm:2.1.1"
-  dependencies:
-    p-reduce: ^2.0.0
-  checksum: 8588bb8b004ee37e559c7e940a480c1742c42725d477b0776ff30b894920a3e48bddf8f60aa0ae82773e500a8fc99d75e947c450e0c2ce187aff72cc1b248f6d
-  languageName: node
-  linkType: hard
-
 "package-hash@npm:^4.0.0":
   version: 4.0.0
   resolution: "package-hash@npm:4.0.0"
@@ -18984,7 +18049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pacote@npm:^13.0.3, pacote@npm:^13.6.1":
+"pacote@npm:^13.6.2":
   version: 13.6.2
   resolution: "pacote@npm:13.6.2"
   dependencies:
@@ -19065,17 +18130,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-conflict-json@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "parse-conflict-json@npm:2.0.2"
-  dependencies:
-    json-parse-even-better-errors: ^2.3.1
-    just-diff: ^5.0.1
-    just-diff-apply: ^5.2.0
-  checksum: 076f65c958696586daefb153f59d575dfb59648be43116a21b74d5ff69ec63dd56f585a27cc2da56d8e64ca5abf0373d6619b8330c035131f8d1e990c8406378
-  languageName: node
-  linkType: hard
-
 "parse-entities@npm:^2.0.0":
   version: 2.0.0
   resolution: "parse-entities@npm:2.0.0"
@@ -19140,24 +18194,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-path@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "parse-path@npm:5.0.0"
+"parse-path@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "parse-path@npm:7.0.0"
   dependencies:
     protocols: ^2.0.0
-  checksum: e9f670559cd8e535f39f548bf5d41ad96a220190ea98df33d0babd9dfaa7c3c70ee2e55394078517d5e7e93c6a39c8eac1261ed3f9e68033656614fc954262e8
+  checksum: 244b46523a58181d251dda9b888efde35d8afb957436598d948852f416d8c76ddb4f2010f9fc94218b4be3e5c0f716aa0d2026194a781e3b8981924142009302
   languageName: node
   linkType: hard
 
-"parse-url@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "parse-url@npm:7.0.2"
+"parse-url@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "parse-url@npm:8.1.0"
   dependencies:
-    is-ssh: ^1.4.0
-    normalize-url: ^6.1.0
-    parse-path: ^5.0.0
-    protocols: ^2.0.1
-  checksum: 3e26852706bebe9fac409909316716dee52883d2fb5c82d65577effba1507abb7bc42bb59ce0ba6c8659168fb99acf89000bd8fe096ed3ad7124fa85227436d7
+    parse-path: ^7.0.0
+  checksum: b93e21ab4c93c7d7317df23507b41be7697694d4c94f49ed5c8d6288b01cba328fcef5ba388e147948eac20453dee0df9a67ab2012415189fff85973bdffe8d9
   languageName: node
   linkType: hard
 
@@ -19324,6 +18375,16 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
+  languageName: node
+  linkType: hard
+
+"path@npm:^0.12.7":
+  version: 0.12.7
+  resolution: "path@npm:0.12.7"
+  dependencies:
+    process: ^0.11.1
+    util: ^0.10.3
+  checksum: 5dedb71e78fc008fcba797defc0b4e1cf06c1f18e0a631e03ba5bb505136f587ff017afc14f9a3d481cbe77aeedff7dc0c1d2ce4d820c1ebf3c4281ca49423a1
   languageName: node
   linkType: hard
 
@@ -19643,7 +18704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process@npm:^0.11.10":
+"process@npm:^0.11.1, process@npm:^0.11.10":
   version: 0.11.10
   resolution: "process@npm:0.11.10"
   checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
@@ -19654,20 +18715,6 @@ __metadata:
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
-  languageName: node
-  linkType: hard
-
-"promise-all-reject-late@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "promise-all-reject-late@npm:1.0.1"
-  checksum: d7d61ac412352e2c8c3463caa5b1c3ca0f0cc3db15a09f180a3da1446e33d544c4261fc716f772b95e4c27d559cfd2388540f44104feb356584f9c73cfb9ffcb
-  languageName: node
-  linkType: hard
-
-"promise-call-limit@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "promise-call-limit@npm:1.0.1"
-  checksum: e69aed17f5f34bbd7aecff28faedb456e3500a08af31ee759ef75f2d8c2219d7c0e59f153f4d8c339056de8c304e0dd4acc500c339e7ea1e9c0e7bb1444367c8
   languageName: node
   linkType: hard
 
@@ -19705,15 +18752,6 @@ __metadata:
     kleur: ^3.0.3
     sisteransi: ^1.0.5
   checksum: d8fd1fe63820be2412c13bfc5d0a01909acc1f0367e32396962e737cb2fc52d004f3302475d5ce7d18a1e8a79985f93ff04ee03007d091029c3f9104bffc007d
-  languageName: node
-  linkType: hard
-
-"promzard@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "promzard@npm:0.3.0"
-  dependencies:
-    read: 1
-  checksum: 443a3b39ac916099988ee0161ab4e22edd1fa27e3d39a38d60e48c11ca6df3f5a90bfe44d95af06ed8659c4050b789ffe64c3f9f8e49a4bea1ea19105c98445a
   languageName: node
   linkType: hard
 
@@ -20385,13 +19423,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-cmd-shim@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "read-cmd-shim@npm:3.0.1"
-  checksum: 79fe66aa78eddcca8dc196765ae3168b3a56e2b69ba54071525eb00a9eeee8cc83b3d5f784432c3d8ce868787fdc059b1a1e0b605246b5108c9003fc927ea263
-  languageName: node
-  linkType: hard
-
 "read-installed@npm:~3.1.3":
   version: 3.1.5
   resolution: "read-installed@npm:3.1.5"
@@ -20410,7 +19441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-package-json-fast@npm:^2.0.2, read-package-json-fast@npm:^2.0.3":
+"read-package-json-fast@npm:^2.0.3":
   version: 2.0.3
   resolution: "read-package-json-fast@npm:2.0.3"
   dependencies:
@@ -20435,7 +19466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-package-json@npm:^5.0.0, read-package-json@npm:^5.0.1":
+"read-package-json@npm:^5.0.0, read-package-json@npm:^5.0.2":
   version: 5.0.2
   resolution: "read-package-json@npm:5.0.2"
   dependencies:
@@ -20512,15 +19543,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read@npm:1, read@npm:^1.0.7":
-  version: 1.0.7
-  resolution: "read@npm:1.0.7"
-  dependencies:
-    mute-stream: ~0.0.4
-  checksum: 2777c254e5732cac96f5d0a1c0f6b836c89ae23d8febd405b206f6f24d5de1873420f1a0795e0e3721066650d19adf802c7882c4027143ee0acf942a4f34f97b
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:1 || 2, readable-stream@npm:^2.0.0, readable-stream@npm:^2.0.1, readable-stream@npm:^2.0.2, readable-stream@npm:^2.0.5, readable-stream@npm:^2.0.6, readable-stream@npm:^2.1.5, readable-stream@npm:^2.2.2, readable-stream@npm:^2.3.3, readable-stream@npm:^2.3.6, readable-stream@npm:~2.3.6":
   version: 2.3.6
   resolution: "readable-stream@npm:2.3.6"
@@ -20557,7 +19579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readdir-scoped-modules@npm:^1.0.0, readdir-scoped-modules@npm:^1.1.0":
+"readdir-scoped-modules@npm:^1.0.0":
   version: 1.1.0
   resolution: "readdir-scoped-modules@npm:1.1.0"
   dependencies:
@@ -21181,6 +20203,9 @@ __metadata:
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
     "@babel/eslint-parser": 7.17.0
+    "@lerna-lite/changed": ^1.11.3
+    "@lerna-lite/cli": ^1.11.3
+    "@lerna-lite/run": ^1.11.3
     "@types/rimraf": ^3.0.2
     "@typescript-eslint/eslint-plugin": 4.29.0
     "@typescript-eslint/parser": 4.29.0
@@ -21199,7 +20224,6 @@ __metadata:
     eslint-plugin-unused-imports: 1.1.2
     husky: 4.3.8
     jest: ^29.0.3
-    lerna: 5.5.1
     lint-staged: 11.1.1
     prettier: 2.3.2
     tsconfig-paths: 3.10.1
@@ -21449,17 +20473,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.4":
-  version: 7.3.4
-  resolution: "semver@npm:7.3.4"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 96451bfd7cba9b60ee87571959dc47e87c95b2fe58a9312a926340fee9907fc7bc062c352efdaf5bb24b2dff59c145e14faf7eb9d718a84b4751312531b39f43
-  languageName: node
-  linkType: hard
-
 "semver@npm:^6.0.0, semver@npm:^6.1.1, semver@npm:^6.1.2, semver@npm:^6.3.0":
   version: 6.3.0
   resolution: "semver@npm:6.3.0"
@@ -21469,7 +20482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.7":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.2.1, semver@npm:^7.3.4, semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -21480,7 +20493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5":
+"semver@npm:^7.3.2, semver@npm:^7.3.5":
   version: 7.3.5
   resolution: "semver@npm:7.3.5"
   dependencies:
@@ -22923,19 +21936,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-stream@npm:~2.2.0":
-  version: 2.2.0
-  resolution: "tar-stream@npm:2.2.0"
-  dependencies:
-    bl: ^4.0.3
-    end-of-stream: ^1.4.1
-    fs-constants: ^1.0.0
-    inherits: ^2.0.3
-    readable-stream: ^3.1.1
-  checksum: 699831a8b97666ef50021c767f84924cfee21c142c2eb0e79c63254e140e6408d6d55a065a2992548e72b06de39237ef2b802b99e3ece93ca3904a37622a66f3
-  languageName: node
-  linkType: hard
-
 "tar@npm:^4":
   version: 4.4.19
   resolution: "tar@npm:4.4.19"
@@ -22951,7 +21951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.1.0":
+"tar@npm:^6.0.2":
   version: 6.1.0
   resolution: "tar@npm:6.1.0"
   dependencies:
@@ -23205,7 +22205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.1, tmp@npm:~0.2.1":
+"tmp@npm:^0.2.1":
   version: 0.2.1
   resolution: "tmp@npm:0.2.1"
   dependencies:
@@ -23384,24 +22384,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"treeverse@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "treeverse@npm:2.0.0"
-  checksum: 3c6b2b890975a4d42c86b9a0f1eb932b4450db3fa874be5c301c4f5e306fd76330c6a490cf334b0937b3a44b049787ba5d98c88bc7b140f34fdb3ab1f83e5269
-  languageName: node
-  linkType: hard
-
 "trim-newlines@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "trim-newlines@npm:3.0.0"
-  checksum: ad99b771e7e6fc785cfdd60f3eeb794a6f2f230dd291987107974abd0c95a051d7cf3b6d45b542a59bfe67eb680c5b259ec19741e6fdfdbee0ab783ab8861585
-  languageName: node
-  linkType: hard
-
-"trim-off-newlines@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "trim-off-newlines@npm:1.0.3"
-  checksum: faf042bb7dd4cb097ab6d358cd51012a9ff5e06f7f2c6570da2ef6f01da9da3ff22ab01080866815e3927ffbf367d57c6aab4c275c67662676b60c563142a558
+  version: 3.0.1
+  resolution: "trim-newlines@npm:3.0.1"
+  checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
   languageName: node
   linkType: hard
 
@@ -23482,7 +22468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.3.0":
+"tslib@npm:^2.1.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
@@ -23614,7 +22600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.8.3, typescript@npm:^3 || ^4, typescript@npm:^4.8.3":
+"typescript@npm:4.8.3, typescript@npm:^4.8.3":
   version: 4.8.3
   resolution: "typescript@npm:4.8.3"
   bin:
@@ -23624,7 +22610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@4.8.3#~builtin<compat/typescript>, typescript@patch:typescript@^3 || ^4#~builtin<compat/typescript>, typescript@patch:typescript@^4.8.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@4.8.3#~builtin<compat/typescript>, typescript@patch:typescript@^4.8.3#~builtin<compat/typescript>":
   version: 4.8.3
   resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=a1c5e5"
   bin:
@@ -24036,6 +23022,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"util@npm:^0.10.3":
+  version: 0.10.4
+  resolution: "util@npm:0.10.4"
+  dependencies:
+    inherits: 2.0.3
+  checksum: 913f9a90d05a60e91f91af01b8bd37e06bca4cc02d7b49e01089f9d5b78be2fffd61fb1a41b517de7238c5fc7337fa939c62d1fb4eb82e014894c7bee6637aaf
+  languageName: node
+  linkType: hard
+
 "util@npm:^0.11.0":
   version: 0.11.1
   resolution: "util@npm:0.11.1"
@@ -24151,12 +23146,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
   bin:
     uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 
@@ -24173,13 +23168,6 @@ __metadata:
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
   checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
-  languageName: node
-  linkType: hard
-
-"v8-compile-cache@npm:2.3.0":
-  version: 2.3.0
-  resolution: "v8-compile-cache@npm:2.3.0"
-  checksum: adb0a271eaa2297f2f4c536acbfee872d0dd26ec2d76f66921aa7fc437319132773483344207bdbeee169225f4739016d8d2dbf0553913a52bb34da6d0334f8e
   languageName: node
   linkType: hard
 
@@ -24208,15 +23196,6 @@ __metadata:
     spdx-correct: ^3.0.0
     spdx-expression-parse: ^3.0.0
   checksum: 35703ac889d419cf2aceef63daeadbe4e77227c39ab6287eeb6c1b36a746b364f50ba22e88591f5d017bc54685d8137bc2d328d0a896e4d3fd22093c0f32a9ad
-  languageName: node
-  linkType: hard
-
-"validate-npm-package-name@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "validate-npm-package-name@npm:3.0.0"
-  dependencies:
-    builtins: ^1.0.3
-  checksum: ce4c68207abfb22c05eedb09ff97adbcedc80304a235a0844f5344f1fd5086aa80e4dbec5684d6094e26e35065277b765c1caef68bcea66b9056761eddb22967
   languageName: node
   linkType: hard
 
@@ -24412,13 +23391,6 @@ __metadata:
   dependencies:
     xml-name-validator: ^4.0.0
   checksum: 0af8589942eeb11c9fe29eb31a1a09f3d5dd136aea53a9848dfbabff79ac0dd26fe13eb54d330d5555fe27bb50b28dca0715e09f9cc2bfa7670ccc8b7f919ca2
-  languageName: node
-  linkType: hard
-
-"walk-up-path@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "walk-up-path@npm:1.0.0"
-  checksum: b8019ac4fb9ba1576839ec66d2217f62ab773c1cc4c704bfd1c79b1359fef5366f1382d3ab230a66a14c3adb1bf0fe102d1fdaa3437881e69154dfd1432abd32
   languageName: node
   linkType: hard
 
@@ -25078,7 +24050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^4.0.0, write-file-atomic@npm:^4.0.1":
+"write-file-atomic@npm:^4.0.1, write-file-atomic@npm:^4.0.2":
   version: 4.0.2
   resolution: "write-file-atomic@npm:4.0.2"
   dependencies:
@@ -25275,20 +24247,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:20.2.4":
-  version: 20.2.4
-  resolution: "yargs-parser@npm:20.2.4"
-  checksum: d251998a374b2743a20271c2fd752b9fbef24eb881d53a3b99a7caa5e8227fcafd9abf1f345ac5de46435821be25ec12189a11030c12ee6481fef6863ed8b924
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:21.0.1":
-  version: 21.0.1
-  resolution: "yargs-parser@npm:21.0.1"
-  checksum: c3ea2ed12cad0377ce3096b3f138df8267edf7b1aa7d710cd502fe16af417bafe4443dd71b28158c22fcd1be5dfd0e86319597e47badf42ff83815485887323a
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:^13.1.2":
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
@@ -25309,10 +24267,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
+"yargs-parser@npm:^20.2.2":
   version: 20.2.7
   resolution: "yargs-parser@npm:20.2.7"
   checksum: ec0ea9e1b5699977380583f5ab1c0e2c6fc5f1ed374eb3053c458df00c543effba53628ad3297f3ccc769660518d5e376fd1cfb298b8e37077421aca8d75ae89
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^20.2.3":
+  version: 20.2.9
+  resolution: "yargs-parser@npm:20.2.9"
+  checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
   languageName: node
   linkType: hard
 
@@ -25385,7 +24350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1, yargs@npm:^17.4.0":
+"yargs@npm:^17.3.1, yargs@npm:^17.5.1":
   version: 17.5.1
   resolution: "yargs@npm:17.5.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -20227,6 +20227,7 @@ __metadata:
     lint-staged: 11.1.1
     prettier: 2.3.2
     tsconfig-paths: 3.10.1
+    typescript: ^4.8.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
With the introduction of yarn 2 and its advanced workspace capabilities (like pnpm) we will have an easier time referring to other packages via the workspace protocol (https://yarnpkg.com/features/workspaces#workspace-ranges-workspace).

The following problem occurs now:

Since we use lerna to publish, we rely on lerna to support the new yarn command, that is used to replace the "workspace" version with the latest version numbers. This ticket (https://github.com/lerna/lerna/issues/2564) mentions active work on the feature, but it is two years old, and the feature is not implemented yet.

Since lerna is not very actively maintained and doesn't support newer protocols like "workspaces" from yarn 2 and pnpm, a switch to the actively maintained lerna-lite needs to happen. Lerna-lite takes a new approach to lerna, is fully written in Typescript, includes the workspace - protocol already and is actively maintained (https://github.com/ghiscoding/lerna-lite).

It should be a drop in replacement because lerna-lite uses the workspace-protocol under the hood and recommends using workspaces as dependencies inside the packages (https://github.com/ghiscoding/lerna-lite/tree/main/packages/version#workspace-protocol)

