### PR TITLE
fix(ui-kit): Proper use of forwardRef for RangeInput

### DIFF
--- a/packages/react-ui-kit/src/Form/RangeInput.tsx
+++ b/packages/react-ui-kit/src/Form/RangeInput.tsx
@@ -38,19 +38,21 @@ export interface RangeInputProps<T = HTMLInputElement> extends TextProps<T> {
 }
 
 export const RangeInput: FC<RangeInputProps> = forwardRef<HTMLInputElement, RangeInputProps<HTMLInputElement>>(
-  ({
+  (
+    {
+      id = Math.random().toString(),
+      label,
+      minValueLabel,
+      maxValueLabel,
+      min = '0',
+      max = '100',
+      value = '0',
+      onChange,
+      wrapperCSS,
+      ...inputProps
+    },
     ref,
-    id = Math.random().toString(),
-    label,
-    minValueLabel,
-    maxValueLabel,
-    min = '0',
-    max = '100',
-    value = '0',
-    onChange,
-    wrapperCSS,
-    ...inputProps
-  }) => {
+  ) => {
     const minNum = Number(min);
     const maxNum = Number(max);
     const valueNum = Number(value);


### PR DESCRIPTION
This will remove the `Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?` for the RangeInput component. 

