### PR TITLE
chore: dedupe async

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6121,21 +6121,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^2.6.0":
+"async@npm:^2.6.0, async@npm:^2.6.1":
   version: 2.6.4
   resolution: "async@npm:2.6.4"
   dependencies:
     lodash: ^4.17.14
   checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
-  languageName: node
-  linkType: hard
-
-"async@npm:^2.6.1":
-  version: 2.6.3
-  resolution: "async@npm:2.6.3"
-  dependencies:
-    lodash: ^4.17.14
-  checksum: 5e5561ff8fca807e88738533d620488ac03a5c43fce6c937451f7e35f943d33ad06c24af3f681a48cca3d2b0002b3118faff0a128dc89438a9bf0226f712c499
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Leftover duplicate dependency to `async` missed in #4540