### PR TITLE
test: Fix Account tests

### DIFF
--- a/packages/core/__mocks__/@wireapp/core-crypto.ts
+++ b/packages/core/__mocks__/@wireapp/core-crypto.ts
@@ -27,3 +27,12 @@ export enum RatchetTreeType {
   Delta = 2,
   ByRef = 3,
 }
+
+export class CoreCrypto {
+  static deferredInit() {
+    return {
+      proteusInit: jest.fn(),
+      proteusNewPrekey: jest.fn(() => Uint8Array.from([])),
+    };
+  }
+}

--- a/packages/core/jest.setup.ts
+++ b/packages/core/jest.setup.ts
@@ -17,16 +17,11 @@
  *
  */
 
-const baseConfig = require('../../jest.config.base');
+import 'fake-indexeddb/auto';
 
-const {TextDecoder, TextEncoder} = require('util');
+import nodeCrypto from 'crypto';
 
-module.exports = {
-  ...baseConfig,
-  testEnvironment: 'node',
-  setupFilesAfterEnv: ['./jest.setup.ts'],
-  globals: {
-    TextDecoder,
-    TextEncoder,
-  },
-};
+// @ts-ignore
+global.crypto = nodeCrypto.webcrypto;
+global.btoa = (text: string) => Buffer.from(text).toString('base64');
+global.atob = (base64: string) => Buffer.from(base64, 'base64').toString();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "commander": "9.4.1",
     "cross-env": "7.0.3",
     "dotenv-defaults": "5.0.2",
+    "fake-indexeddb": "^4.0.0",
     "jest": "^29.2.1",
     "jest-websocket-mock": "2.4.0",
     "mock-socket": "9.1.5",

--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -26,12 +26,9 @@ import {NotificationAPI} from '@wireapp/api-client/lib/notification';
 import {Self, SelfAPI} from '@wireapp/api-client/lib/self';
 import {WebSocketClient} from '@wireapp/api-client/lib/tcp';
 import {ReconnectingWebsocket} from '@wireapp/api-client/lib/tcp/ReconnectingWebsocket';
-import 'fake-indexeddb/auto';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {WS} from 'jest-websocket-mock';
 import nock, {cleanAll} from 'nock';
-
-import nodeCrypto from 'crypto';
 
 import {APIClient} from '@wireapp/api-client';
 import {AccentColor, ValidationUtil} from '@wireapp/commons';
@@ -90,12 +87,6 @@ describe('Account', () => {
     token_type: 'Bearer',
     user: 'aaf9a833-ef30-4c22-86a0-9adc8a15b3b4',
   };
-
-  beforeEach(() => {
-    // @ts-ignore
-    global.crypto = nodeCrypto.webcrypto;
-    global.window = {crypto: nodeCrypto.webcrypto, btoa: i => i};
-  });
 
   beforeEach(() => {
     nock(MOCK_BACKEND.rest)

--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -26,9 +26,12 @@ import {NotificationAPI} from '@wireapp/api-client/lib/notification';
 import {Self, SelfAPI} from '@wireapp/api-client/lib/self';
 import {WebSocketClient} from '@wireapp/api-client/lib/tcp';
 import {ReconnectingWebsocket} from '@wireapp/api-client/lib/tcp/ReconnectingWebsocket';
+import 'fake-indexeddb/auto';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {WS} from 'jest-websocket-mock';
 import nock, {cleanAll} from 'nock';
+
+import nodeCrypto from 'crypto';
 
 import {APIClient} from '@wireapp/api-client';
 import {AccentColor, ValidationUtil} from '@wireapp/commons';
@@ -87,6 +90,12 @@ describe('Account', () => {
     token_type: 'Bearer',
     user: 'aaf9a833-ef30-4c22-86a0-9adc8a15b3b4',
   };
+
+  beforeEach(() => {
+    // @ts-ignore
+    global.crypto = nodeCrypto.webcrypto;
+    global.window = {crypto: nodeCrypto.webcrypto, btoa: i => i};
+  });
 
   beforeEach(() => {
     nock(MOCK_BACKEND.rest)

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -424,7 +424,7 @@ export class Account<T = any> extends EventEmitter {
 
     let key = await secretStore.getsecretValue(coreCryptoKeyId);
     if (!key) {
-      key = window.crypto.getRandomValues(new Uint8Array(16));
+      key = crypto.getRandomValues(new Uint8Array(16));
       await secretStore.saveSecretValue(coreCryptoKeyId, key);
     }
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/WithMockedGenerics.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/WithMockedGenerics.test.ts
@@ -32,6 +32,7 @@ import {PayloadBundleState} from '../../../conversation';
 import {buildTextMessage} from '../../../conversation/message/MessageBuilder';
 import {CryptographyService} from '../../../cryptography';
 import {getUUID} from '../../../test/PayloadHelper';
+import {CoreCrypto} from '@wireapp/core-crypto/platforms/web/corecrypto';
 
 jest.mock('./Utility/getGenericMessageParams', () => {
   return {
@@ -69,7 +70,8 @@ const buildProteusService = (federated: boolean = false) => {
     useQualifiedIds: false,
     nbPrekeys: 1,
   });
-  return new ProteusService(apiClient, cryptographyService, {useQualifiedIds: federated});
+  const coreCrypto = {} as CoreCrypto;
+  return new ProteusService(apiClient, cryptographyService, coreCrypto, {useQualifiedIds: federated});
 };
 
 describe('sendGenericMessage', () => {

--- a/packages/core/src/util/encryptedStore.test.node.ts
+++ b/packages/core/src/util/encryptedStore.test.node.ts
@@ -17,17 +17,9 @@
  *
  */
 
-require('fake-indexeddb/auto');
-import nodeCrypto from 'crypto';
-
 import {createCustomEncryptedStore, createEncryptedStore} from './encryptedStore';
 
 describe('encryptedStore', () => {
-  beforeEach(() => {
-    // @ts-ignore
-    global.crypto = nodeCrypto.webcrypto;
-  });
-
   describe('Store and restore secret values with default encryption', () => {
     it('Stores secret values', async () => {
       const store = await createEncryptedStore('test');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4209,6 +4209,7 @@ __metadata:
     commander: 9.4.1
     cross-env: 7.0.3
     dotenv-defaults: 5.0.2
+    fake-indexeddb: ^4.0.0
     hash.js: 1.1.7
     http-status-codes: 2.2.0
     idb: 7.1.1


### PR DESCRIPTION
Since `@wireapp/core-crypto` is a esmodule only, we cannot, as of now, import it in our unit test, we need to manually mock it