### PR TITLE
fix: Make sure clientId is set before init cryptobox

### DIFF
--- a/packages/core/src/main/Account.ts
+++ b/packages/core/src/main/Account.ts
@@ -444,11 +444,10 @@ export class Account<T = any> extends EventEmitter {
   }
 
   public async loadAndValidateLocalClient(entropyData?: Uint8Array): Promise<RegisteredClient> {
-    await this.service!.cryptography.initCryptobox();
-
     const loadedClient = await this.service!.client.getLocalClient();
     await this.apiClient.api.client.getClient(loadedClient.id);
     this.apiClient.context!.clientId = loadedClient.id;
+    await this.service!.cryptography.initCryptobox();
     if (this.mlsConfig && this.backendFeatures.supportsMLS) {
       this.coreCryptoClient = await this.createMLSClient(
         loadedClient,


### PR DESCRIPTION
This ensures that the `clientId` has been set before actually initiating cryptobox. 
This fixes an issue where prekeys could be generated but a clientId was not defined yet (so keys could not be uploaded to be backend)