### PR TITLE
feat(core): recover mls conversation from quick sync 404 error [FS-1172]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -637,6 +637,13 @@ export class Account<T = any> extends EventEmitter {
       }
     });
 
+    const handleMissedNotifications = async (notificationId: string) => {
+      if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
+        await this.service?.conversation.handleEpochMissmatch();
+      }
+      return onMissedNotifications(notificationId);
+    };
+
     const processNotificationStream = async (abortHandler: AbortHandler) => {
       // Lock websocket in order to buffer any message that arrives while we handle the notification stream
       this.apiClient.transport.ws.lock();
@@ -648,7 +655,7 @@ export class Account<T = any> extends EventEmitter {
           await handleNotification(notification, source);
           onNotificationStreamProgress(progress);
         },
-        onMissedNotifications,
+        handleMissedNotifications,
         abortHandler,
       );
       this.logger.log(`Finished processing notifications ${JSON.stringify(results)}`, results);

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -639,7 +639,7 @@ export class Account<T = any> extends EventEmitter {
 
     const handleMissedNotifications = async (notificationId: string) => {
       if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
-        await this.service?.conversation.handleEpochMissmatch();
+        await this.service?.conversation.handleEpochMismatch();
       }
       return onMissedNotifications(notificationId);
     };

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -176,19 +176,6 @@ describe('ConversationService', () => {
       } as Conversation;
     };
 
-    it('tries to re-join when not established yet conversation found', async () => {
-      const [conversationService, {apiClient}] = buildConversationService();
-
-      const mlsConversation = createConversation(1);
-      const mockedDBResponse: Conversation[] = [mlsConversation];
-      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
-
-      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(false);
-
-      await conversationService.handleEpochMismatch();
-      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation.qualified_id);
-    });
-
     it('re-joins multiple not-established conversations', async () => {
       const [conversationService, {apiClient}] = buildConversationService();
 
@@ -203,21 +190,6 @@ describe('ConversationService', () => {
       await conversationService.handleEpochMismatch();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
-    });
-
-    it('tries to re-join when epoch mismatch detected', async () => {
-      const [conversationService, {apiClient, mlsService}] = buildConversationService();
-
-      const mlsConversation = createConversation(1);
-
-      const mockedDBResponse: Conversation[] = [mlsConversation];
-      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
-
-      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(2);
-
-      await conversationService.handleEpochMismatch();
-      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation.qualified_id);
     });
 
     it('re-joins multiple conversations when mismatches detected', async () => {

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -18,7 +18,7 @@
  */
 
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client';
-import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
+import {Conversation, ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 
 import {APIClient} from '@wireapp/api-client';
 import {GenericMessage} from '@wireapp/protocol-messaging';
@@ -47,6 +47,8 @@ jest.mock('../message/messageSender', () => ({
 const mockedMLSService = {
   encryptMessage: () => {},
   commitPendingProposals: () => Promise.resolve(),
+  getEpoch: () => Promise.resolve(),
+  joinByExternalCommit: jest.fn(),
 } as unknown as MLSService;
 
 const mockedProteusService = {
@@ -68,6 +70,7 @@ describe('ConversationService', () => {
         time: new Date().toISOString(),
       }),
     );
+
     jest.spyOn(client.api.user, 'postListClients').mockReturnValue(
       Promise.resolve({
         qualified_user_map: {
@@ -87,7 +90,8 @@ describe('ConversationService', () => {
       userId: PayloadHelper.getUUID(),
       clientId: PayloadHelper.getUUID(),
     };
-    return new ConversationService(
+
+    const conversationService = new ConversationService(
       client,
       new CryptographyService(client, new MemoryEngine(), {useQualifiedIds: false, nbPrekeys: 1}),
       {
@@ -96,6 +100,10 @@ describe('ConversationService', () => {
       mockedMLSService,
       mockedProteusService,
     );
+
+    jest.spyOn(conversationService, 'joinByExternalCommit');
+
+    return [conversationService, {apiClient: client, mlsService: mockedMLSService}] as const;
   }
 
   describe('"send PROTEUS"', () => {
@@ -109,7 +117,7 @@ describe('ConversationService', () => {
     ];
     messages.forEach(({type, message}) => {
       it(`calls callbacks when sending '${type}' message is successful`, async () => {
-        const conversationService = buildConversationService();
+        const [conversationService] = buildConversationService();
         const sentTime = new Date().toISOString();
 
         MockedMessagingProtocols.getGenericMessageParams.mockResolvedValue({
@@ -141,7 +149,7 @@ describe('ConversationService', () => {
     ];
     messages.forEach(({type, message}) => {
       it(`calls callbacks when sending '${type}' message is starting and successful`, async () => {
-        const conversationService = buildConversationService();
+        const [conversationService] = buildConversationService();
         const promise = conversationService.send({
           protocol: ConversationProtocol.MLS,
           groupId,
@@ -154,6 +162,98 @@ describe('ConversationService', () => {
     });
   });
 
+  describe('"handleEpochMismatch"', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    const createConversation = (epoch: number, conversationId?: string) => {
+      return {
+        group_id: 'group-id',
+        qualified_id: {id: conversationId || 'conversation-id', domain: 'staging.zinfra.io'},
+        protocol: ConversationProtocol.MLS,
+        epoch,
+      } as Conversation;
+    };
+
+    it('tries to re-join when not established yet conversation found', async () => {
+      const [conversationService, {apiClient}] = buildConversationService();
+
+      const mlsConversation = createConversation(1);
+      const mockedDBResponse: Conversation[] = [mlsConversation];
+      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
+
+      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(false);
+
+      await conversationService.handleEpochMismatch();
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation.qualified_id);
+    });
+
+    it('re-joins multiple not-established conversations', async () => {
+      const [conversationService, {apiClient}] = buildConversationService();
+
+      const mlsConversation1 = createConversation(1, 'conversation1');
+      const mlsConversation2 = createConversation(1, 'conversation2');
+
+      const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
+      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
+
+      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(false);
+
+      await conversationService.handleEpochMismatch();
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
+    });
+
+    it('tries to re-join when epoch mismatch detected', async () => {
+      const [conversationService, {apiClient, mlsService}] = buildConversationService();
+
+      const mlsConversation = createConversation(1);
+
+      const mockedDBResponse: Conversation[] = [mlsConversation];
+      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
+
+      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(true);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(2);
+
+      await conversationService.handleEpochMismatch();
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation.qualified_id);
+    });
+
+    it('re-joins multiple conversations when mismatches detected', async () => {
+      const [conversationService, {apiClient, mlsService}] = buildConversationService();
+
+      const mlsConversation1 = createConversation(1, 'conversation1');
+      const mlsConversation2 = createConversation(1, 'conversation2');
+
+      const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
+      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
+
+      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(true);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(2);
+
+      await conversationService.handleEpochMismatch();
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
+    });
+
+    it("does not re-join when there's no mismatch", async () => {
+      const [conversationService, {apiClient, mlsService}] = buildConversationService();
+
+      const mlsConversation = createConversation(1);
+
+      const mockedDBResponse: Conversation[] = [mlsConversation];
+      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
+
+      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(true);
+
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
+
+      await conversationService.handleEpochMismatch();
+      expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
+    });
+  });
+
   describe('fetchAllParticipantsClients', () => {
     it('gives the members and clients of a federated conversation', async () => {
       const members = {
@@ -162,7 +262,7 @@ describe('ConversationService', () => {
           ['test-id-2']: ['test-client-id-1-user-2', 'test-client-id-2-user-2'],
         },
       };
-      const conversationService = buildConversationService(true);
+      const [conversationService] = buildConversationService(true);
       MockedMessagingProtocols.getConversationQualifiedMembers.mockResolvedValue([
         {domain: 'test-domain', id: 'test-id-1'},
         {domain: 'test-domain', id: 'test-id-2'},
@@ -180,7 +280,7 @@ describe('ConversationService', () => {
         user2: ['client1', 'client2'],
         user3: ['client1', 'client2'],
       };
-      const conversationService = buildConversationService(true);
+      const [conversationService] = buildConversationService(true);
       jest
         .spyOn(conversationService['messageService'], 'sendMessage')
         .mockImplementation((_client, _recipients, _text, options) => {
@@ -197,7 +297,7 @@ describe('ConversationService', () => {
         domain1: {user1: ['client1', 'client2']},
         domain2: {user2: ['client1', 'client2'], user3: ['client1', 'client2']},
       };
-      const conversationService = buildConversationService(true);
+      const [conversationService] = buildConversationService(true);
       jest
         .spyOn(conversationService['messageService'], 'sendFederatedMessage')
         .mockImplementation((_client, _recipients, _text, options) => {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -423,7 +423,8 @@ export class ConversationService {
 
       if (!isEstablished) {
         //if conversation was found bot not yet established, join
-        this.joinByExternalCommit(qualifiedId);
+        await this.joinByExternalCommit(qualifiedId);
+        return;
       }
 
       const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
@@ -432,7 +433,8 @@ export class ConversationService {
       const shouldRejoin = remoteConversationEpoch !== epoch;
       if (shouldRejoin) {
         // -if there's no match -> try to rejoin
-        this.joinByExternalCommit(qualifiedId);
+        await this.joinByExternalCommit(qualifiedId);
+        return;
       }
     }
   }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -429,13 +429,19 @@ export class ConversationService {
           continue;
         }
 
-        const remoteConversationEpoch = await this.mlsService.getEpoch(groupId);
+        const clientStoredEpoch = await this.mlsService.getEpoch(groupId);
+
+        //corecrypto stores epoch number as BigInt, we're mapping both values to be sure comparison is valid
+        const isEpochMismatched = BigInt(clientStoredEpoch) !== BigInt(epoch);
 
         //if there's no match -> try to rejoin
-        const isEpochMismatched = remoteConversationEpoch !== epoch;
         if (isEpochMismatched) {
           this.logger.info(
-            `MLS conversation with id ${qualifiedId.id} was found in the database, epoch mismatch detected, joining via external commit`,
+            `MLS conversation with id ${
+              qualifiedId.id
+            } was found in the database, epoch mismatch detected {client: ${String(
+              clientStoredEpoch,
+            )}, backend: ${String(epoch)}}, joining via external commit`,
           );
           await this.joinByExternalCommit(qualifiedId);
         }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -411,7 +411,7 @@ export class ConversationService {
     const localEpoch = await this.mlsService.getEpoch(groupId);
 
     this.logger.log(
-      `Comparing conversation's (group_id: ${groupId}) local and backend epoch number: {local: ${BigInt(
+      `Comparing conversation's (group_id: ${groupId}) local and backend epoch number: {local: ${String(
         localEpoch,
       )}, backend: ${backendEpoch}}`,
     );

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -407,7 +407,7 @@ export class ConversationService {
     return this.mlsService.wipeConversation(groupId);
   }
 
-  private async isEpochMismatched(groupId: string, backendEpoch: number): Promise<boolean> {
+  private async matchesEpoch(groupId: string, backendEpoch: number): Promise<boolean> {
     const localEpoch = await this.mlsService.getEpoch(groupId);
 
     this.logger.log(
@@ -416,7 +416,7 @@ export class ConversationService {
       )}, backend: ${backendEpoch}}`,
     );
     //corecrypto stores epoch number as BigInt, we're mapping both values to be sure comparison is valid
-    return BigInt(localEpoch) !== BigInt(backendEpoch);
+    return BigInt(localEpoch) === BigInt(backendEpoch);
   }
 
   public async handleEpochMismatch() {
@@ -432,7 +432,7 @@ export class ConversationService {
     for (const {qualified_id: qualifiedId, group_id: groupId, epoch} of mlsConversations) {
       try {
         //if conversation is not established or epoch does not match -> try to rejoin
-        if (!(await this.isMLSConversationEstablished(groupId)) || (await this.isEpochMismatched(groupId, epoch))) {
+        if (!(await this.isMLSConversationEstablished(groupId)) || !(await this.matchesEpoch(groupId, epoch))) {
           this.logger.log(
             `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
           );

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -435,8 +435,7 @@ export class ConversationService {
           return;
         }
 
-        const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
-        const remoteConversationEpoch = await this.mlsService.getEpoch(groupIdBytes);
+        const remoteConversationEpoch = await this.mlsService.getEpoch(groupId);
 
         //if there's no match -> try to rejoin
         const isEpochMismatched = remoteConversationEpoch !== epoch;

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -408,7 +408,7 @@ export class ConversationService {
   }
 
   public async handleEpochMismatch() {
-    this.logger.info(`There were some missed messages, handling possible epoch missmatch in MLS conversations.`);
+    this.logger.info(`There were some missed messages, handling possible epoch mismatch in MLS conversations.`);
 
     //fetch all the mls conversations from backend
     const conversations = await this.apiClient.api.conversation.getConversationList();

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -44,6 +44,7 @@ import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conver
 import {CryptographyService} from '../../cryptography/';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService, optionalToUint8Array} from '../../messagingProtocols/mls';
+import {MLSConversation} from '../../messagingProtocols/mls/types';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
 import {
   AddUsersToProteusConversationParams,
@@ -53,7 +54,6 @@ import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/ful
 import {RemoteData} from '../content';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
 import {MessageService} from '../message/MessageService';
-import {MLSConversation} from '../../messagingProtocols/mls/types';
 
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
@@ -410,7 +410,7 @@ export class ConversationService {
     return protocol === ConversationProtocol.MLS && epoch !== undefined && group_id !== undefined;
   }
 
-  public async handleEpochMissmatch() {
+  public async handleEpochMismatch() {
     //fetch all the mls conversations from backend
     const conversations = await this.apiClient.api.conversation.getConversationList();
     const foundConversations = conversations.found || [];
@@ -432,7 +432,7 @@ export class ConversationService {
 
       const shouldRejoin = remoteConversationEpoch !== epoch;
       if (shouldRejoin) {
-        // -if there's no match -> try to rejoin
+        //if there's no match -> try to rejoin
         await this.joinByExternalCommit(qualifiedId);
         return;
       }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -420,14 +420,13 @@ export class ConversationService {
       //check all the established conversations' epoch with the core-crypto epoch
       for (const {qualified_id: qualifiedId, group_id: groupId, epoch} of mlsConversations) {
         const isEstablished = await this.isMLSConversationEstablished(groupId);
-
         if (!isEstablished) {
           this.logger.info(
             `MLS conversation with id ${qualifiedId.id} was found in the database, but not established yet, joining via external commit`,
           );
           //if conversation was found bot not yet established, join
           await this.joinByExternalCommit(qualifiedId);
-          return;
+          continue;
         }
 
         const remoteConversationEpoch = await this.mlsService.getEpoch(groupId);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -45,12 +45,12 @@ import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conver
 import {CryptographyService} from '../../cryptography/';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService, optionalToUint8Array} from '../../messagingProtocols/mls';
-import {MLSConversation} from '../../messagingProtocols/mls/types';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
 import {
   AddUsersToProteusConversationParams,
   SendProteusMessageParams,
 } from '../../messagingProtocols/proteus/ProteusService/ProteusService.types';
+import {isMLSConversation} from '../../util';
 import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/fullyQualifiedClientIdUtils';
 import {RemoteData} from '../content';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
@@ -407,11 +407,6 @@ export class ConversationService {
     return this.mlsService.wipeConversation(groupId);
   }
 
-  public isMLSConversation(conversation: Conversation): conversation is MLSConversation {
-    const {protocol, epoch, group_id} = conversation;
-    return protocol === ConversationProtocol.MLS && epoch !== undefined && group_id !== undefined;
-  }
-
   public async handleEpochMismatch() {
     this.logger.info(`There were some missed messages, handling possible epoch missmatch in MLS conversations.`);
 
@@ -419,7 +414,7 @@ export class ConversationService {
     const conversations = await this.apiClient.api.conversation.getConversationList();
     const foundConversations = conversations.found || [];
 
-    const mlsConversations = foundConversations.filter(this.isMLSConversation);
+    const mlsConversations = foundConversations.filter(isMLSConversation);
 
     try {
       //check all the established conversations' epoch with the core-crypto epoch

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -177,8 +177,9 @@ export class MLSService {
     return coreCryptoKeyPackagesPayload;
   }
 
-  public getEpoch(groupId: Uint8Array) {
-    return this.coreCryptoClient.conversationEpoch(groupId);
+  public getEpoch(groupId: string | Uint8Array) {
+    const groupIdBytes = typeof groupId === 'string' ? Decoder.fromBase64(groupId).asBytes : groupId;
+    return this.coreCryptoClient.conversationEpoch(groupIdBytes);
   }
 
   public async newProposal(proposalType: ProposalType, args: ProposalArgs | AddProposalArgs | RemoveProposalArgs) {

--- a/packages/core/src/messagingProtocols/mls/types.ts
+++ b/packages/core/src/messagingProtocols/mls/types.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {Conversation, ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CoreCryptoCallbacks} from '@wireapp/core-crypto';
@@ -74,3 +75,9 @@ export interface CryptoProtocolConfig<T = any> {
   /** if set to true, will use experimental proteus encryption/decryption library (core-crypto). If not set will fallback to the legacy proteus library (cryptobox) */
   proteus?: boolean;
 }
+
+export type MLSConversation = Conversation & {
+  protocol: ConversationProtocol.MLS;
+  epoch: number;
+  group_id: string;
+};

--- a/packages/core/src/util/TypePredicateUtil.ts
+++ b/packages/core/src/util/TypePredicateUtil.ts
@@ -17,8 +17,15 @@
  *
  */
 
-import {QualifiedUserClients, UserClients} from '@wireapp/api-client/lib/conversation/';
+import {
+  Conversation,
+  ConversationProtocol,
+  QualifiedUserClients,
+  UserClients,
+} from '@wireapp/api-client/lib/conversation/';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
+
+import {MLSConversation} from '../messagingProtocols/mls/types';
 
 export function isStringArray(obj: any): obj is string[] {
   return Array.isArray(obj) && (obj.length === 0 || typeof obj[0] === 'string');
@@ -49,4 +56,9 @@ export function isUserClients(obj: any): obj is UserClients {
     return isStringArray(firstUserClientArray);
   }
   return false;
+}
+
+export function isMLSConversation(conversation: Conversation): conversation is MLSConversation {
+  const {protocol, epoch, group_id} = conversation;
+  return protocol === ConversationProtocol.MLS && epoch !== undefined && group_id !== undefined;
 }


### PR DESCRIPTION
Adds logic for `MLS` conversation to recover from `404` error in quick sync flow.