### PR TITLE
fix: Avoid message gaps during websocket connection

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -341,7 +341,7 @@ export class APIClient extends EventEmitter {
     delete this.context;
   }
 
-  public connect(onConnect?: OnConnect): Promise<WebSocketClient> {
+  public connect(onConnect?: OnConnect): WebSocketClient {
     return this.transport.ws.connect(this.context?.clientId, onConnect);
   }
 


### PR DESCRIPTION
This changes the behavior of the initial connection to the websocket. 

Currently the flow goes like this:
- we call `onConnect` function (which will download the notification stream);
- we connect to the websocket (not waiting for the notification stream to have been fully parsed)

So in between the time we start processing the notification stream and the time the websocket is connected, we could potentially miss messages. 

Let's take a example to illustrate this (x axis is time):

```text
ws:                  --1----2-------
message:             -----1---------
notif stream:        -1-------2-----
```

- we start the connection flow
- `ws 1`: websocket connection starts
- `notif stream 1`: we start downloading the notification stream
- `message 1`: one message has been sent to this device
- `ws 2`: the websocket connection is up but `message1` has been sent before
- `notif stream 2`: the notification stream has been processed but `message1` was sent after the download

This change makes sure the websocket connection is fully live before downloading the notification stream

```text
ws:                  --1----2---------
message:             -----1-----------
notif stream:        --------1-------2
```

Since we download the notification stream **only** after the websocket is fully connected the `message1` will appear in the notification stream (since we download the notification stream slightly later). We then fill the gap where message could be lost.
