### PR TITLE
feat: Add conversationId to calling messages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "@wireapp/core-crypto": "0.6.0-pre.4",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
-    "@wireapp/protocol-messaging": "1.42.0",
+    "@wireapp/protocol-messaging": "1.43.0",
     "@wireapp/store-engine-dexie": "workspace:^",
     "axios": "1.2.1",
     "bazinga64": "6.0.3",

--- a/packages/core/src/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/conversation/message/MessageBuilder.ts
@@ -40,12 +40,12 @@ import {
   Reaction,
   LastRead,
   Cleared,
+  ICalling,
 } from '@wireapp/protocol-messaging';
 
 import {
   ButtonActionConfirmationMessage,
   ButtonActionMessage,
-  CallMessage,
   ConfirmationMessage,
   DeleteMessage,
   EditedTextMessage,
@@ -296,10 +296,8 @@ export function buildSessionResetMessage(): GenericMessage {
   });
 }
 
-export function buildCallMessage(payloadBundle: CallMessage['content']): GenericMessage {
-  const callMessage = Calling.create({
-    content: payloadBundle,
-  });
+export function buildCallMessage(payload: ICalling): GenericMessage {
+  const callMessage = Calling.create(payload);
 
   return GenericMessage.create({
     [GenericMessageType.CALLING]: callMessage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,7 +4338,7 @@ __metadata:
     "@wireapp/core-crypto": 0.6.0-pre.4
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
-    "@wireapp/protocol-messaging": 1.42.0
+    "@wireapp/protocol-messaging": 1.43.0
     "@wireapp/store-engine-dexie": "workspace:^"
     axios: 1.2.1
     bazinga64: 6.0.3
@@ -4526,6 +4526,18 @@ __metadata:
     protobufjs-cli: 1.0.2
     typescript: 4.8.4
   checksum: 5ed5a07fdcca9ca269480ef838e5ef00dd9236e5cb7124d48732fed67065f67343c015734ace52d2d8a84ef183016b8520ad8b06386c49216904adb0b17cd72c
+  languageName: node
+  linkType: hard
+
+"@wireapp/protocol-messaging@npm:1.43.0":
+  version: 1.43.0
+  resolution: "@wireapp/protocol-messaging@npm:1.43.0"
+  dependencies:
+    long: 5.2.0
+    protobufjs: 7.1.2
+    protobufjs-cli: 1.0.2
+    typescript: 4.8.4
+  checksum: 6d6fc2e9cb6118cb5180a22898ca23a0b1bf3783b31a94840001195da8f1644b2e42009bd9513f1048208a2d469aa20d750f3a42515a4a7960efa38c1894e479
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This will allow sending calling message to the `selfConversation` referring to a call in a different conversation