### PR TITLE
fix(api-client): Add flag to use dev version of the api

### DIFF
--- a/packages/api-client/src/APIClient.test.node.ts
+++ b/packages/api-client/src/APIClient.test.node.ts
@@ -112,6 +112,39 @@ describe('APIClient', () => {
       expect(federationEndpoints).toBe(true);
     });
 
+    it('uses version dev version if available and requested', async () => {
+      nock(baseUrl)
+        .get('/api-version')
+        .reply(200, {supported: [0, 1], development: [2]});
+      const client = new APIClient();
+      const {version, isFederated, federationEndpoints} = await client.useVersion([0, 1, 2], true);
+      expect(version).toBe(2);
+      expect(isFederated).toBe(false);
+      expect(federationEndpoints).toBe(true);
+    });
+
+    it('ignores dev version if not requested', async () => {
+      nock(baseUrl)
+        .get('/api-version')
+        .reply(200, {supported: [0, 1], development: [2]});
+      const client = new APIClient();
+      const {version, isFederated, federationEndpoints} = await client.useVersion([0, 1, 2], false);
+      expect(version).toBe(1);
+      expect(isFederated).toBe(false);
+      expect(federationEndpoints).toBe(true);
+    });
+
+    it('ignores dev version if not listed in the supported versions', async () => {
+      nock(baseUrl)
+        .get('/api-version')
+        .reply(200, {supported: [0, 1], development: [2]});
+      const client = new APIClient();
+      const {version, isFederated, federationEndpoints} = await client.useVersion([0, 1], true);
+      expect(version).toBe(1);
+      expect(isFederated).toBe(false);
+      expect(federationEndpoints).toBe(true);
+    });
+
     it('returns the backend federation state', async () => {
       const response: BackendVersionResponse = {supported: [0, 1], federation: true};
       nock(baseUrl).get('/api-version').reply(200, response);

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -235,9 +235,14 @@ export class APIClient extends EventEmitter {
    * Will set the APIClient to use a specific version of the API (by default uses version 0)
    * It will fetch the API Config and use the highest possible version
    * @param acceptedVersions Which version the consumer supports
+   * @param useDevVersion allow the api-client to use development version of the api (if present). The dev version also need to be listed on the supportedVersions given as parameters
+   *   If we have version 2 that is a dev version, this is going to be the output of those calls
+   *   - useVersion([0, 1, 2], true) > version 2 is used
+   *   - useVersion([0, 1, 2], false) > version 1 is used
+   *   - useVersion([0, 1], true) > version 1 is used
    * @return The highest version that is both supported by client and backend
    */
-  async useVersion(acceptedVersions: number[]): Promise<BackendFeatures> {
+  async useVersion(acceptedVersions: number[], useDevVersion = false): Promise<BackendFeatures> {
     if (acceptedVersions.length === 1 && acceptedVersions[0] === 0) {
       // Nothing to do since version 0 is the default one
       return this.computeBackendFeatures(0);
@@ -246,7 +251,7 @@ export class APIClient extends EventEmitter {
     try {
       backendVersions = (await this.transport.http.sendRequest<BackendVersionResponse>({url: '/api-version'})).data;
     } catch (error) {}
-    const devVersions = backendVersions.development ?? [];
+    const devVersions = useDevVersion ? backendVersions.development ?? [] : [];
     const highestCommonVersion = backendVersions.supported
       .concat(devVersions)
       .sort()


### PR DESCRIPTION
BREAKING CHANGE: The APIClient would, initially, always consider the development version when calling `useVersion`. Now, to actually use bleeding edge version of the backend API a new flag needs to be provided