### PR TITLE
fix: Improve granularity of coreCrypto decryption error handling

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@
  */
 
 export {Account, ConnectionState, ProcessedEventPayload} from './Account';
+export {ProteusErrors} from './messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator';
 export * as auth from './auth/';
 export * as conversation from './conversation/';
 export {CoreError} from './CoreError';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,6 @@
  */
 
 export {Account, ConnectionState, ProcessedEventPayload} from './Account';
-export {ProteusErrors} from './messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator';
 export * as auth from './auth/';
 export * as conversation from './conversation/';
 export {CoreError} from './CoreError';

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
@@ -27,7 +27,7 @@ describe('generateDecryptionError', () => {
   it('returns a ProteusError.DecryptError', () => {
     const error = generateDecryptionError(basePayload, new Error());
     expect(error).toBeInstanceOf(DecryptionError);
-    expect(error.message).toBe('Failed to decrypt message from user1 (client1) with unkown error');
+    expect(error.message).toBe('Unknown decryption error from user1 (client1)');
     expect(error.code).toBe(ProteusErrors.Unknown);
   });
 
@@ -43,5 +43,12 @@ describe('generateDecryptionError', () => {
     expect(error).toBeInstanceOf(DecryptionError);
     expect(error.message).toBe('Invalid message from user1 (client1)');
     expect(error.code).toBe(ProteusErrors.InvalidMessage);
+  });
+
+  it('handles invalid signature', () => {
+    const error = generateDecryptionError(basePayload, new Error('InvalidSignature'));
+    expect(error).toBeInstanceOf(DecryptionError);
+    expect(error.message).toBe('Invalid signature from user1 (client1)');
+    expect(error.code).toBe(ProteusErrors.InvalidSignature);
   });
 });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
@@ -17,21 +17,15 @@
  *
  */
 
-import logdown from 'logdown';
-
 import {generateDecryptionError} from './DecryptionErrorGenerator';
 
 import {DecryptionError} from '../../../../errors/DecryptionError';
-
-const logger = {
-  warn: jest.fn(),
-} as unknown as logdown.Logger;
 
 const basePayload = {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'};
 
 describe('generateDecryptionError', () => {
   it('returns a ProteusError.DecryptError', () => {
-    const error = generateDecryptionError(basePayload, new Error(), logger);
+    const error = generateDecryptionError(basePayload, new Error());
     expect(error).toBeInstanceOf(DecryptionError);
     expect(error.message).toBe('Unknown decryption error');
   });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {generateDecryptionError} from './DecryptionErrorGenerator';
+import {generateDecryptionError, ProteusErrors} from './DecryptionErrorGenerator';
 
 import {DecryptionError} from '../../../../errors/DecryptionError';
 
@@ -27,6 +27,21 @@ describe('generateDecryptionError', () => {
   it('returns a ProteusError.DecryptError', () => {
     const error = generateDecryptionError(basePayload, new Error());
     expect(error).toBeInstanceOf(DecryptionError);
-    expect(error.message).toBe('Unknown decryption error');
+    expect(error.message).toBe('Failed to decrypt message from user1 (client1) with unkown error');
+    expect(error.code).toBe(ProteusErrors.Unknown);
+  });
+
+  it('handles remote identity changed', () => {
+    const error = generateDecryptionError(basePayload, new Error('RemoteIdentityChanged'));
+    expect(error).toBeInstanceOf(DecryptionError);
+    expect(error.message).toBe('Remote identity of user1 (client1) has changed');
+    expect(error.code).toBe(ProteusErrors.RemoteIdentityChanged);
+  });
+
+  it('handles invalid message', () => {
+    const error = generateDecryptionError(basePayload, new Error('InvalidMessage'));
+    expect(error).toBeInstanceOf(DecryptionError);
+    expect(error.message).toBe('Invalid message from user1 (client1)');
+    expect(error.code).toBe(ProteusErrors.InvalidMessage);
   });
 });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
@@ -21,9 +21,6 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {DecryptionError} from '../../../../errors/DecryptionError';
 
-type ErrorWithCode = Error & {code?: number};
-const hasErrorCode = (error: any): ErrorWithCode => error && error.code;
-
 export const ProteusErrors = {
   InvalidMessage: 201,
   RemoteIdentityChanged: 204,
@@ -42,8 +39,7 @@ const CoreCryptoErrorMapping: Record<CoreCryptoErrors, ProteusErrorCode> = {
 };
 
 const mapCoreCryptoError = (error: any): ProteusErrorCode => {
-  const code = hasErrorCode(error) ? error.code : CoreCryptoErrorMapping[error.message as CoreCryptoErrors];
-  return code ?? ProteusErrors.Unknown;
+  return CoreCryptoErrorMapping[error.message as CoreCryptoErrors] ?? ProteusErrors.Unknown;
 };
 
 const getErrorMessage = (code: ProteusErrorCode, userId: QualifiedId, clientId: string): string => {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
@@ -18,46 +18,53 @@
  */
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-import logdown from 'logdown';
 
 import {DecryptionError} from '../../../../errors/DecryptionError';
 
 type ErrorWithCode = Error & {code?: number};
 const hasErrorCode = (error: any): ErrorWithCode => error && error.code;
 
-const generateDecryptionError = (
-  senderInfo: {clientId: string; userId: QualifiedId},
-  error: any,
-  logger: logdown.Logger,
-): DecryptionError => {
-  const errorCode = hasErrorCode(error) ? error.code ?? 999 : 999;
-  let message = 'Unknown decryption error';
+export const ProteusErrors = {
+  InvalidMessage: 201,
+  RemoteIdentityChanged: 204,
+  Unknown: 999,
+} as const;
 
-  const {clientId: remoteClientId, userId} = senderInfo;
-  const {id: remoteUserId} = userId;
+type ProteusErrorCode = typeof ProteusErrors[keyof typeof ProteusErrors];
 
-  const isDuplicateMessage = false; // TODO when coreCrypto returns ganular errors
-  const isOutdatedMessage = false; // TODO when coreCrypto returns ganular errors
-  // We don't need to show these message errors to the user
-  if (isDuplicateMessage || isOutdatedMessage) {
-    message = `Message from user ID "${remoteUserId}" will not be handled because it is outdated or a duplicate.`;
-  }
-
-  const isInvalidMessage = false; // TODO when coreCrypto returns ganular errors
-  const isInvalidSignature = false; // TODO when coreCrypto returns ganular errors
-  const isRemoteIdentityChanged = false; // TODO when coreCrypto returns ganular errors
-  // Session is broken, let's see what's really causing it...
-  if (isInvalidMessage || isInvalidSignature) {
-    message = `Session with user '${remoteUserId}' (${remoteClientId}) is broken.\nReset the session for possible fix.`;
-  } else if (isRemoteIdentityChanged) {
-    message = `Remote identity of client '${remoteClientId}' from user '${remoteUserId}' changed`;
-  }
-
-  logger.warn(
-    `Failed to decrypt event from client '${remoteClientId}' of user '${remoteUserId}'.\nError Code: '${errorCode}'\nError Message: ${error.message}`,
-    error,
-  );
-  return new DecryptionError(message, errorCode);
+const CoreCryptoErrorMapping: Record<string, ProteusErrorCode> = {
+  InvalidMessage: ProteusErrors.InvalidMessage,
+  RemoteIdentityChanged: ProteusErrors.RemoteIdentityChanged,
 };
 
-export {generateDecryptionError};
+const mapCoreCryptoError = (error: any): ProteusErrorCode => {
+  const code = hasErrorCode(error) ? error.code : CoreCryptoErrorMapping[error.message];
+  return code ?? ProteusErrors.Unknown;
+};
+
+const getErrorMessage = (code: ProteusErrorCode, userId: QualifiedId, clientId: string): string => {
+  const sender = `${userId.id} (${clientId})`;
+  switch (code) {
+    case ProteusErrors.InvalidMessage:
+      return `Invalid message from ${sender}`;
+
+    case ProteusErrors.RemoteIdentityChanged:
+      return `Remote identity of ${sender} has changed`;
+
+    case ProteusErrors.Unknown:
+      return `Failed to decrypt message from ${sender} with unkown error`;
+
+    default:
+      return `Unhandled error code "${code}" from ${sender}`;
+  }
+};
+
+type SenderInfo = {clientId: string; userId: QualifiedId};
+export const generateDecryptionError = (senderInfo: SenderInfo, error: any): DecryptionError => {
+  const {clientId: remoteClientId, userId} = senderInfo;
+
+  const code = mapCoreCryptoError(error);
+  const message = getErrorMessage(code, userId, remoteClientId);
+
+  return new DecryptionError(message, code);
+};

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
@@ -27,18 +27,22 @@ const hasErrorCode = (error: any): ErrorWithCode => error && error.code;
 export const ProteusErrors = {
   InvalidMessage: 201,
   RemoteIdentityChanged: 204,
+  InvalidSignature: 207,
   Unknown: 999,
 } as const;
 
-type ProteusErrorCode = typeof ProteusErrors[keyof typeof ProteusErrors];
+type CoreCryptoErrors = keyof typeof ProteusErrors;
+type ProteusErrorCode = typeof ProteusErrors[CoreCryptoErrors];
 
-const CoreCryptoErrorMapping: Record<string, ProteusErrorCode> = {
+const CoreCryptoErrorMapping: Record<CoreCryptoErrors, ProteusErrorCode> = {
   InvalidMessage: ProteusErrors.InvalidMessage,
   RemoteIdentityChanged: ProteusErrors.RemoteIdentityChanged,
+  InvalidSignature: ProteusErrors.InvalidSignature,
+  Unknown: ProteusErrors.Unknown,
 };
 
 const mapCoreCryptoError = (error: any): ProteusErrorCode => {
-  const code = hasErrorCode(error) ? error.code : CoreCryptoErrorMapping[error.message];
+  const code = hasErrorCode(error) ? error.code : CoreCryptoErrorMapping[error.message as CoreCryptoErrors];
   return code ?? ProteusErrors.Unknown;
 };
 
@@ -48,11 +52,14 @@ const getErrorMessage = (code: ProteusErrorCode, userId: QualifiedId, clientId: 
     case ProteusErrors.InvalidMessage:
       return `Invalid message from ${sender}`;
 
+    case ProteusErrors.InvalidSignature:
+      return `Invalid signature from ${sender}`;
+
     case ProteusErrors.RemoteIdentityChanged:
       return `Remote identity of ${sender} has changed`;
 
     case ProteusErrors.Unknown:
-      return `Failed to decrypt message from ${sender} with unkown error`;
+      return `Unknown decryption error from ${sender}`;
 
     default:
       return `Unhandled error code "${code}" from ${sender}`;

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -232,7 +232,7 @@ export class ProteusService {
 
       return decryptedMessage;
     } catch (error) {
-      throw generateDecryptionError({userId, clientId}, error, this.logger);
+      throw generateDecryptionError({userId, clientId}, error);
     }
   }
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/index.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/index.ts
@@ -20,3 +20,4 @@
 export * from './ProteusService';
 export * from '../Utility';
 export * from './ProteusService.types';
+export {ProteusErrors} from './DecryptionErrorGenerator';


### PR DESCRIPTION
We do not have perfect handling for decryption error code on coreCrypto side, but we can still handle a bunch of different scenarios that will improve user facing errors on the front-end