### PR TITLE
feat: provide utils to extract parameters from URL's hash (SQSERVICES-1610)

### DIFF
--- a/packages/commons/src/main/util/UrlUtil.test.ts
+++ b/packages/commons/src/main/util/UrlUtil.test.ts
@@ -96,6 +96,52 @@ describe('UrlUtil', () => {
     });
   });
 
+  describe('getURLParameterFromHash', () => {
+    it('returns empty string if parameter does not exist', () => {
+      const expected = '';
+      const actual = UrlUtil.getURLParameterFromHash('q');
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns parameter value if parameter exist', () => {
+      const expected = '1';
+      const actual = UrlUtil.getURLParameterFromHash('q', '#q=1');
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('getURLParameterFromAny', () => {
+    it('returns empty string if parameter does not exist', () => {
+      const expected = '';
+      const actual = UrlUtil.getURLParameterFromAny('q');
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns parameter value if parameter exist', () => {
+      const expected = '1';
+      const actual = UrlUtil.getURLParameterFromAny('q', '#q=1');
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns parameter value if parameter exist in both possible sources', () => {
+      const expected = '1';
+      const actual = UrlUtil.getURLParameterFromAny('q', '#q=1&test=44', '?q=3');
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns parameter value if parameter exist in both possible sources', () => {
+      const expected = '';
+      const actual = UrlUtil.getURLParameterFromAny('q', '#q=', '?q=3');
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns parameter value if parameter exist only as query parameter', () => {
+      const expected = '3';
+      const actual = UrlUtil.getURLParameterFromAny('q', '', '?q=3');
+      expect(actual).toEqual(expected);
+    });
+  });
+
   describe('hasURLParameter', () => {
     it('returns false if parameter does not exist', () => {
       const expected = false;

--- a/packages/commons/src/main/util/UrlUtil.ts
+++ b/packages/commons/src/main/util/UrlUtil.ts
@@ -47,9 +47,55 @@ export function paramsToRecord(params: string): Record<string, any> {
   });
   return records;
 }
-
+/**
+ * Looks for a given parameter by name in the query part of the URL of the current window's location.
+ * @param parameterName the name of the parameter to search for
+ * @param search the source to look at for the parameter, defaults to window.location.search
+ * @returns the first found parameter or an empty string
+ */
 export function getURLParameter(parameterName: string, search = window.location.search): string {
   return new URLSearchParams(search).get(parameterName) || '';
+}
+
+/**
+ * Looks for a given parameter by name in the hash part of the URL of the current window's location.
+ * @param parameterName the name of the parameter to search for
+ * @param hash the source to look for at the parameter, defaults to window.location.hash
+ * @returns the first found parameter or an empty string
+ */
+export function getURLParameterFromHash(parameterName: string, hash = window.location.hash): string {
+  // window.location.hash always starts with #
+  if (hash.length <= 1 || hash[0] !== '#') {
+    return '';
+  }
+  return new URLSearchParams(hash.substring(1)).get(parameterName) || '';
+}
+
+/**
+ * Looks for a given parameter by name in the hash and query part of the URL of the current window's location.
+ * Findings in the hash part are preferend ver the query part.
+ * Empty values are considered a valid value.
+ * @param parameterName the name of the parameter to search for
+ * @param hash the "hash" source to look for at the parameter, defaults to window.location.hash
+ * @param search the "search" source to look at for the parameter, defaults to window.location.search
+ * @returns the first found parameter or an empty string
+ */
+export function getURLParameterFromAny(
+  parameterName: string,
+  hash = window.location.hash,
+  search = window.location.search,
+): string {
+  // getURLParameterFromHash cannot be used here, as it will always return an empty string, even if the value is not set.
+  // a decision whether the value was set or not is then no longer possible.
+
+  // window.location.hash always starts with #
+  if (hash.length > 1 && hash[0] === '#') {
+    const result = new URLSearchParams(hash.substring(1)).get(parameterName);
+    if (result !== null) {
+      return result;
+    }
+  }
+  return getURLParameter(parameterName, search);
 }
 
 export function hasURLParameter(parameterName: string, search = window.location.search): boolean {


### PR DESCRIPTION
## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes


No breaking changes introduced.

Added two new APIs to allow future migration from `getURLParameter` to `getURLParameterFromHash`.