### PR TITLE
runfix: rename system crypto config

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -441,8 +441,8 @@ export class Account<T = any> extends EventEmitter {
     const {CoreCrypto} = await import('@wireapp/core-crypto');
     const dbName = this.generateSecretsDbName(context);
 
-    const secretStore = mlsConfig.secretsCrypto
-      ? await createCustomEncryptedStore(dbName, mlsConfig.secretsCrypto)
+    const secretStore = mlsConfig.systemCrypto
+      ? await createCustomEncryptedStore(dbName, mlsConfig.systemCrypto)
       : await createEncryptedStore(dbName);
 
     let key = await secretStore.getsecretValue(coreCryptoKeyId);

--- a/packages/core/src/main/mls/types.ts
+++ b/packages/core/src/main/mls/types.ts
@@ -40,7 +40,7 @@ export interface MLSConfig<T = any> {
    * encrypt/decrypt function pair that will be called before storing/fetching secrets in the secrets database.
    * If not provided will use the built in encryption mechanism
    */
-  secretsCrypto?: SecretCrypto<T>;
+  systemCrypto?: SecretCrypto<T>;
 
   /**
    * path on the public server to the core crypto wasm file.


### PR DESCRIPTION
Rename `secretsCrypto` to `systemCrypto`, see https://github.com/wireapp/wire-desktop/pull/6094
