### PR TITLE
feat(api-client): api v3 deprecated endpoints [FS-1268]

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -85,7 +85,6 @@ export class ConversationAPI {
     CODE_CHECK: '/code-check',
     CONVERSATIONS: '/conversations',
     MLS: '/mls',
-    IDS: 'ids',
     JOIN: '/join',
     LIST: 'list',
     LIST_IDS: 'list-ids',
@@ -868,6 +867,34 @@ export class ConversationAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateConversationAccess
    */
   public async putAccess(
+    conversationId: QualifiedId | string,
+    accessData: ConversationAccessUpdateData,
+  ): Promise<ConversationAccessUpdateEvent> {
+    const isQualifiedId = typeof conversationId !== 'string';
+
+    return this.backendFeatures.federationEndpoints && isQualifiedId
+      ? this.putQualifiedAccess(conversationId, accessData)
+      : this.putLegacyAccess(isQualifiedId ? conversationId.id : conversationId, accessData);
+  }
+
+  private async putQualifiedAccess(
+    conversationId: QualifiedId,
+    accessData: ConversationAccessUpdateData,
+  ): Promise<ConversationAccessUpdateEvent> {
+    const config: AxiosRequestConfig = {
+      data: accessData,
+      method: 'put',
+      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.ACCESS}`,
+    };
+
+    const response = await this.client.sendJSON<ConversationAccessUpdateEvent>(config);
+    return response.data;
+  }
+
+  /**
+   * @deprecated use putQualifiedAccess instead
+   */
+  private async putLegacyAccess(
     conversationId: string,
     accessData: ConversationAccessUpdateData,
   ): Promise<ConversationAccessUpdateEvent> {

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -103,6 +103,12 @@ export class ConversationAPI {
 
   constructor(protected readonly client: HttpClient, protected readonly backendFeatures: BackendFeatures) {}
 
+  private generateBaseConversationUrl(conversationId: QualifiedId): string {
+    return this.backendFeatures.federationEndpoints
+      ? `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}`
+      : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}`;
+  }
+
   /**
    * Delete a conversation code.
    * @param conversationId ID of conversation to delete the code for
@@ -870,42 +876,15 @@ export class ConversationAPI {
     conversationId: QualifiedId,
     accessData: ConversationAccessUpdateData,
   ): Promise<ConversationAccessUpdateEvent> {
-    return this.backendFeatures.federationEndpoints
-      ? this.putQualifiedAccess(conversationId, accessData)
-      : this.putLegacyAccess(conversationId.id, accessData);
-  }
-
-  private async putQualifiedAccess(
-    conversationId: QualifiedId,
-    accessData: ConversationAccessUpdateData,
-  ): Promise<ConversationAccessUpdateEvent> {
     const config: AxiosRequestConfig = {
       data: accessData,
       method: 'put',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.ACCESS}`,
+      url: `${this.generateBaseConversationUrl(conversationId)}/${ConversationAPI.URL.ACCESS}`,
     };
 
     const response = await this.client.sendJSON<ConversationAccessUpdateEvent>(config);
     return response.data;
   }
-
-  /**
-   * @deprecated use putQualifiedAccess instead
-   */
-  private async putLegacyAccess(
-    conversationId: string,
-    accessData: ConversationAccessUpdateData,
-  ): Promise<ConversationAccessUpdateEvent> {
-    const config: AxiosRequestConfig = {
-      data: accessData,
-      method: 'put',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.ACCESS}`,
-    };
-
-    const response = await this.client.sendJSON<ConversationAccessUpdateEvent>(config);
-    return response.data;
-  }
-
   /**
    * Update conversation properties.
    * @param conversationId The conversation ID to update properties of

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -25,7 +25,6 @@ import {
   ClientMismatch,
   Conversation,
   ConversationCode,
-  ConversationIds,
   ConversationRolesList,
   Conversations,
   DefaultConversationRoleName,
@@ -280,27 +279,6 @@ export class ConversationAPI {
     };
 
     return getConversationChunks();
-  }
-
-  /**
-   * Get all conversation IDs.
-   * @param limit Max. number of IDs to return
-   * @param conversationId Conversation ID to start from (exclusive)
-   * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/conversationIds
-   * @deprecated Use `getListConversations()` instead.
-   */
-  public async getConversationIds(limit: number, conversationId?: string): Promise<ConversationIds> {
-    const config: AxiosRequestConfig = {
-      method: 'get',
-      params: {
-        size: limit,
-        start: conversationId,
-      },
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.IDS}`,
-    };
-
-    const response = await this.client.sendJSON<ConversationIds>(config);
-    return response.data;
   }
 
   /**

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -867,14 +867,12 @@ export class ConversationAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateConversationAccess
    */
   public async putAccess(
-    conversationId: QualifiedId | string,
+    conversationId: QualifiedId,
     accessData: ConversationAccessUpdateData,
   ): Promise<ConversationAccessUpdateEvent> {
-    const isQualifiedId = typeof conversationId !== 'string';
-
-    return this.backendFeatures.federationEndpoints && isQualifiedId
+    return this.backendFeatures.federationEndpoints
       ? this.putQualifiedAccess(conversationId, accessData)
-      : this.putLegacyAccess(isQualifiedId ? conversationId.id : conversationId, accessData);
+      : this.putLegacyAccess(conversationId.id, accessData);
   }
 
   private async putQualifiedAccess(

--- a/packages/api-client/src/conversation/data/ConversationAccessUpdateData.ts
+++ b/packages/api-client/src/conversation/data/ConversationAccessUpdateData.ts
@@ -22,7 +22,7 @@ import {CONVERSATION_ACCESS, CONVERSATION_LEGACY_ACCESS_ROLE, CONVERSATION_ACCES
 /**@deprecated */
 export interface ConversationAccessV2UpdateData {
   access: CONVERSATION_ACCESS[];
-  access_role: CONVERSATION_LEGACY_ACCESS_ROLE;
+  access_role?: CONVERSATION_LEGACY_ACCESS_ROLE;
   access_role_v2?: CONVERSATION_ACCESS_ROLE[];
 }
 


### PR DESCRIPTION
Remove deprecated endpoints/fields due to api v3 updates (backwards compatibility):
- [x] The deprecated GET /conversations/ids endpoint was removed.
- [x] The deprecated endpoints GET /conversations/ids and GET /conversations have been removed. Use POST /conversations/list-ids followed by POST /conversations/list instead.
- [x] The endpoint PUT /conversations/:id/access has been removed. Use its qualified counterpart instead.
- [x] The field access_role_v2 in the Conversation type, in the request body of POST /conversations, and in the request body of PUT /conversations/:domain/:id/access has been removed. Its content is now contained in the access_role field instead. It replaces the legacy access role, previously contained in the access_role field.