### PR TITLE
fix: Prepare for core-crypto proteus support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "0.5.2",
+    "@wireapp/core-crypto": "0.6.0-pre.2",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.42.0",

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -276,9 +276,7 @@ export class Account<T = any> extends EventEmitter {
         await this.service?.notification.checkExistingPendingProposals();
 
         // initialize schedulers for renewing key materials
-        await this.service?.notification.checkForKeyMaterialsUpdate(
-          this.cryptoProtocolConfig.mls.keyingMaterialUpdateThreshold,
-        );
+        await this.service?.notification.checkForKeyMaterialsUpdate();
 
         // initialize scheduler for syncing key packages with backend
         await this.service?.notification.checkForKeyPackagesBackendSync();
@@ -400,7 +398,11 @@ export class Account<T = any> extends EventEmitter {
     });
 
     const clientService = new ClientService(this.apiClient, this.storeEngine, cryptographyService);
-    const mlsService = new MLSService(this.apiClient, () => this.coreCryptoClient);
+    const mlsService = new MLSService(
+      this.apiClient,
+      () => this.coreCryptoClient,
+      this.cryptoProtocolConfig?.mls ?? {},
+    );
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -48,7 +48,7 @@ import {CryptographyService, SessionId} from './cryptography/';
 import {GiphyService} from './giphy/';
 import {LinkPreviewService} from './linkPreview';
 import {MLSService} from './mls';
-import {MLSCallbacks, MLSConfig} from './mls/types';
+import {MLSCallbacks, CryptoProtocolConfig} from './mls/types';
 import {HandledEventPayload, NotificationService} from './notification/';
 import {SelfService} from './self/';
 import {TeamService} from './team/';
@@ -128,9 +128,9 @@ interface AccountOptions<T> {
   nbPrekeys?: number;
 
   /**
-   * Config for MLS devices. Will not load corecrypt or create MLS devices if undefined
+   * Config for MLS and proteus devices. Will fallback to the old proteus logic if not provided
    */
-  mlsConfig?: MLSConfig<T>;
+  cryptoProtocolConfig?: CryptoProtocolConfig<T>;
 }
 
 type InitOptions = {
@@ -159,7 +159,7 @@ export class Account<T = any> extends EventEmitter {
   private readonly createStore: CreateStoreFn;
   private storeEngine?: CRUDEngine;
   private readonly nbPrekeys: number;
-  private readonly mlsConfig?: MLSConfig<T>;
+  private readonly cryptoProtocolConfig?: CryptoProtocolConfig<T>;
   private coreCryptoClient?: CoreCrypto;
 
   public static readonly TOPIC = TOPIC;
@@ -187,12 +187,12 @@ export class Account<T = any> extends EventEmitter {
    */
   constructor(
     apiClient: APIClient = new APIClient(),
-    {createStore = () => undefined, nbPrekeys = 2, mlsConfig}: AccountOptions<T> = {},
+    {createStore = () => undefined, nbPrekeys = 2, cryptoProtocolConfig}: AccountOptions<T> = {},
   ) {
     super();
     this.apiClient = apiClient;
     this.backendFeatures = this.apiClient.backendFeatures;
-    this.mlsConfig = mlsConfig;
+    this.cryptoProtocolConfig = cryptoProtocolConfig;
     this.nbPrekeys = nbPrekeys;
     this.createStore = createStore;
 
@@ -271,12 +271,14 @@ export class Account<T = any> extends EventEmitter {
     if (initClient) {
       await this.initClient({clientType});
 
-      if (this.mlsConfig && this.backendFeatures.supportsMLS) {
+      if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
         // initialize schedulers for pending mls proposals once client is initialized
         await this.service?.notification.checkExistingPendingProposals();
 
         // initialize schedulers for renewing key materials
-        await this.service?.notification.checkForKeyMaterialsUpdate();
+        await this.service?.notification.checkForKeyMaterialsUpdate(
+          this.cryptoProtocolConfig.mls.keyingMaterialUpdateThreshold,
+        );
 
         // initialize scheduler for syncing key packages with backend
         await this.service?.notification.checkForKeyPackagesBackendSync();
@@ -398,7 +400,7 @@ export class Account<T = any> extends EventEmitter {
     });
 
     const clientService = new ClientService(this.apiClient, this.storeEngine, cryptographyService);
-    const mlsService = new MLSService(this.mlsConfig, this.apiClient, () => this.coreCryptoClient);
+    const mlsService = new MLSService(this.apiClient, () => this.coreCryptoClient);
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);
@@ -448,11 +450,11 @@ export class Account<T = any> extends EventEmitter {
     await this.apiClient.api.client.getClient(loadedClient.id);
     this.apiClient.context!.clientId = loadedClient.id;
     await this.service!.cryptography.initCryptobox();
-    if (this.mlsConfig && this.backendFeatures.supportsMLS) {
+    if (this.cryptoProtocolConfig && this.backendFeatures.supportsMLS) {
       this.coreCryptoClient = await this.createMLSClient(
         loadedClient,
         this.apiClient.context!,
-        this.mlsConfig,
+        this.cryptoProtocolConfig,
         entropyData,
       );
     }
@@ -463,7 +465,7 @@ export class Account<T = any> extends EventEmitter {
   private async createMLSClient(
     client: RegisteredClient,
     context: Context,
-    mlsConfig: MLSConfig,
+    cryptoProtocolConfig: CryptoProtocolConfig,
     entropyData?: Uint8Array,
   ) {
     if (!this.service) {
@@ -472,8 +474,8 @@ export class Account<T = any> extends EventEmitter {
     const coreCryptoKeyId = 'corecrypto-key';
     const dbName = this.generateSecretsDbName(context);
 
-    const secretStore = mlsConfig.systemCrypto
-      ? await createCustomEncryptedStore(dbName, mlsConfig.systemCrypto)
+    const secretStore = cryptoProtocolConfig.systemCrypto
+      ? await createCustomEncryptedStore(dbName, cryptoProtocolConfig.systemCrypto)
       : await createEncryptedStore(dbName);
 
     let key = await secretStore.getsecretValue(coreCryptoKeyId);
@@ -490,7 +492,7 @@ export class Account<T = any> extends EventEmitter {
       databaseName: `corecrypto-${this.generateDbName(context)}`,
       key: Encoder.toBase64(key).asString,
       clientId: `${userId}:${client.id}@${domain}`,
-      wasmFilePath: mlsConfig.coreCrypoWasmFilePath,
+      wasmFilePath: cryptoProtocolConfig.coreCrypoWasmFilePath,
       entropySeed: entropyData,
     });
 
@@ -511,13 +513,13 @@ export class Account<T = any> extends EventEmitter {
     if (!this.service) {
       throw new Error('Services are not set.');
     }
-    this.logger.info(`Creating new client {mls: ${!!this.mlsConfig}}`);
+    this.logger.info(`Creating new client {mls: ${!!this.cryptoProtocolConfig}}`);
     const registeredClient = await this.service.client.register(loginData, clientInfo, entropyData);
-    if (this.mlsConfig && this.backendFeatures.supportsMLS) {
+    if (this.cryptoProtocolConfig && this.backendFeatures.supportsMLS) {
       this.coreCryptoClient = await this.createMLSClient(
         registeredClient,
         this.apiClient.context!,
-        this.mlsConfig,
+        this.cryptoProtocolConfig,
         entropyData,
       );
     }

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -452,7 +452,7 @@ export class Account<T = any> extends EventEmitter {
     await this.apiClient.api.client.getClient(loadedClient.id);
     this.apiClient.context!.clientId = loadedClient.id;
     await this.service!.cryptography.initCryptobox();
-    if (this.cryptoProtocolConfig && this.backendFeatures.supportsMLS) {
+    if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
       this.coreCryptoClient = await this.createMLSClient(
         loadedClient,
         this.apiClient.context!,

--- a/packages/core/src/mls/MLSService/MLSService.ts
+++ b/packages/core/src/mls/MLSService/MLSService.ts
@@ -35,7 +35,7 @@ import {
 import {APIClient} from '@wireapp/api-client';
 import {QualifiedUsers} from '../../conversation';
 import {Converter, Decoder, Encoder} from 'bazinga64';
-import {MLSCallbacks} from '../types';
+import {CryptoProtocolConfig, MLSCallbacks} from '../types';
 import {sendMessage} from '../../conversation/message/messageSender';
 import {parseFullQualifiedClientId} from '../../util/fullyQualifiedClientIdUtils';
 import {PostMlsMessageResponse} from '@wireapp/api-client/lib/conversation';
@@ -53,6 +53,7 @@ export class MLSService {
   constructor(
     private readonly apiClient: APIClient,
     private readonly coreCryptoClientProvider: () => CoreCrypto | undefined,
+    public readonly config: CryptoProtocolConfig['mls'],
   ) {}
 
   private get coreCryptoClient() {

--- a/packages/core/src/mls/MLSService/MLSService.ts
+++ b/packages/core/src/mls/MLSService/MLSService.ts
@@ -35,7 +35,7 @@ import {
 import {APIClient} from '@wireapp/api-client';
 import {QualifiedUsers} from '../../conversation';
 import {Converter, Decoder, Encoder} from 'bazinga64';
-import {MLSCallbacks, MLSConfig} from '../types';
+import {MLSCallbacks} from '../types';
 import {sendMessage} from '../../conversation/message/messageSender';
 import {parseFullQualifiedClientId} from '../../util/fullyQualifiedClientIdUtils';
 import {PostMlsMessageResponse} from '@wireapp/api-client/lib/conversation';
@@ -51,7 +51,6 @@ export class MLSService {
   groupIdFromConversationId?: MLSCallbacks['groupIdFromConversationId'];
 
   constructor(
-    public readonly config: MLSConfig | undefined,
     private readonly apiClient: APIClient,
     private readonly coreCryptoClientProvider: () => CoreCrypto | undefined,
   ) {}

--- a/packages/core/src/mls/MLSService/MLSService.ts
+++ b/packages/core/src/mls/MLSService/MLSService.ts
@@ -95,7 +95,7 @@ export class MLSService {
   public configureMLSCallbacks({groupIdFromConversationId, ...coreCryptoCallbacks}: MLSCallbacks): void {
     this.coreCryptoClient.registerCallbacks({
       ...coreCryptoCallbacks,
-      clientIdBelongsToOneOf: (client, otherClients) => {
+      clientIsExistingGroupUser: (client, otherClients) => {
         const decoder = new TextDecoder();
         const {user} = parseFullQualifiedClientId(decoder.decode(client));
         return otherClients.some(client => {

--- a/packages/core/src/mls/types.ts
+++ b/packages/core/src/mls/types.ts
@@ -25,7 +25,7 @@ type SecretCrypto<T> = {
   decrypt: (payload: T) => Promise<Uint8Array>;
 };
 
-export interface MLSCallbacks extends Pick<CoreCryptoCallbacks, 'authorize'> {
+export interface MLSCallbacks extends Pick<CoreCryptoCallbacks, 'authorize' | 'userAuthorize'> {
   /**
    * Should return a groupId corresponding to the conversation ID given
    * Used for the core to know what core-crypto conversation we are dealing with when receiving events

--- a/packages/core/src/mls/types.ts
+++ b/packages/core/src/mls/types.ts
@@ -55,5 +55,7 @@ export interface CryptoProtocolConfig<T = any> {
      */
     keyingMaterialUpdateThreshold?: number;
   };
-  proteus: boolean;
+
+  /** if set to true, will use experimental proteus encryption/decryption library (core-crypto). If not set will fallback to the legacy proteus library (cryptobox) */
+  proteus?: boolean;
 }

--- a/packages/core/src/mls/types.ts
+++ b/packages/core/src/mls/types.ts
@@ -49,7 +49,8 @@ export interface CryptoProtocolConfig<T = any> {
    */
   coreCrypoWasmFilePath: string;
 
-  mls: {
+  /** If set will create an MLS capable device from the current device */
+  mls?: {
     /**
      * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
      */

--- a/packages/core/src/mls/types.ts
+++ b/packages/core/src/mls/types.ts
@@ -35,7 +35,7 @@ export interface MLSCallbacks extends Pick<CoreCryptoCallbacks, 'authorize' | 'u
   groupIdFromConversationId: (conversationId: QualifiedId) => Promise<string | undefined>;
 }
 
-export interface MLSConfig<T = any> {
+export interface CryptoProtocolConfig<T = any> {
   /**
    * encrypt/decrypt function pair that will be called before storing/fetching secrets in the secrets database.
    * If not provided will use the built in encryption mechanism
@@ -49,8 +49,11 @@ export interface MLSConfig<T = any> {
    */
   coreCrypoWasmFilePath: string;
 
-  /**
-   * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
-   */
-  keyingMaterialUpdateThreshold?: number;
+  mls: {
+    /**
+     * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
+     */
+    keyingMaterialUpdateThreshold?: number;
+  };
+  proteus: boolean;
 }

--- a/packages/core/src/notification/NotificationService.ts
+++ b/packages/core/src/notification/NotificationService.ts
@@ -515,11 +515,10 @@ export class NotificationService extends EventEmitter {
     return `renew-key-material-update-${groupId}`;
   }
 
-  private async scheduleTaskToRenewKeyMaterial({groupId, previousUpdateDate}: LastKeyMaterialUpdateParams) {
-    //given period of time (30 days by default) after last update date renew key material
-    const keyingMaterialUpdateThreshold =
-      this.mlsService.config?.keyingMaterialUpdateThreshold || DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD;
-
+  private async scheduleTaskToRenewKeyMaterial(
+    {groupId, previousUpdateDate}: LastKeyMaterialUpdateParams,
+    keyingMaterialUpdateThreshold: number,
+  ) {
     const firingDate = previousUpdateDate + keyingMaterialUpdateThreshold;
 
     const key = this.createKeyMaterialUpdateTaskSchedulerId(groupId);
@@ -538,10 +537,10 @@ export class NotificationService extends EventEmitter {
    * Function must only be called once, after application start
    *
    */
-  public async checkForKeyMaterialsUpdate() {
+  public async checkForKeyMaterialsUpdate(keyingMaterialUpdateThreshold = DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD) {
     try {
       const keyMaterialUpdateDates = keyMaterialUpdatesStore.getAllUpdateDates();
-      keyMaterialUpdateDates.forEach(date => this.scheduleTaskToRenewKeyMaterial(date));
+      keyMaterialUpdateDates.forEach(date => this.scheduleTaskToRenewKeyMaterial(date, keyingMaterialUpdateThreshold));
     } catch (error) {
       this.logger.error('Could not get last key material update dates', error);
     }

--- a/packages/core/src/notification/NotificationService.ts
+++ b/packages/core/src/notification/NotificationService.ts
@@ -515,10 +515,10 @@ export class NotificationService extends EventEmitter {
     return `renew-key-material-update-${groupId}`;
   }
 
-  private async scheduleTaskToRenewKeyMaterial(
-    {groupId, previousUpdateDate}: LastKeyMaterialUpdateParams,
-    keyingMaterialUpdateThreshold: number,
-  ) {
+  private async scheduleTaskToRenewKeyMaterial({groupId, previousUpdateDate}: LastKeyMaterialUpdateParams) {
+    //given period of time (30 days by default) after last update date renew key material
+    const keyingMaterialUpdateThreshold =
+      this.mlsService.config?.keyingMaterialUpdateThreshold || DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD;
     const firingDate = previousUpdateDate + keyingMaterialUpdateThreshold;
 
     const key = this.createKeyMaterialUpdateTaskSchedulerId(groupId);
@@ -537,10 +537,10 @@ export class NotificationService extends EventEmitter {
    * Function must only be called once, after application start
    *
    */
-  public async checkForKeyMaterialsUpdate(keyingMaterialUpdateThreshold = DEFAULT_KEYING_MATERIAL_UPDATE_THRESHOLD) {
+  public async checkForKeyMaterialsUpdate() {
     try {
       const keyMaterialUpdateDates = keyMaterialUpdatesStore.getAllUpdateDates();
-      keyMaterialUpdateDates.forEach(date => this.scheduleTaskToRenewKeyMaterial(date, keyingMaterialUpdateThreshold));
+      keyMaterialUpdateDates.forEach(date => this.scheduleTaskToRenewKeyMaterial(date));
     } catch (error) {
       this.logger.error('Could not get last key material update dates', error);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4299,10 +4299,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@wireapp/core-crypto@npm:0.5.2"
-  checksum: 4952e9fedf939bbef6f81ebdabbe6fa7e70e03aaa6187c57c2856f9ca2a1c082fdac3e0dcc169ed0ae81ff566e4218886804e9aeda296434f518d98df4165392
+"@wireapp/core-crypto@npm:0.6.0-pre.2":
+  version: 0.6.0-pre.2
+  resolution: "@wireapp/core-crypto@npm:0.6.0-pre.2"
+  checksum: a3e41cfa813228da709566a100b4da13f94c466bc2bb393ef44b8c7161d890e99ce06bfe1764762c2f1f984774fc1bd924e6051aaf3e56878e3ccd8d8a1cfa68
   languageName: node
   linkType: hard
 
@@ -4319,7 +4319,7 @@ __metadata:
     "@types/tough-cookie": 4.0.2
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 0.5.2
+    "@wireapp/core-crypto": 0.6.0-pre.2
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.42.0


### PR DESCRIPTION
BREAKING CHANGE: the coreCrypto callbacks now need a `userAuthorize` callback to be set. The `mlsConfig` has changed quite a bit