### PR TITLE
chore(api-client): Remove ui-kit from api-client deps

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -30,7 +30,6 @@
     "@types/spark-md5": "3.0.2",
     "@types/tough-cookie": "4.0.1",
     "@types/ws": "7.4.7",
-    "@wireapp/react-ui-kit": "workspace:^",
     "@wireapp/store-engine": "workspace:^",
     "@wireapp/store-engine-fs": "workspace:^",
     "babel-loader": "8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5462,7 +5462,6 @@ __metadata:
     "@wireapp/commons": "workspace:^"
     "@wireapp/priority-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.38.0
-    "@wireapp/react-ui-kit": "workspace:^"
     "@wireapp/store-engine": "workspace:^"
     "@wireapp/store-engine-fs": "workspace:^"
     axios: 0.21.4
@@ -5900,7 +5899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wireapp/react-ui-kit@workspace:^, @wireapp/react-ui-kit@workspace:packages/react-ui-kit":
+"@wireapp/react-ui-kit@workspace:packages/react-ui-kit":
   version: 0.0.0-use.local
   resolution: "@wireapp/react-ui-kit@workspace:packages/react-ui-kit"
   dependencies:


### PR DESCRIPTION
This should improve the workflow when updating the `ui-kit` (we won't have to build both the `core` and `api-client` whenever the ui-kit is updated)

Since #4420 the ui-kit is not used anymore on the `api-client` side