### PR TITLE
refactor: Factorize reencryption logic

### DIFF
--- a/packages/core/src/main/conversation/message/MessageService.test.node.ts
+++ b/packages/core/src/main/conversation/message/MessageService.test.node.ts
@@ -45,12 +45,12 @@ type TestUser = {id: string; domain: string; clients: string[]};
 const user1: TestUser = {
   id: UUID.genV4().toString(),
   domain: '1.wire.test',
-  clients: ['client1.1', 'client1.2', 'client1.3', 'client1.4'],
+  clients: ['ad5ab2f5439402b2', 'e059de5875ddc36f', 'ed8131af9535b10d', 'a5c4a2556640216a'],
 };
 const user2: TestUser = {
   id: UUID.genV4().toString(),
   domain: '2.wire.test',
-  clients: ['client2.1', 'client2.2', 'client2.3', 'client2.4'],
+  clients: ['c7aa19bca47845d2', '15c4a2556640216a', '3044dc9a15bee659', 'dedd4398e2eb6e12'],
 };
 
 function generateQualifiedRecipients(users: TestUser[]): QualifiedUserClients {
@@ -69,10 +69,7 @@ function generateRecipients(users: TestUser[]): UserClients {
   }, {} as UserClients);
 }
 
-function fakeEncrypt(
-  _: unknown,
-  recipients: QualifiedUserClients,
-): Promise<{missing: any; encrypted: QualifiedOTRRecipients}> {
+function fakeEncrypt(_: unknown, recipients: QualifiedUserClients): Promise<QualifiedOTRRecipients> {
   const encryptedPayload = Object.entries(recipients).reduce((acc, [domain, users]) => {
     acc[domain] = Object.entries(users).reduce((userClients, [userId, clients]) => {
       userClients[userId] = clients.reduce((payloads, client) => {
@@ -83,7 +80,7 @@ function fakeEncrypt(
     }, {} as OTRRecipients<Uint8Array>);
     return acc;
   }, {} as QualifiedOTRRecipients);
-  return Promise.resolve({encrypted: encryptedPayload, missing: {}});
+  return Promise.resolve(encryptedPayload);
 }
 
 describe('MessageService', () => {
@@ -126,7 +123,6 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseMessageSendingStatus);
         });
-        jest.spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -153,7 +149,6 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseMessageSendingStatus);
         });
-        jest.spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -177,7 +172,6 @@ describe('MessageService', () => {
           };
           return Promise.reject(error);
         });
-        jest.spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 

--- a/packages/core/src/main/conversation/message/MessageService.ts
+++ b/packages/core/src/main/conversation/message/MessageService.ts
@@ -130,10 +130,10 @@ export class MessageService {
     const send = (payload: QualifiedOTRRecipients) => {
       return this.sendFederatedOtrMessage(sendingClientId, payload, options);
     };
-    const encrypted = await this.cryptographyService.encryptQualified(plainText, recipients);
+    const encryptedPayload = await this.cryptographyService.encryptQualified(plainText, recipients);
 
     try {
-      return await send(encrypted);
+      return await send(encryptedPayload);
     } catch (error) {
       if (!this.isClientMismatchError(error)) {
         throw error;
@@ -143,7 +143,7 @@ export class MessageService {
       if (shouldStopSending) {
         return {...mismatch, errored: true};
       }
-      const reEncryptedPayload = await this.reencryptAfterFederatedMismatch(mismatch, encrypted, plainText);
+      const reEncryptedPayload = await this.reencryptAfterFederatedMismatch(mismatch, encryptedPayload, plainText);
       return send(reEncryptedPayload);
     }
   }

--- a/packages/core/src/main/cryptography/CryptographyService.test.node.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.test.node.ts
@@ -195,7 +195,7 @@ describe('CryptographyService', () => {
         },
       };
       const text = new Uint8Array(Buffer.from('Hello', 'utf8'));
-      const {encrypted} = await cryptographyService.encrypt(text, preKeyBundleMap);
+      const encrypted = await cryptographyService.encrypt(text, preKeyBundleMap);
       expect(Object.keys(encrypted).length).toBe(2);
       expect(Object.keys(encrypted[firstUserID]).length).toBe(3);
       expect(Object.keys(encrypted[secondUserID]).length).toBe(2);
@@ -219,7 +219,7 @@ describe('CryptographyService', () => {
       const otrBundles = await Promise.all(
         Array.from(Array(encryptionRuns).keys()).map(() => cryptographyService.encrypt(text, preKeyBundleMap)),
       );
-      const encryptedPayloads = otrBundles.map(({encrypted}) => encrypted[userId][clientId]);
+      const encryptedPayloads = otrBundles.map(encrypted => encrypted[userId][clientId]);
       const messageCounters = encryptedPayloads.map(encodedCiphertext => {
         const messageBytes = encodedCiphertext;
         const messageEnvelope = Proteus.message.Envelope.deserialise(messageBytes.buffer);

--- a/packages/core/src/main/cryptography/CryptographyService.ts
+++ b/packages/core/src/main/cryptography/CryptographyService.ts
@@ -205,7 +205,9 @@ export class CryptographyService {
         }
       }
       const measuredTime = Date.now() - startedAt;
-      this.logger.info(`Encrypted payload for ${Object.keys(encrypted).length} recipients in ${measuredTime}ms`);
+      this.logger.info(
+        `Encrypted payload for ${Object.keys(encrypted).length} recipients in ${measuredTime}ms (domain: ${domain})`,
+      );
     }
 
     if (Object.keys(missing).length > 0) {


### PR DESCRIPTION
This PR will help in the effort of bringing the fingerprint computation to the core. 
The idea is to gather all manipulation of prekeys only inside of the `CryptoService`. It should be the only entity aware of prekeys. 

Prekeys will be needed in order to create missing sessions with devices we will want to compute fingerprint of