### PR TITLE
fix: Avoid unlocking websocket when connection is aborted

### DIFF
--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -64,7 +64,7 @@ export class CryptographyService {
   ) {
     this.cryptobox = new Cryptobox(this.storeEngine, config.nbPrekeys);
     this.database = new CryptographyDatabaseRepository(this.storeEngine);
-    this.logger = logdown('@wireapp/core/cryptography/CryptographyService', {
+    this.logger = logdown('@wireapp/core/CryptographyService', {
       logger: console,
       markdown: false,
     });

--- a/packages/core/src/main/cryptography/GenericMessageMapper.ts
+++ b/packages/core/src/main/cryptography/GenericMessageMapper.ts
@@ -40,7 +40,7 @@ import {
 } from '../conversation/content';
 
 export class GenericMessageMapper {
-  private static readonly logger = logdown('@wireapp/core/cryptography/GenericMessageMapper', {
+  private static readonly logger = logdown('@wireapp/core/GenericMessageMapper', {
     logger: console,
     markdown: false,
   });

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -73,7 +73,7 @@ export class NotificationService extends EventEmitter {
   private readonly backend: NotificationBackendRepository;
   private readonly cryptographyService: CryptographyService;
   private readonly database: NotificationDatabaseRepository;
-  private readonly logger = logdown('@wireapp/core/notification/NotificationService', {
+  private readonly logger = logdown('@wireapp/core/NotificationService', {
     logger: console,
     markdown: false,
   });
@@ -92,10 +92,9 @@ export class NotificationService extends EventEmitter {
     this.database = new NotificationDatabaseRepository(storeEngine);
   }
 
-  private async getAllNotifications() {
+  private async getAllNotifications(since: string) {
     const clientId = this.apiClient.clientId;
-    const lastNotificationId = await this.database.getLastNotificationId();
-    return this.backend.getAllNotifications(clientId, lastNotificationId);
+    return this.backend.getAllNotifications(clientId, since);
   }
 
   /** Should only be called with a completely new client. */
@@ -141,28 +140,44 @@ export class NotificationService extends EventEmitter {
     return this.database.updateLastNotificationId(lastNotification);
   }
 
-  public async handleNotificationStream(
+  public async processNotificationStream(
     notificationHandler: NotificationHandler,
     onMissedNotifications: (notificationId: string) => void,
     abortHandler: AbortHandler,
-  ): Promise<void> {
-    const {notifications, missedNotification} = await this.getAllNotifications();
+  ): Promise<{total: number; error: number; success: number}> {
+    const lastNotificationId = await this.database.getLastNotificationId();
+    const {notifications, missedNotification} = await this.getAllNotifications(lastNotificationId);
     if (missedNotification) {
       onMissedNotifications(missedNotification);
     }
 
+    const results = {total: notifications.length, error: 0, success: 0};
+    const logMessage =
+      notifications.length > 0
+        ? `Start processing ${notifications.length} notification since notification id ${lastNotificationId}`
+        : `No notification to process from the stream`;
+    this.logger.log(logMessage);
     for (const [index, notification] of notifications.entries()) {
       if (abortHandler.isAborted()) {
         /* Stop handling notifications if the websocket has been disconnected.
          * Upon reconnecting we are going to restart handling the notification stream for where we left of
          */
-        return;
+        this.logger.warn(`Stop processing notifications as connection to websocket was closed`);
+        return results;
       }
-      await notificationHandler(notification, PayloadBundleSource.NOTIFICATION_STREAM, {
-        done: index + 1,
-        total: notifications.length,
-      }).catch(error => this.logger.error(error));
+      try {
+        await notificationHandler(notification, PayloadBundleSource.NOTIFICATION_STREAM, {
+          done: index + 1,
+          total: notifications.length,
+        });
+        results.success++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : error;
+        this.logger.error(`Error while processing notification ${notification.id}: ${message}`, error);
+        results.error++;
+      }
     }
+    return results;
   }
 
   /**

--- a/packages/core/src/main/notification/NotificationService.ts
+++ b/packages/core/src/main/notification/NotificationService.ts
@@ -154,7 +154,7 @@ export class NotificationService extends EventEmitter {
     const results = {total: notifications.length, error: 0, success: 0};
     const logMessage =
       notifications.length > 0
-        ? `Start processing ${notifications.length} notification since notification id ${lastNotificationId}`
+        ? `Start processing ${notifications.length} notifications since notification id ${lastNotificationId}`
         : `No notification to process from the stream`;
     this.logger.log(logMessage);
     for (const [index, notification] of notifications.entries()) {

--- a/packages/core/src/main/util/TaskScheduler/TaskScheduler.ts
+++ b/packages/core/src/main/util/TaskScheduler/TaskScheduler.ts
@@ -19,7 +19,7 @@
 
 import logdown from 'logdown';
 
-const logger = logdown('@wireapp/core/util/TaskScheduler/TaskScheduler', {
+const logger = logdown('@wireapp/core/TaskScheduler', {
   logger: console,
   markdown: false,
 });


### PR DESCRIPTION
We have identified a potential missing message gap in the handling of the notification stream. 

Here is the full explanation for this:

We we connect to the websocket, the very first thing we do is locking the websocket (so that no message coming in will be parsed before the notification stream). 
Once locked we start processing the notifications given by the `/notifications` endpoint one by one. 

**Here is the catch** if, somehow, the websocket loses the connection **while** we are processing the notification stream, we are going to cancel the notification handling process **BUT** we are not going to avoid `unlocking` the websocket. 

As a result, if ever, there were some messages buffered in the websocket, they are going to be released at this point but we will still have missed the notifications thats were canceled before. 

Here is a concrete example:

- I regain internet connection 
- the websocket connects successfully
- we have 10 notifications that we fetch from backend
- while processing the notifications, we receive 1 notification from the websocket
- at notification 5, the websocket connection is lost (bad internet, backend issue...)
- we cancel the notification handling process (there are still 5 other notifications to process)
- we release the websocket (as well as the 1 message stuck in the websocket buffer)
- the webapp processes this buffered message
-> we now store the last notification ID as the last message from the websocket. This will discard any previous notification that we haven't processed (the 5 notifications that we canceled).

This is coherent with report logs we got
![Screenshot 2022-10-12 at 16 28 24](https://user-images.githubusercontent.com/1090716/195370992-4c21cb56-45f3-4788-a5b7-fed4bb913564.png)
