### PR TITLE
chore: avoid running build twice for each package

### DIFF
--- a/bin/testUpdated.js
+++ b/bin/testUpdated.js
@@ -33,8 +33,5 @@ const changedPackages = JSON.parse(output.toString());
 const packageNames = changedPackages.map(project => project.name);
 
 const scopes = packageNames.map(packageName => `--scope ${packageName}`).join(' ');
-console.info(`Building packages "${scopes}"`);
-execSync(`npx lerna run dist --include-dependencies ${scopes}`, {stdio: [0, 1]});
-
 console.info(`Running tests for packages "${packageNames}"...`);
 execSync(`npx lerna run test --no-sort --concurrency 1 ${scopes}`, {stdio: [0, 1]});

--- a/packages/certificate-check/package.json
+++ b/packages/certificate-check/package.json
@@ -25,7 +25,7 @@
     "build": "tsc",
     "clean": "rimraf \"src/*.{js?(.map),d.ts}\"",
     "dist": "yarn clean && yarn build",
-    "test": "yarn test:node",
+    "test": "yarn build && yarn test:node",
     "test:project": "yarn dist && yarn test",
     "test:node": "nyc jasmine --config=jasmine.json",
     "prepare": "yarn dist"


### PR DESCRIPTION
Right now build is actually ran 3 times:
- one in the testUpdated.js script (we build all the changed packages)
- one for each package test (some test script build their own version before actually testing)
- when releasing. 

We can remove the build from the testUpdated.js since the packages are now responsible for building (if they need to) when `yarn test` is called