### PR TITLE
feat: fetch all notifications when 404 without body returned

### DIFF
--- a/packages/api-client/src/notification/NotificationAPI/NotificationAPI.ts
+++ b/packages/api-client/src/notification/NotificationAPI/NotificationAPI.ts
@@ -19,7 +19,7 @@
 
 import axios, {AxiosRequestConfig} from 'axios';
 
-import {HttpClient} from '../../http';
+import {BackendError, BackendErrorLabel, HttpClient} from '../../http';
 import {Notification, NotificationList} from '..';
 
 export const NOTIFICATION_SIZE_MAXIMUM = 10000;
@@ -108,6 +108,10 @@ export class NotificationAPI {
             hasMissedNotifications = true;
             payload = {...defaultPayload, ...error.response?.data};
           }
+        } else if (error instanceof BackendError && error.label === BackendErrorLabel.NOT_FOUND) {
+          //notification was not found in the database,
+          //we need to load all the notifications from the beginning (without 'since' param)
+          return getNotificationChunks(currentClientId);
         } else {
           throw error;
         }


### PR DESCRIPTION
Due to API v3 changes ([see changelog](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/672006169/API+changes+v2+v3)) `/notifications` endpoint has been updated: It does not return **error body** - list of notifications since encoded timestamp (timestamp is not contained in UUIDv4) or from the beginning. 

From now when api responds with 404 error, body does not contain notifications, we have to handle this error and fetch all the notifications from the beginning by manually calling `/notifications` endpoint without `since` param.