### PR TITLE
feat(core, api-client): associate client id with login session [FS-1137]

### DIFF
--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -227,12 +227,13 @@ export class HttpClient extends EventEmitter {
     return this.accessTokenStore.updateToken(accessToken);
   }
 
-  public async postAccess(expiredAccessToken?: AccessTokenData): Promise<AccessTokenData> {
+  public async postAccess(expiredAccessToken?: AccessTokenData, clientId?: string): Promise<AccessTokenData> {
     const config: AxiosRequestConfig = {
       headers: {},
       method: 'post',
       url: `${AuthAPI.URL.ACCESS}`,
       withCredentials: true,
+      params: clientId && {client_id: clientId},
     };
 
     if (expiredAccessToken?.access_token && config?.headers) {
@@ -243,6 +244,17 @@ export class HttpClient extends EventEmitter {
 
     const response = await sendRequestWithCookie<AccessTokenData>(this, config);
     return response.data;
+  }
+
+  /**
+   * Will associate specified client id with session and return newly created access token.
+   *
+   * @param  {string} clientId - id of the client with which the new login session will be associated
+   */
+  public async associateClientWithSession(clientId: string): Promise<AccessTokenData> {
+    const storedToken = this.accessTokenStore.accessToken;
+    const newToken = await this.postAccess(storedToken, clientId);
+    return this.accessTokenStore.updateToken(newToken);
   }
 
   public async sendRequest<T>(

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -255,7 +255,7 @@ export class Account<T = any> extends EventEmitter {
   }
 
   /**
-   * Will init the core with an aleady existing client (both on backend and local)
+   * Will init the core with an already existing client (both on backend and local)
    * Will fail if local client cannot be found
    *
    * @param clientType The type of client the user is using (temporary or permanent)
@@ -286,7 +286,10 @@ export class Account<T = any> extends EventEmitter {
 
     // Assumption: client gets only initialized once
     if (initClient) {
-      await this.initClient({clientType});
+      const {localClient} = await this.initClient({clientType});
+
+      //call /access endpoint with client_id after client initialisation
+      await this.apiClient.transport.http.associateClientWithSession(localClient.id);
 
       if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
         // initialize schedulers for pending mls proposals once client is initialized
@@ -331,7 +334,7 @@ export class Account<T = any> extends EventEmitter {
   /**
    * Will try to get the load the local client from local DB.
    * If clientInfo are provided, will also create the client on backend and DB
-   * If clientInfo are not provideo, the method will fail if local client cannot be found
+   * If clientInfo are not provided, the method will fail if local client cannot be found
    *
    * @param loginData User's credentials
    * @param clientInfo Will allow creating the client if the local client cannot be found (else will fail if local client is not found)
@@ -595,7 +598,7 @@ export class Account<T = any> extends EventEmitter {
     onNotificationStreamProgress?: ({done, total}: {done: number; total: number}) => void;
 
     /**
-     * called when the connection stateh with the backend has changed
+     * called when the connection state with the backend has changed
      */
     onConnectionStateChanged?: (state: ConnectionState) => void;
 


### PR DESCRIPTION
Call `/access` endpoint with `client_id` param after client initialisation to associate current client with session.

See [use case](https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/669745506/Use+case+associate+client+ID+with+login+session) for more context.
