### PR TITLE
fix: Handle case of empty list of users added to a conversation

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -52,6 +52,7 @@ describe('MLSService', () => {
 
       jest.spyOn(apiClient.api.client, 'claimMLSKeyPackages').mockResolvedValue({key_packages: []});
       jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation();
+      jest.spyOn(mlsService as any, 'processCommitAction').mockImplementation();
     });
 
     it('creates a new mls conversation and avoid adding the selfUser', async () => {


### PR DESCRIPTION
When no users are added to an MLS conversation, a simple update to the keying material can be done. 