### PR TITLE
fix: Revert axios to version 1.1.2

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -8,7 +8,7 @@
     "@wireapp/commons": "workspace:^",
     "@wireapp/priority-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.39.0",
-    "axios": "^1.1.3",
+    "axios": "1.1.2",
     "axios-retry": "3.3.1",
     "http-status-codes": "2.2.0",
     "logdown": "3.3.1",

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -259,7 +259,9 @@ export class HttpClient extends EventEmitter {
     config.headers = {
       ...config.headers,
       'Content-Type': ContentType.APPLICATION_JSON,
-    };
+      // There is a typedef error in axios 1.1.2. This has been fixed with 1.1.3 (that we cannot use as of now because of webpack build https://github.com/axios/axios/issues/5154)
+      // This `any` can be removed when we use axios > 1.1.3
+    } as any;
     return this.sendRequest<T>(config, false, isSynchronousRequest);
   }
 
@@ -267,7 +269,9 @@ export class HttpClient extends EventEmitter {
     config.headers = {
       ...config.headers,
       'Content-Type': ContentType.APPLICATION_XML,
-    };
+      // There is a typedef error in axios 1.1.2. This has been fixed with 1.1.3 (that we cannot use as of now because of webpack build https://github.com/axios/axios/issues/5154)
+      // This `any` can be removed when we use axios > 1.1.3
+    } as any;
     return this.sendRequest<T>(config, false, false);
   }
 
@@ -278,7 +282,9 @@ export class HttpClient extends EventEmitter {
     config.headers = {
       ...config.headers,
       'Content-Type': ContentType.APPLICATION_PROTOBUF,
-    };
+      // There is a typedef error in axios 1.1.2. This has been fixed with 1.1.3 (that we cannot use as of now because of webpack build https://github.com/axios/axios/issues/5154)
+      // This `any` can be removed when we use axios > 1.1.3
+    } as any;
     return this.sendRequest<T>(config, false, isSynchronousRequest);
   }
 
@@ -289,7 +295,9 @@ export class HttpClient extends EventEmitter {
     config.headers = {
       ...config.headers,
       'Content-Type': ContentType.MESSAGES_MLS,
-    };
+      // There is a typedef error in axios 1.1.2. This has been fixed with 1.1.3 (that we cannot use as of now because of webpack build https://github.com/axios/axios/issues/5154)
+      // This `any` can be removed when we use axios > 1.1.3
+    } as any;
     return this.sendRequest<T>(config, false, isSynchronousRequest);
   }
 }

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -126,7 +126,9 @@ export class HttpClient extends EventEmitter {
         config.headers = {
           ...config.headers,
           Authorization: `${token_type} ${access_token}`,
-        };
+          // There is a typedef error in axios 1.1.2. This has been fixed with 1.1.3 (that we cannot use as of now because of webpack build https://github.com/axios/axios/issues/5154)
+          // This `any` can be removed when we use axios > 1.1.3
+        } as any;
       }
     }
 

--- a/packages/cli-client/package.json
+++ b/packages/cli-client/package.json
@@ -6,7 +6,7 @@
     "@wireapp/api-client": "workspace:^",
     "@wireapp/core": "workspace:^",
     "@wireapp/store-engine-fs": "workspace:^",
-    "axios": "^1.1.3",
+    "axios": "1.1.2",
     "commander": "9.4.1",
     "dotenv": "16.0.3",
     "fs-extra": "10.1.0"

--- a/packages/copy-config/package.json
+++ b/packages/copy-config/package.json
@@ -1,7 +1,7 @@
 {
   "bin": "src/main/cli.js",
   "dependencies": {
-    "axios": "1.1.3",
+    "axios": "1.1.2",
     "copy": "0.3.2",
     "cosmiconfig": "7.0.1",
     "fs-extra": "10.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,7 @@
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.39.0",
     "@wireapp/store-engine-dexie": "workspace:^",
-    "axios": "^1.1.3",
+    "axios": "1.1.2",
     "bazinga64": "5.11.10",
     "hash.js": "1.1.7",
     "http-status-codes": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5059,7 +5059,7 @@ __metadata:
     "@wireapp/protocol-messaging": 1.39.0
     "@wireapp/store-engine": "workspace:^"
     "@wireapp/store-engine-fs": "workspace:^"
-    axios: ^1.1.3
+    axios: 1.1.2
     axios-retry: 3.3.1
     babel-loader: 8.2.5
     browser-sync: 2.27.10
@@ -5115,7 +5115,7 @@ __metadata:
     "@wireapp/api-client": "workspace:^"
     "@wireapp/core": "workspace:^"
     "@wireapp/store-engine-fs": "workspace:^"
-    axios: ^1.1.3
+    axios: 1.1.2
     commander: 9.4.1
     dotenv: 16.0.3
     fs-extra: 10.1.0
@@ -5152,7 +5152,7 @@ __metadata:
   dependencies:
     "@types/copy": 0.3.2
     "@types/fs-extra": 9.0.13
-    axios: 1.1.3
+    axios: 1.1.2
     copy: 0.3.2
     cosmiconfig: 7.0.1
     fs-extra: 10.1.0
@@ -5191,7 +5191,7 @@ __metadata:
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.39.0
     "@wireapp/store-engine-dexie": "workspace:^"
-    axios: ^1.1.3
+    axios: 1.1.2
     bazinga64: 5.11.10
     commander: 9.4.1
     cross-env: 7.0.3
@@ -6298,7 +6298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:*, axios@npm:1.1.3, axios@npm:^1.1.3":
+"axios@npm:*":
   version: 1.1.3
   resolution: "axios@npm:1.1.3"
   dependencies:
@@ -6315,6 +6315,17 @@ __metadata:
   dependencies:
     follow-redirects: ^1.10.0
   checksum: c87915fa0b18c15c63350112b6b3563a3e2ae524d7707de0a73d2e065e0d30c5d3da8563037bc29d4cc1b7424b5a350cb7274fa52525c6c04a615fe561c6ab11
+  languageName: node
+  linkType: hard
+
+"axios@npm:1.1.2":
+  version: 1.1.2
+  resolution: "axios@npm:1.1.2"
+  dependencies:
+    follow-redirects: ^1.15.0
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 136c25a5031aa2845fdbda3006c36888bbe351b11d1195f1f898a23c5df1430febbdb1ad034a61f27967e83762d5b5a3e851fff8a363cb4badeb883f8ff21461
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Axios 1.1.3 has a problem with webpack build (see https://github.com/axios/axios/issues/5154)