### PR TITLE
fix: Warn consumer when a new client is detected

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -213,6 +213,7 @@ export class ProteusService {
       if (!sessionExists) {
         await this.coreCryptoClient.proteusSessionSave(sessionId);
         await this.prekeyGenerator.consumePrekey();
+        this.config.onNewClient?.({userId, clientId});
         this.logger.info(`Created a new session from message for session ID "${sessionId}" and decrypted the message`);
       } else {
         this.logger.info(`Decrypted message for session ID "${sessionId}"`);


### PR DESCRIPTION
This will allow the consumer to be warned that a new client sent a message. 
This allows detecting a change in verified devices (an potentially degrade a conversation verification state if a message from an unknown device has been sent)