### PR TITLE
feat: Keep track of subconversation group ids

### DIFF
--- a/packages/api-client/src/event/ConversationEvent.ts
+++ b/packages/api-client/src/event/ConversationEvent.ts
@@ -157,6 +157,8 @@ export interface ConversationOtrMessageAddEvent extends BaseConversationEvent {
 export interface ConversationMLSMessageAddEvent extends BaseConversationEvent {
   data: ConversationMLSMessageAddData;
   type: CONVERSATION_EVENT.MLS_MESSAGE_ADD;
+  /** if the message is sent in a subconversation, there is the identifier of the subconversation */
+  subconv?: string;
   senderClientId: string;
 }
 

--- a/packages/core/src/messagingProtocols/mls/EventHandler/ConversationEvent/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/ConversationEvent/events/messageAdd/messageAdd.ts
@@ -39,6 +39,7 @@ const handleMLSMessageAdd = async ({mlsService, event, logger}: HandleMLSMessage
 
   const groupId = await mlsService.getGroupIdFromConversationId(
     event.qualified_conversation ?? {id: event.conversation, domain: ''},
+    event.subconv,
   );
   const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/subconversationGroupIdMapper.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/subconversationGroupIdMapper.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {getGroupId, storeSubconversationGroupId} from './subconversationGroupIdMapper';
+
+describe('subconversationGroupIdMapper', () => {
+  it('returns empty groupId if conversation is not known', () => {
+    const groupId = getGroupId({domain: 'example.com', id: '123'}, 'subconversation');
+    expect(groupId).toBeUndefined();
+  });
+
+  it('returns the stored groupId', () => {
+    const conversationId = {domain: 'example.com', id: '123'};
+    const subconversation = 'subconversation';
+    const groupId = 'groupID';
+    storeSubconversationGroupId(conversationId, subconversation, groupId);
+
+    const result = getGroupId({domain: 'example.com', id: '123'}, 'subconversation');
+    expect(result).toBe(groupId);
+  });
+});

--- a/packages/core/src/messagingProtocols/mls/MLSService/subconversationGroupIdMapper.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/subconversationGroupIdMapper.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+const groupIdMap = new Map<string, string>();
+
+function generateSubconversationId(parentConversation: QualifiedId, subconversation: string): string {
+  return `${parentConversation.id}@${parentConversation.domain}:${subconversation}`;
+}
+
+export function storeSubconversationGroupId(
+  parentConversation: QualifiedId,
+  subconversation: string,
+  subgroupId: string,
+): void {
+  const subconversationId = generateSubconversationId(parentConversation, subconversation);
+  groupIdMap.set(subconversationId, subgroupId);
+}
+
+export function getGroupId(parentConversation: QualifiedId, subconversation: string): string | undefined {
+  const subconversationId = generateSubconversationId(parentConversation, subconversation);
+  return groupIdMap.get(subconversationId);
+}


### PR DESCRIPTION
Will allow parsing and decrypting messages that are sent in a subconversation.