### PR TITLE
feat: Gracefully handle mls protocol messages

### DIFF
--- a/packages/core/src/main/mls/MLSService/MLSService.ts
+++ b/packages/core/src/main/mls/MLSService/MLSService.ts
@@ -134,6 +134,10 @@ export class MLSService {
     return coreCryptoKeyPackagesPayload;
   }
 
+  public getEpoch(groupId: Uint8Array) {
+    return this.getCoreCryptoClient().conversationEpoch(groupId);
+  }
+
   public async newProposal(proposalType: ProposalType, args: ProposalArgs | AddProposalArgs | RemoveProposalArgs) {
     return this.getCoreCryptoClient().newProposal(proposalType, args);
   }


### PR DESCRIPTION
This will prevent coreCrypto specific messages to be sent back to the consumer. 
They need to stay completely opaque to coreCrypto and don't have any application value. 

This PR also improves the logs and display the new epoch when receiving a commit