### PR TITLE
runfix: prevent checkboxes from squishing [ACC-398]

### DIFF
--- a/packages/react-ui-kit/src/Form/Checkbox.tsx
+++ b/packages/react-ui-kit/src/Form/Checkbox.tsx
@@ -83,7 +83,7 @@ const StyledLabel = ({
           boxSizing: 'border-box',
           content: '""',
           display: 'inline-block',
-          width: '22px',
+          minWidth: '22px',
           height: '22px',
           lineHeight: '1.4rem',
           margin: '0 8px 0 0px',

--- a/packages/react-ui-kit/src/Form/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Checkbox.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`"Checkbox" renders (dark theme) 1`] = `
   box-sizing: border-box;
   content: "";
   display: inline-block;
-  width: 22px;
+  min-width: 22px;
   height: 22px;
   line-height: 1.4rem;
   margin: 0 8px 0 0px;
@@ -203,7 +203,7 @@ exports[`"Checkbox" renders 1`] = `
   box-sizing: border-box;
   content: "";
   display: inline-block;
-  width: 22px;
+  min-width: 22px;
   height: 22px;
   line-height: 1.4rem;
   margin: 0 8px 0 0px;
@@ -328,7 +328,7 @@ exports[`"Checkbox" renders as invalid 1`] = `
   box-sizing: border-box;
   content: "";
   display: inline-block;
-  width: 22px;
+  min-width: 22px;
   height: 22px;
   line-height: 1.4rem;
   margin: 0 8px 0 0px;
@@ -449,7 +449,7 @@ exports[`"Checkbox" renders disabled 1`] = `
   box-sizing: border-box;
   content: "";
   display: inline-block;
-  width: 22px;
+  min-width: 22px;
   height: 22px;
   line-height: 1.4rem;
   margin: 0 8px 0 0px;


### PR DESCRIPTION
### Issue 
[[ACC-398]](https://wearezeta.atlassian.net/browse/ACC-398)
- checkboxes get sqished by the label in some modals / when the font size is set to max
![Screenshot from 2023-01-10 13-45-41](https://user-images.githubusercontent.com/78490891/211557710-dd0b820a-33d5-4223-9529-31889513c01a.png)
![image](https://user-images.githubusercontent.com/78490891/211558035-cfc3a8f3-6e57-421d-ba9a-12e586e840b4.png)

### Solution
- assign a min-width to the checkbox
![Screenshot from 2023-01-10 13-46-40](https://user-images.githubusercontent.com/78490891/211558257-40f55562-b78d-4424-8248-251ce0a0f742.png)


[ACC-398]: https://wearezeta.atlassian.net/browse/ACC-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ