### PR TITLE
feat: Session creation callbacks

### DIFF
--- a/packages/api-client/src/client/ClientClassification.ts
+++ b/packages/api-client/src/client/ClientClassification.ts
@@ -22,4 +22,5 @@ export enum ClientClassification {
   LEGAL_HOLD = 'legalhold',
   PHONE = 'phone',
   TABLET = 'tablet',
+  UNKNOWN = '?',
 }

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -134,7 +134,7 @@ interface AccountOptions<T> {
 }
 
 type InitOptions = {
-  /** cookie  */
+  /** cookie used to identify the current user. Will use the browser cookie if not defined */
   cookie?: Cookie;
 
   /** fully initiate the client and register periodic checks */

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -141,10 +141,10 @@ type InitOptions = {
   initClient?: boolean;
 
   /**
-   * callback triggered when a new session between 2 devices is created.
-   * This happens when receiving a message from a device that doesn't already have an established session
+   * callback triggered when a message from an unknown client is received.
+   * An unknown client is a client we don't yet have a session with
    */
-  onNewSession?: (sessionId: SessionId) => void;
+  onNewClient?: (sessionId: SessionId) => void;
 };
 
 const coreDefaultClient: ClientInfo = {
@@ -245,7 +245,7 @@ export class Account<T = any> extends EventEmitter {
    */
   public async init(
     clientType: ClientType,
-    {cookie, initClient = true, onNewSession}: InitOptions = {},
+    {cookie, initClient = true, onNewClient}: InitOptions = {},
   ): Promise<Context> {
     const context = await this.apiClient.init(clientType, cookie);
     await this.initServices(context);
@@ -258,7 +258,7 @@ export class Account<T = any> extends EventEmitter {
         this.logger.debug(`Successfully uploaded '${prekeys.length}' PreKeys.`);
       },
 
-      onNewSession,
+      onNewSession: onNewClient,
     });
 
     // Assumption: client gets only initialized once

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -250,6 +250,12 @@ export class Account<T = any> extends EventEmitter {
     const context = await this.apiClient.init(clientType, cookie);
     await this.initServices(context);
 
+    /** @fixme
+     * When we will start migrating to CoreCrypto encryption/decryption, those hooks won't be available anymore
+     * We will need to implement
+     *   - the mechanism to handle messages from an unknown sender
+     *   - the mechanism to generate new prekeys when we reach a certain threshold of prekeys
+     */
     this.service!.cryptography.setCryptoboxHooks({
       onNewPrekeys: async prekeys => {
         this.logger.debug(`Received '${prekeys.length}' new PreKeys.`);
@@ -264,6 +270,7 @@ export class Account<T = any> extends EventEmitter {
     // Assumption: client gets only initialized once
     if (initClient) {
       await this.initClient({clientType});
+
       if (this.mlsConfig) {
         // initialize schedulers for pending mls proposals once client is initialized
         await this.service?.notification.checkExistingPendingProposals();

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -63,13 +63,20 @@ describe('CryptographyService', () => {
     });
   });
 
-  describe('"constructSessionId"', () => {
+  describe('constructSessionId & parseSessionId', () => {
     it('constructs a Session ID by a given User ID and Client ID.', () => {
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
       const actual = cryptographyService.constructSessionId(userId, clientId);
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);
+
+      const parsedSessionId = cryptographyService.parseSessionId(actual);
+      expect(parsedSessionId).toEqual({
+        userId,
+        clientId,
+        domain: undefined,
+      });
     });
 
     it('constructs a Session ID by a given User ID and Client ID and domain.', async () => {
@@ -79,10 +86,18 @@ describe('CryptographyService', () => {
       });
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
-      const actual = cryptographyService.constructSessionId(userId, clientId, 'test.wire.link');
+      const domain = 'test.wire.link';
+      const actual = cryptographyService.constructSessionId(userId, clientId, domain);
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);
-      expect(actual).toContain('test.wire.link');
+      expect(actual).toContain(domain);
+
+      const parsedSessionId = cryptographyService.parseSessionId(actual);
+      expect(parsedSessionId).toEqual({
+        userId,
+        clientId,
+        domain,
+      });
     });
 
     it('constructs a qualified Session ID by a given qualified User ID and Client ID.', async () => {
@@ -92,10 +107,18 @@ describe('CryptographyService', () => {
       });
       const clientId = '1ceb9063fced26d3';
       const userId = 'afbb5d60-1187-4385-9c29-7361dea79647';
-      const actual = cryptographyService.constructSessionId({id: userId, domain: 'test.wire.link'}, clientId);
+      const domain = 'test.wire.link';
+      const actual = cryptographyService.constructSessionId({id: userId, domain}, clientId);
       expect(actual).toContain(clientId);
       expect(actual).toContain(userId);
-      expect(actual).toContain('test.wire.link');
+      expect(actual).toContain(domain);
+
+      const parsedSessionId = cryptographyService.parseSessionId(actual);
+      expect(parsedSessionId).toEqual({
+        userId,
+        clientId,
+        domain,
+      });
     });
   });
 

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -120,6 +120,12 @@ describe('CryptographyService', () => {
         domain,
       });
     });
+
+    it('fails to parse wrongly formatted session Id', () => {
+      expect(() => {
+        cryptographyService.parseSessionId('jfkdsmqfd');
+      }).toThrow(Error);
+    });
   });
 
   describe('"decrypt"', () => {

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -117,7 +117,7 @@ export class CryptographyService {
   }) {
     if (onNewPrekeys) {
       this.cryptobox.on(Cryptobox.TOPIC.NEW_PREKEYS, prekeys => {
-        const serializedPreKeys = prekeys.map(prekey => this.cryptobox.serialize_prekey(prekey));
+        const serializedPreKeys = prekeys.map(this.cryptobox.serialize_prekey);
         onNewPrekeys(serializedPreKeys);
       });
     }

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -88,6 +88,9 @@ export class CryptographyService {
     // see https://regex101.com/r/c8FtCw/1
     const regex = /((?<domain>.+)@)?(?<userId>.+)@(?<clientId>.+)$/g;
     const match = regex.exec(sessionId);
+    if (!match) {
+      throw new Error(`given session id "${sessionId}" has wrong format`);
+    }
     const {domain, userId, clientId} = match?.groups || {};
     return {clientId, domain, userId};
   }

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -91,8 +91,7 @@ export class CryptographyService {
     if (!match) {
       throw new Error(`given session id "${sessionId}" has wrong format`);
     }
-    const {domain, userId, clientId} = match.groups;
-    return {clientId, domain, userId};
+    return match.groups as SessionId;
   }
 
   public static convertArrayRecipientsToBase64(recipients: OTRRecipients<Uint8Array>): OTRRecipients<string> {

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -81,6 +81,10 @@ export class CryptographyService {
     return baseDomain && this.config.useQualifiedIds ? `${baseDomain}@${baseId}` : baseId;
   }
 
+  private isSessionId(object: any): object is SessionId {
+    return object.userId && object.clientId;
+  }
+
   /**
    * Splits a sessionId into userId, clientId & domain (if any).
    */
@@ -88,10 +92,10 @@ export class CryptographyService {
     // see https://regex101.com/r/c8FtCw/1
     const regex = /((?<domain>.+)@)?(?<userId>.+)@(?<clientId>.+)$/g;
     const match = regex.exec(sessionId);
-    if (!match) {
+    if (!match || !this.isSessionId(match.groups)) {
       throw new Error(`given session id "${sessionId}" has wrong format`);
     }
-    return match.groups as SessionId;
+    return match.groups;
   }
 
   public static convertArrayRecipientsToBase64(recipients: OTRRecipients<Uint8Array>): OTRRecipients<string> {

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -91,7 +91,7 @@ export class CryptographyService {
     if (!match) {
       throw new Error(`given session id "${sessionId}" has wrong format`);
     }
-    const {domain, userId, clientId} = match?.groups || {};
+    const {domain, userId, clientId} = match.groups;
     return {clientId, domain, userId};
   }
 


### PR DESCRIPTION
Migrate back session handling code from the webapp to the core. 

This enables the core to hook into the cryptobox sessions handling and react to it. 
Namely, we have 2 hooks:
- `onNewSession` which is called when cryptobox receives a message from a client it doesn't have a session with
- `onNewPrekeys` which is called when cryptbox is warned that a prekey has been consumed and generates new ones

BREAKING CHANGE: the `Account.init` function signature has changed. If you used `cookie` or `initClient` they are now moved to the option param. `account.init(clientType, cookie, false)` becomes `account.init(clientType, {cookie, initClient: false})`