### PR TITLE
feat: Configure apiVersion from the core

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -212,6 +212,23 @@ export class Account<T = any> extends EventEmitter {
     });
   }
 
+  /**
+   * Will set the APIClient to use a specific version of the API (by default uses version 0)
+   * It will fetch the API Config and use the highest possible version
+   * @param acceptedVersions Which version the consumer supports
+   * @param useDevVersion allow the api-client to use development version of the api (if present). The dev version also need to be listed on the supportedVersions given as parameters
+   *   If we have version 2 that is a dev version, this is going to be the output of those calls
+   *   - useVersion([0, 1, 2], true) > version 2 is used
+   *   - useVersion([0, 1, 2], false) > version 1 is used
+   *   - useVersion([0, 1], true) > version 1 is used
+   * @return The highest version that is both supported by client and backend
+   */
+  public async useAPIVersion(supportedVersions: number[], useDevVersion?: boolean) {
+    const features = await this.apiClient.useVersion(supportedVersions, useDevVersion);
+    this.backendFeatures = features;
+    return features;
+  }
+
   private persistCookie(storeEngine: CRUDEngine, cookie: Cookie): Promise<string> {
     const entity = {expiration: cookie.expiration, zuid: cookie.zuid};
     return storeEngine.updateOrCreate(AUTH_TABLE_NAME, AUTH_COOKIE_KEY, entity);


### PR DESCRIPTION
This will allow the consumer to set the api version that they want to use directly from the `core` and avoid mismatch between the configuration of the core and the API Client. 