### PR TITLE
chore: add eslint warning for floating promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
     "jsx-a11y/no-static-element-interactions": "warn",
     "jsx-a11y/anchor-has-content": "warn",
     "jsx-a11y/label-has-associated-control": "warn",
-    "jsx-a11y/heading-has-content": "warn"
+    "jsx-a11y/heading-has-content": "warn",
+    "@typescript-eslint/no-floating-promises": "warn"
   }
 }


### PR DESCRIPTION
Adds `"@typescript-eslint/no-floating-promises": "warn"` eslint rule.