### PR TITLE
feat: add initial db migration trigger logic [FS-1095]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -147,6 +147,8 @@ type InitOptions = {
   onNewClient?: (sessionId: SessionId) => void;
 };
 
+type DBMigrationConfig = {storeName: string};
+
 const coreDefaultClient: ClientInfo = {
   classification: ClientClassification.DESKTOP,
   cookieLabel: 'default',
@@ -161,6 +163,7 @@ export class Account<T = any> extends EventEmitter {
   private readonly nbPrekeys: number;
   private readonly cryptoProtocolConfig?: CryptoProtocolConfig<T>;
   private coreCryptoClient?: CoreCrypto;
+  private dbMigrationConfig?: DBMigrationConfig;
 
   public static readonly TOPIC = TOPIC;
   public service?: {
@@ -272,6 +275,14 @@ export class Account<T = any> extends EventEmitter {
       await this.initClient({clientType});
 
       if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
+        if (this.dbMigrationConfig) {
+          try {
+            await this.service?.mls.proteusCryptoboxMigrate(this.dbMigrationConfig.storeName);
+          } catch (error) {
+            this.logger.error('Client was not able to perform DB migration:', error);
+          }
+        }
+
         // initialize schedulers for pending mls proposals once client is initialized
         await this.service?.notification.checkExistingPendingProposals();
 
@@ -283,6 +294,15 @@ export class Account<T = any> extends EventEmitter {
       }
     }
     return context;
+  }
+
+  /**
+   * Will schedule db migration task that will be executed right after the client is initialised.
+   *
+   * @param migrationConfig migration config object containing storeName (required to trigger migration).
+   */
+  public async scheduleDBMigration(migrationConfig: DBMigrationConfig) {
+    this.dbMigrationConfig = migrationConfig;
   }
 
   /**

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -145,15 +145,6 @@ type InitOptions = {
    * An unknown client is a client we don't yet have a session with
    */
   onNewClient?: (sessionId: SessionId) => void;
-
-  /**
-   * Database migration config object storing a name of the db and onSuccess callback function.
-   * When provided, the client will trigger migration script after initialisation.
-   */
-  dbMigrationConfig?: {
-    storeName: string;
-    onSuccess: () => void;
-  };
 };
 
 const coreDefaultClient: ClientInfo = {
@@ -254,7 +245,7 @@ export class Account<T = any> extends EventEmitter {
    */
   public async init(
     clientType: ClientType,
-    {cookie, initClient = true, onNewClient, dbMigrationConfig}: InitOptions = {},
+    {cookie, initClient = true, onNewClient}: InitOptions = {},
   ): Promise<Context> {
     const context = await this.apiClient.init(clientType, cookie);
     await this.initServices(context);

--- a/packages/core/src/mls/MLSService/MLSService.ts
+++ b/packages/core/src/mls/MLSService/MLSService.ts
@@ -237,4 +237,8 @@ export class MLSService {
   public async wipeConversation(conversationId: ConversationId): Promise<void> {
     return this.coreCryptoClient.wipeConversation(conversationId);
   }
+
+  public async proteusCryptoboxMigrate(storeName: string) {
+    return this.coreCryptoClient.proteusCryptoboxMigrate(storeName);
+  }
 }


### PR DESCRIPTION
We want to migrate from cryptobox to corecrypto. We will trigger a migration script after dexie db version has upgraded (`upgrade` hook on webapp side). 

Blockers:
We need to have core-crypto proteus client initialised to call `coreCryptoClient.proteusCryptoboxMigrate` method. [FS-1096](https://wearezeta.atlassian.net/browse/FS-1096)