### PR TITLE
feat: Consume prekey when a session is reset

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -31,6 +31,7 @@ import type {QualifiedId, QualifiedUserPreKeyBundleMap, UserPreKeyBundleMap} fro
 import logdown from 'logdown';
 
 import type {CoreCrypto} from '@wireapp/core-crypto';
+import {ClientAction} from '@wireapp/protocol-messaging';
 
 import {PrekeyGenerator} from './PrekeysGenerator';
 import type {
@@ -40,14 +41,20 @@ import type {
   SendProteusMessageParams,
 } from './ProteusService.types';
 
-import {MessageSendingState, SendResult} from '../../../conversation';
+import {GenericMessageType, MessageSendingState, SendResult} from '../../../conversation';
 import {MessageService} from '../../../conversation/message/MessageService';
 import {CoreDatabase} from '../../../storage/CoreDB';
 import type {EventHandlerResult} from '../../common.types';
 import {EventHandlerParams, handleBackendEvent} from '../EventHandler';
 import {getGenericMessageParams} from '../Utility/getGenericMessageParams';
 import {isClearFromMismatch} from '../Utility/isClearFromMismatch';
-import {buildEncryptedPayloads, constructSessionId, initSession, initSessions} from '../Utility/SessionHandler';
+import {
+  buildEncryptedPayloads,
+  constructSessionId,
+  deleteSession,
+  initSession,
+  initSessions,
+} from '../Utility/SessionHandler';
 
 export class ProteusService {
   private readonly messageService: MessageService;
@@ -65,10 +72,20 @@ export class ProteusService {
   }
 
   public async handleEvent(params: Pick<EventHandlerParams, 'event' | 'source' | 'dryRun'>): EventHandlerResult {
-    return handleBackendEvent({
+    const handledEvent = await handleBackendEvent({
       ...params,
       decryptMessage: (payload, userId, clientId) => this.decrypt(payload, userId, clientId),
     });
+    if (handledEvent?.decryptedData) {
+      const isSessionReset =
+        handledEvent.decryptedData[GenericMessageType.CLIENT_ACTION] === ClientAction.RESET_SESSION;
+      if (isSessionReset) {
+        this.logger.debug('A session was reset from a remote device');
+        // If a session reset message was received, we need to count a consumed prekey (because the sender has created a new session from a new prekey)
+        await this.prekeyGenerator.consumePrekey();
+      }
+    }
+    return handledEvent;
   }
 
   public init() {
@@ -215,6 +232,15 @@ export class ProteusService {
     const payload = await this.coreCryptoClient.proteusEncryptBatched(sessions, plainText);
 
     return buildEncryptedPayloads(payload);
+  }
+
+  public deleteSession(userId: QualifiedId, clientId: string) {
+    return deleteSession({
+      userId,
+      clientId,
+      useQualifiedIds: this.config.useQualifiedIds,
+      coreCrypto: this.coreCryptoClient,
+    });
   }
 
   public async encryptQualified(

--- a/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.ts
+++ b/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.ts
@@ -239,6 +239,17 @@ const initSessions = async ({
   return [...existingSessions, ...newSessions];
 };
 
+interface DeleteSessionParams {
+  userId: QualifiedId;
+  clientId: string;
+  coreCrypto: CoreCrypto;
+  useQualifiedIds: boolean;
+}
+function deleteSession(params: DeleteSessionParams) {
+  const sessionId = constructSessionId(params);
+  return params.coreCrypto.proteusSessionDelete(sessionId);
+}
+
 interface CreateSessionsFromPreKeysProps {
   preKeyBundleMap: UserPreKeyBundleMap;
   coreCrypto: CoreCrypto;
@@ -297,4 +308,4 @@ const buildEncryptedPayloads = <T>(payloads: Map<string, T>): EncryptedPayloads<
   }, {} as EncryptedPayloads<T>);
 };
 
-export {constructSessionId, initSession, initSessions, buildEncryptedPayloads};
+export {constructSessionId, initSession, initSessions, deleteSession, buildEncryptedPayloads};


### PR DESCRIPTION
Adds the handling of `session reset` messages (they should decrease the number of prekeys that are tracked since the sending side has generated a new session from a fresh prekey)