### PR TITLE
refactor: extract lastRead, cleared and DataTransfer message from ConversationService

### DIFF
--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -68,7 +68,6 @@ type SendResult = {
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
   private readonly messageService: MessageService;
-  private selfConversationId?: QualifiedId;
 
   constructor(
     private readonly apiClient: APIClient,
@@ -176,16 +175,6 @@ export class ConversationService {
       }
       return bundleMap;
     }, {});
-  }
-
-  private async getSelfConversationId(): Promise<QualifiedId> {
-    if (!this.selfConversationId) {
-      const {userId} = this.apiClient.context!;
-      const {qualified_id, id} = await this.apiClient.api.conversation.getConversation(userId);
-      const domain = this.config.useQualifiedIds ? qualified_id.domain : '';
-      this.selfConversationId = {id, domain};
-    }
-    return this.selfConversationId;
   }
 
   private async getQualifiedRecipientsForConversation(

--- a/packages/core/src/main/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/main/conversation/ConversationService/ConversationService.ts
@@ -33,25 +33,16 @@ import {
 import {CONVERSATION_TYPING, ConversationMemberUpdateData} from '@wireapp/api-client/src/conversation/data';
 import {ConversationMemberLeaveEvent} from '@wireapp/api-client/src/event';
 import {QualifiedId, QualifiedUserPreKeyBundleMap, UserPreKeyBundleMap} from '@wireapp/api-client/src/user';
-import {Cleared, DataTransfer, GenericMessage, LastRead} from '@wireapp/protocol-messaging';
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
-import {
-  GenericMessageType,
-  MessageTimer,
-  PayloadBundleSource,
-  PayloadBundleState,
-  PayloadBundleType,
-  RemoveUsersParams,
-} from '../../conversation/';
-import {ClearedContent, RemoteData} from '../content';
+import {MessageTimer, PayloadBundleState, RemoveUsersParams} from '../../conversation/';
+import {RemoteData} from '../content';
 import {CryptographyService} from '../../cryptography/';
 import {MLSService} from '../../mls';
 import {NotificationService} from '../../notification';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {isStringArray, isQualifiedIdArray, isQualifiedUserClients, isUserClients} from '../../util/TypePredicateUtil';
-import {createId} from '../message/MessageBuilder';
 import {MessageService} from '../message/MessageService';
-import {ClearConversationMessage} from '../message/OtrMessage';
 import {XOR} from '@wireapp/commons/src/main/util/TypeUtil';
 import {
   AddUsersParams,
@@ -301,102 +292,6 @@ export class ConversationService {
       }, []);
     }
     return userIds;
-  }
-
-  public async clearConversation(
-    conversationId: string,
-    timestamp: number | Date = new Date(),
-    messageId: string = createId(),
-    sendAsProtobuf?: boolean,
-  ): Promise<ClearConversationMessage> {
-    if (timestamp instanceof Date) {
-      timestamp = timestamp.getTime();
-    }
-
-    const content: ClearedContent = {
-      clearedTimestamp: timestamp,
-      conversationId,
-    };
-
-    const clearedMessage = Cleared.create(content);
-
-    const genericMessage = GenericMessage.create({
-      [GenericMessageType.CLEARED]: clearedMessage,
-      messageId,
-    });
-
-    const selfConversationId = await this.getSelfConversationId();
-
-    await this.sendGenericMessage(selfConversationId, this.apiClient.validatedClientId, genericMessage, {
-      sendAsProtobuf,
-    });
-
-    return {
-      content,
-      conversation: conversationId,
-      from: this.apiClient.context!.userId,
-      id: messageId,
-      messageTimer: 0,
-      source: PayloadBundleSource.LOCAL,
-      state: PayloadBundleState.OUTGOING_SENT,
-      timestamp: Date.now(),
-      type: PayloadBundleType.CONVERSATION_CLEAR,
-    };
-  }
-
-  /**
-   * Sends a LastRead message to the current user's self conversation.
-   * This will allow all the user's devices to compute which messages are unread
-   *
-   * @param conversationId The conversation which has been read
-   * @param lastReadTimestamp The timestamp at which the conversation was read
-   * @param sendingOptions?
-   * @return Resolves when the message has been sent
-   */
-  public async sendLastRead(
-    conversationId: QualifiedId,
-    lastReadTimestamp: number,
-    sendingOptions?: MessageSendingOptions,
-  ) {
-    const lastRead = new LastRead({
-      conversationId: conversationId.id,
-      lastReadTimestamp,
-    });
-
-    const genericMessage = GenericMessage.create({
-      [GenericMessageType.LAST_READ]: lastRead,
-      messageId: createId(),
-    });
-
-    const selfConversationId = await this.getSelfConversationId();
-
-    return this.sendGenericMessage(selfConversationId, this.apiClient.validatedClientId, genericMessage, {
-      ...sendingOptions,
-    });
-  }
-
-  /**
-   * Syncs all self user's devices with the countly id
-   *
-   * @param countlyId The countly id of the current device
-   * @param sendingOptions?
-   * @return Resolves when the message has been sent
-   */
-  public async sendCountlySync(countlyId: string, sendingOptions: MessageSendingOptions) {
-    const dataTransfer = new DataTransfer({
-      trackingIdentifier: {
-        identifier: countlyId,
-      },
-    });
-    const genericMessage = new GenericMessage({
-      [GenericMessageType.DATA_TRANSFER]: dataTransfer,
-      messageId: createId(),
-    });
-
-    const selfConversationId = await this.getSelfConversationId();
-    return this.sendGenericMessage(selfConversationId, this.apiClient.validatedClientId, genericMessage, {
-      ...sendingOptions,
-    });
   }
 
   /**

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -46,6 +46,7 @@ import {
   ClientAction,
   Composite,
   Confirmation,
+  DataTransfer,
   Ephemeral,
   GenericMessage,
   Knock,
@@ -54,10 +55,13 @@ import {
   MessageEdit,
   MessageHide,
   Reaction,
+  LastRead,
+  Cleared,
 } from '@wireapp/protocol-messaging';
 import {MessageToProtoMapper} from '../message/MessageToProtoMapper';
 import {GenericMessageType} from '../GenericMessageType';
 import {AssetTransferState} from '../AssetTransferState';
+import {QualifiedId} from '@wireapp/api-client/src/user';
 
 export function createId() {
   return UUID.genV4().toString();
@@ -186,6 +190,43 @@ export function buildFileAbortMessage(
   });
 
   return genericMessage;
+}
+
+export function buildLastRead(conversationId: QualifiedId, lastReadTimestamp: number) {
+  const lastRead = new LastRead({
+    conversationId: conversationId.id,
+    lastReadTimestamp,
+  });
+
+  return GenericMessage.create({
+    [GenericMessageType.LAST_READ]: lastRead,
+    messageId: createId(),
+  });
+}
+
+export function buildDataTransfer(identifier: string) {
+  const dataTransfer = new DataTransfer({
+    trackingIdentifier: {
+      identifier,
+    },
+  });
+
+  return new GenericMessage({
+    [GenericMessageType.DATA_TRANSFER]: dataTransfer,
+    messageId: createId(),
+  });
+}
+
+export function buildClearedMessage(conversationId: QualifiedId, timestamp: number = Date.now()) {
+  const clearedMessage = Cleared.create({
+    clearedTimestamp: timestamp,
+    conversationId: conversationId.id,
+  });
+
+  return GenericMessage.create({
+    [GenericMessageType.CLEARED]: clearedMessage,
+    messageId: createId(),
+  });
 }
 
 export function buildImageMessage(

--- a/packages/core/src/main/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/main/conversation/message/MessageBuilder.ts
@@ -192,7 +192,7 @@ export function buildFileAbortMessage(
   return genericMessage;
 }
 
-export function buildLastRead(conversationId: QualifiedId, lastReadTimestamp: number) {
+export function buildLastReadMessage(conversationId: QualifiedId, lastReadTimestamp: number) {
   const lastRead = new LastRead({
     conversationId: conversationId.id,
     lastReadTimestamp,
@@ -204,7 +204,7 @@ export function buildLastRead(conversationId: QualifiedId, lastReadTimestamp: nu
   });
 }
 
-export function buildDataTransfer(identifier: string) {
+export function buildDataTransferMessage(identifier: string) {
   const dataTransfer = new DataTransfer({
     trackingIdentifier: {
       identifier,


### PR DESCRIPTION
BREAKING CHANGE: The `sendLastRead`, `SendCountly` and `clearConversation` methods have been removed in favor of using the regular message sending method `send`. You now need to use the `MessageBuilder` and the `send` method to send those types of messages. `conversationService.send({payload: MessageBuilder.buildClearedMessage(conversationId) ...})`