### PR TITLE
feat: api v3 support for typing endpoint [FS-1311]

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -104,7 +104,7 @@ export class ConversationAPI {
   constructor(protected readonly client: HttpClient, protected readonly backendFeatures: BackendFeatures) {}
 
   private generateBaseConversationUrl(conversationId: QualifiedId): string {
-    return this.backendFeatures.federationEndpoints
+    return this.backendFeatures.federationEndpoints && conversationId.domain
       ? `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}`
       : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}`;
   }
@@ -856,11 +856,11 @@ export class ConversationAPI {
    * @param typingData The typing status
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/isTyping
    */
-  public async postTyping(conversationId: string, typingData: ConversationTypingData): Promise<void> {
+  public async postTyping(conversationId: QualifiedId, typingData: ConversationTypingData): Promise<void> {
     const config: AxiosRequestConfig = {
       data: typingData,
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.TYPING}`,
+      url: `${this.generateBaseConversationUrl(conversationId)}/${ConversationAPI.URL.TYPING}`,
     };
 
     await this.client.sendJSON(config);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -199,11 +199,11 @@ export class ConversationService {
     return sendMessage(() => (isMLS(params) ? this.sendMLSMessage(params) : this.proteusService.sendMessage(params)));
   }
 
-  public sendTypingStart(conversationId: string): Promise<void> {
+  public sendTypingStart(conversationId: QualifiedId): Promise<void> {
     return this.apiClient.api.conversation.postTyping(conversationId, {status: CONVERSATION_TYPING.STARTED});
   }
 
-  public sendTypingStop(conversationId: string): Promise<void> {
+  public sendTypingStop(conversationId: QualifiedId): Promise<void> {
     return this.apiClient.api.conversation.postTyping(conversationId, {status: CONVERSATION_TYPING.STOPPED});
   }
 


### PR DESCRIPTION
Add support for `/conversations/{domain}/{id}/typing` endpoint in api v3.