### PR TITLE
fix: Do not import CoreCrypto twice

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -438,7 +438,6 @@ export class Account<T = any> extends EventEmitter {
       throw new Error('Services are not set.');
     }
     const coreCryptoKeyId = 'corecrypto-key';
-    const {CoreCrypto} = await import('@wireapp/core-crypto');
     const dbName = this.generateSecretsDbName(context);
 
     const secretStore = mlsConfig.systemCrypto


### PR DESCRIPTION
Since [#4402](https://github.com/wireapp/wire-web-packages/pull/4402/files#diff-c4b99150dbc7672f5929baaccfef2bafe8fc6a95d69ccd7e9682db7e0b4d4e8dR41) CoreCrypto is not only imported with `type`. So there is no need of re-loading it later on. 