### PR TITLE
feat: trigger event when a new client is detected

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -207,6 +207,7 @@ export class ProteusService {
 
     if (!sessionExists) {
       await this.coreCryptoClient.proteusSessionSave(sessionId);
+      this.config.onNewClient?.({userId, clientId});
       await this.prekeyGenerator.consumePrekey();
       this.logger.info(`Created a new session from message for session ID "${sessionId}" and decrypted the message`);
     } else {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.types.ts
@@ -30,8 +30,13 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {AddUsersParams, MessageSendingOptions, SendCommonParams} from '../../../conversation';
 
+export interface NewClient {
+  clientId: string;
+  userId: QualifiedId;
+}
 export type ProteusServiceConfig = {
   useQualifiedIds: boolean;
+  onNewClient?: (client: NewClient) => void;
 };
 
 export type NewDevicePrekeys = {prekeys: PreKey[]; lastPrekey: PreKey};


### PR DESCRIPTION
When a new session is detected (by receiving an event from a client we do not have a session with) we need to warn the consumer that a new client has been detected. 
That can be used later on to trigger conversation degradation