### PR TITLE
feat: Enable sending hide message to mls conversations

### DIFF
--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -33,7 +33,7 @@ import {
 import {CONVERSATION_TYPING, ConversationMemberUpdateData} from '@wireapp/api-client/src/conversation/data';
 import {ConversationMemberLeaveEvent} from '@wireapp/api-client/src/event';
 import {QualifiedId, QualifiedUserPreKeyBundleMap, UserPreKeyBundleMap} from '@wireapp/api-client/src/user';
-import {Cleared, DataTransfer, GenericMessage, LastRead, MessageHide} from '@wireapp/protocol-messaging';
+import {Cleared, DataTransfer, GenericMessage, LastRead} from '@wireapp/protocol-messaging';
 
 import {
   GenericMessageType,
@@ -43,7 +43,7 @@ import {
   PayloadBundleType,
   RemoveUsersParams,
 } from '../../conversation/';
-import {ClearedContent, HiddenContent, RemoteData} from '../content';
+import {ClearedContent, RemoteData} from '../content';
 import {CryptographyService} from '../../cryptography/';
 import {MLSService} from '../../mls';
 import {NotificationService} from '../../notification';
@@ -51,7 +51,7 @@ import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {isStringArray, isQualifiedIdArray, isQualifiedUserClients, isUserClients} from '../../util/TypePredicateUtil';
 import {MessageBuilder} from '../message/MessageBuilder';
 import {MessageService} from '../message/MessageService';
-import {ClearConversationMessage, HideMessage, OtrMessage} from '../message/OtrMessage';
+import {ClearConversationMessage, OtrMessage} from '../message/OtrMessage';
 import {XOR} from '@wireapp/commons/src/main/util/TypeUtil';
 import {
   AddUsersParams,

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -457,44 +457,6 @@ export class ConversationService {
     return qualifiedUserClients;
   }
 
-  public async deleteMessageLocal(
-    conversationId: string,
-    messageIdToHide: string,
-    sendAsProtobuf?: boolean,
-    conversationDomain?: string,
-  ): Promise<HideMessage> {
-    const messageId = MessageBuilder.createId();
-
-    const content: HiddenContent = MessageHide.create({
-      conversationId,
-      messageId: messageIdToHide,
-    });
-
-    const genericMessage = GenericMessage.create({
-      [GenericMessageType.HIDDEN]: content,
-      messageId,
-    });
-
-    const {id: selfConversationId} = await this.getSelfConversationId();
-
-    await this.sendGenericMessage(this.apiClient.validatedClientId, selfConversationId, genericMessage, {
-      sendAsProtobuf,
-      conversationDomain,
-    });
-
-    return {
-      content,
-      conversation: conversationId,
-      from: this.apiClient.context!.userId,
-      id: messageId,
-      messageTimer: this.messageTimer.getMessageTimer(conversationId),
-      source: PayloadBundleSource.LOCAL,
-      state: PayloadBundleState.OUTGOING_SENT,
-      timestamp: Date.now(),
-      type: PayloadBundleType.MESSAGE_HIDE,
-    };
-  }
-
   /**
    * Create a group conversation.
    * @param  {string} name

--- a/packages/core/src/main/conversation/ConversationService/messageGenerator.ts
+++ b/packages/core/src/main/conversation/ConversationService/messageGenerator.ts
@@ -28,6 +28,7 @@ import {
   FileAssetAbortMessage,
   FileAssetMessage,
   FileAssetMetaDataMessage,
+  HideMessage,
   ImageAssetMessageOutgoing,
   LocationMessage,
   OtrMessage,
@@ -50,6 +51,7 @@ import {
   Location,
   MessageDelete,
   MessageEdit,
+  MessageHide,
   Reaction,
 } from '@wireapp/protocol-messaging';
 import {PayloadBundleType} from '../message/PayloadBundle';
@@ -99,9 +101,10 @@ export function generateGenericMessage<T extends OtrMessage>(
       return {genericMessage: generateReactionGenericMessage(payload), content};
     case PayloadBundleType.TEXT:
       return {genericMessage: generateTextGenericMessage(payload, messageTimer), content};
-
     case PayloadBundleType.MESSAGE_DELETE:
       return {genericMessage: generateDeleteMessage(payload), content};
+    case PayloadBundleType.MESSAGE_HIDE:
+      return {genericMessage: generateHideMessage(payload), content};
 
     /**
      * ToDo: Create Generic implementation for everything else
@@ -342,6 +345,18 @@ function generateDeleteMessage(payload: DeleteMessage): GenericMessage {
 
   return GenericMessage.create({
     [GenericMessageType.DELETED]: content,
+    messageId: payload.id,
+  });
+}
+
+function generateHideMessage(payload: HideMessage): GenericMessage {
+  const content = MessageHide.create({
+    messageId: payload.content.messageId,
+    conversationId: payload.content.conversationId,
+  });
+
+  return GenericMessage.create({
+    [GenericMessageType.HIDDEN]: content,
     messageId: payload.id,
   });
 }

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -65,7 +65,7 @@ interface CreateMessageDeleteOption extends BaseOptions {
 
 interface CreateMessageHideOption extends BaseOptions {
   messageIdToDelete: string;
-  conversationId: string;
+  targetConversation: string;
 }
 
 interface CreateImageOptions extends BaseOptions {
@@ -196,7 +196,7 @@ export class MessageBuilder {
   public static createMessageHide(payload: CreateMessageHideOption): HideMessage {
     return {
       ...createCommonProperties(payload),
-      content: {messageId: payload.messageIdToDelete, conversationId: payload.conversationId},
+      content: {messageId: payload.messageIdToDelete, conversationId: payload.targetConversation},
       type: PayloadBundleType.MESSAGE_HIDE,
     };
   }

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -44,6 +44,7 @@ import {
   FileAssetAbortMessage,
   FileAssetMessage,
   FileAssetMetaDataMessage,
+  HideMessage,
   ImageAssetMessageOutgoing,
   LocationMessage,
   PingMessage,
@@ -58,8 +59,13 @@ interface BaseOptions {
   messageId?: string;
 }
 
-interface CreateDeleteOption extends BaseOptions {
+interface CreateMessageDeleteOption extends BaseOptions {
   messageIdToDelete: string;
+}
+
+interface CreateMessageHideOption extends BaseOptions {
+  messageIdToDelete: string;
+  conversationId: string;
 }
 
 interface CreateImageOptions extends BaseOptions {
@@ -179,11 +185,19 @@ export class MessageBuilder {
     };
   }
 
-  public static createDelete(payload: CreateDeleteOption): DeleteMessage {
+  public static createMessageDelete(payload: CreateMessageDeleteOption): DeleteMessage {
     return {
       ...createCommonProperties(payload),
       content: {messageId: payload.messageIdToDelete},
       type: PayloadBundleType.MESSAGE_DELETE,
+    };
+  }
+
+  public static createMessageHide(payload: CreateMessageHideOption): HideMessage {
+    return {
+      ...createCommonProperties(payload),
+      content: {messageId: payload.messageIdToDelete, conversationId: payload.conversationId},
+      type: PayloadBundleType.MESSAGE_HIDE,
     };
   }
 


### PR DESCRIPTION
This will allow the consumer to send `hide` message even in MLS conversations 

BREAKING CHANGES: the `deleteMessageLocal` method has been removed. You should now use the `send` method in combinaison with `MessageBuilder.buildHideMessage` 
`MessageBuilder.createDelete` has been renamed `MessageBuilder.createMessageDelete`
