### PR TITLE
feat(api-client, core): add supportsMLS flag to api backend features [FS-1051]

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -124,6 +124,8 @@ export type BackendFeatures = {
   federationEndpoints: boolean;
   /** Is the backend actually talking to other federated domains */
   isFederated: boolean;
+  /** Does the backend API support MLS features */
+  supportsMLS: boolean;
 };
 
 export type BackendVersionResponse = {supported: number[]; federation?: boolean; development?: number[]};
@@ -228,6 +230,7 @@ export class APIClient extends EventEmitter {
       version: backendVersion,
       federationEndpoints: backendVersion > 0,
       isFederated: responsePayload?.federation || false,
+      supportsMLS: backendVersion >= 2,
     };
   }
 

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.test.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.test.ts
@@ -29,6 +29,7 @@ describe('ConversationAPI', () => {
     version: 0,
     federationEndpoints: false,
     isFederated: false,
+    supportsMLS: false,
   });
   describe('postORTMessage', () => {
     it('add ignore_missing and report_missing parameters', async () => {

--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -238,7 +238,7 @@ export class Account<T = any> extends EventEmitter {
     if (initClient) {
       await this.initClient({clientType});
 
-      if (this.mlsConfig) {
+      if (this.mlsConfig && this.backendFeatures.supportsMLS) {
         // initialize schedulers for pending mls proposals once client is initialized
         await this.service?.notification.checkExistingPendingProposals();
 
@@ -416,7 +416,7 @@ export class Account<T = any> extends EventEmitter {
     const loadedClient = await this.service!.client.getLocalClient();
     await this.apiClient.api.client.getClient(loadedClient.id);
     this.apiClient.context!.clientId = loadedClient.id;
-    if (this.mlsConfig) {
+    if (this.mlsConfig && this.backendFeatures.supportsMLS) {
       this.coreCryptoClient = await this.createMLSClient(
         loadedClient,
         this.apiClient.context!,
@@ -481,7 +481,7 @@ export class Account<T = any> extends EventEmitter {
     }
     this.logger.info(`Creating new client {mls: ${!!this.mlsConfig}}`);
     const registeredClient = await this.service.client.register(loginData, clientInfo, entropyData);
-    if (this.mlsConfig) {
+    if (this.mlsConfig && this.backendFeatures.supportsMLS) {
       this.coreCryptoClient = await this.createMLSClient(
         registeredClient,
         this.apiClient.context!,


### PR DESCRIPTION
Add `supportsMLS` flag to backend features interface on `api-client` and enable it when **`backendVersion >= 2`**.

Consume the flag on the `core` side and based on that, decide whether to initialise MLS client or not.
