### PR TITLE
refactor: Lazy load crypto clients 

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -313,17 +313,6 @@ export class Account<T = any> extends EventEmitter {
     return validClient;
   }
 
-  /**
-   * In order to be able to send MLS messages, the core needs a few information from the consumer.
-   * Namely:
-   * - is the current user allowed to administrate a specific conversation
-   * - what is the groupId of a conversation
-   * @param mlsCallbacks
-   */
-  configureMLSCallbacks(mlsCallbacks: MLSCallbacks) {
-    this.service?.mls?.configureMLSCallbacks(mlsCallbacks);
-  }
-
   private async generateSecretKey(baseDbName: string) {
     const coreCryptoKeyId = 'corecrypto-key';
     const dbName = `secrets-${baseDbName}`;
@@ -365,6 +354,17 @@ export class Account<T = any> extends EventEmitter {
         this.logger.debug(`Successfully uploaded '${prekeys.length}' PreKeys.`);
       },
     });
+  }
+
+  /**
+   * In order to be able to send MLS messages, the core needs a few information from the consumer.
+   * Namely:
+   * - is the current user allowed to administrate a specific conversation
+   * - what is the groupId of a conversation
+   * @param mlsCallbacks
+   */
+  configureMLSCallbacks(mlsCallbacks: MLSCallbacks) {
+    this.service?.mls?.configureMLSCallbacks(mlsCallbacks);
   }
 
   public async initServices(context: Context): Promise<void> {

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -596,10 +596,6 @@ export class Account<T = any> extends EventEmitter {
     return `wire@${this.apiClient.config.urls.name}@${context.userId}${clientType}`;
   }
 
-  private generateSecretsDbName(context: Context) {
-    return `secrets-${this.generateDbName(context)}`;
-  }
-
   private generateCoreDbName(context: Context) {
     return `core-${this.generateDbName(context)}`;
   }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {CommitBundle} from '@wireapp/core-crypto/platforms/web/corecrypto';
+import type {CommitBundle} from '@wireapp/core-crypto';
 
 export interface UploadCommitOptions {
   /**

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
@@ -20,7 +20,7 @@
 import {PreKey} from '@wireapp/api-client/lib/auth';
 import {Encoder} from 'bazinga64';
 
-import {CoreCrypto} from '@wireapp/core-crypto';
+import type {CoreCrypto} from '@wireapp/core-crypto';
 
 import {CryptoClient, LAST_PREKEY_ID} from './CryptoClient.types';
 import {PrekeyTracker} from './PrekeysTracker';

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
@@ -115,11 +115,11 @@ export class CoreCryptoWrapper implements CryptoClient {
     await this.coreCrypto.proteusSessionFromPrekey(sessionId, Uint8Array.from(fakePrekey));
   }
 
-  async migrateToCoreCrypto(dbName: string) {
+  async migrateFromCryptobox(dbName: string) {
     return this.coreCrypto.proteusCryptoboxMigrate(dbName);
   }
 
-  get isCoreCrypto() {
-    return true;
+  async wipe() {
+    return this.coreCrypto.wipe();
   }
 }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
@@ -39,6 +39,10 @@ export class CoreCryptoWrapper implements CryptoClient {
     this.prekeyTracker = new PrekeyTracker(this, db, config);
   }
 
+  getNativeClient() {
+    return this.coreCrypto;
+  }
+
   encrypt(sessions: string[], plainText: Uint8Array) {
     return this.coreCrypto.proteusEncryptBatched(sessions, plainText);
   }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
@@ -19,10 +19,14 @@
 
 import {PreKey} from '@wireapp/api-client/lib/auth';
 
+import type {CoreCrypto} from '@wireapp/core-crypto';
+import type {Cryptobox} from '@wireapp/cryptobox';
+
 export const LAST_PREKEY_ID = 65535;
 export type InitialPrekeys = {prekeys: PreKey[]; lastPrekey: PreKey};
 
 export interface CryptoClient {
+  getNativeClient(): CoreCrypto | Cryptobox;
   encrypt(sessions: string[], plainText: Uint8Array): Promise<Map<string, Uint8Array>>;
   decrypt(sessionId: string, message: Uint8Array): Promise<Uint8Array>;
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
@@ -19,14 +19,11 @@
 
 import {PreKey} from '@wireapp/api-client/lib/auth';
 
-import type {CoreCrypto} from '@wireapp/core-crypto';
-import type {Cryptobox} from '@wireapp/cryptobox';
-
 export const LAST_PREKEY_ID = 65535;
 export type InitialPrekeys = {prekeys: PreKey[]; lastPrekey: PreKey};
 
-export interface CryptoClient {
-  getNativeClient(): CoreCrypto | Cryptobox;
+export interface CryptoClient<T = unknown> {
+  getNativeClient(): T;
   encrypt(sessions: string[], plainText: Uint8Array): Promise<Map<string, Uint8Array>>;
   decrypt(sessionId: string, message: Uint8Array): Promise<Uint8Array>;
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
@@ -45,6 +45,9 @@ export interface CryptoClient {
   deleteSession(sessionId: string): Promise<void>;
   newPrekey(id: number): Promise<PreKey>;
   debugBreakSession(sessionId: string): void;
-  migrateToCoreCrypto(dbName: string): Promise<void>;
-  get isCoreCrypto(): boolean;
+  /**
+   * Will migrate the database from a different client type
+   */
+  migrateFromCryptobox?(dbName: string): Promise<void>;
+  wipe(): Promise<void>;
 }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
@@ -20,6 +20,7 @@
 import {PreKey} from '@wireapp/api-client/lib/auth';
 
 import {Cryptobox} from '@wireapp/cryptobox';
+import {CRUDEngine} from '@wireapp/store-engine';
 
 import {CryptoClient, LAST_PREKEY_ID} from './CryptoClient.types';
 
@@ -27,6 +28,10 @@ type Config = {
   onNewPrekeys: (prekeys: PreKey[]) => void;
 };
 
+export function buildClient(storeEngine: CRUDEngine, config: Config & {nbPrekeys: number}) {
+  const cryptobox = new Cryptobox(storeEngine, config.nbPrekeys);
+  return new CryptoboxWrapper(cryptobox, {onNewPrekeys: () => {}});
+}
 export class CryptoboxWrapper implements CryptoClient {
   constructor(private readonly cryptobox: Cryptobox, config: Config) {
     this.cryptobox.on(Cryptobox.TOPIC.NEW_PREKEYS, prekeys => {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
@@ -35,6 +35,10 @@ export class CryptoboxWrapper implements CryptoClient {
     });
   }
 
+  getNativeClient() {
+    return this.cryptobox;
+  }
+
   async encrypt(sessions: string[], plainText: Uint8Array) {
     const encryptedPayloads: [string, Uint8Array][] = [];
     for (const sessionId of sessions) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
@@ -119,11 +119,5 @@ export class CryptoboxWrapper implements CryptoClient {
     this.cryptobox['cachedSessions'].set(sessionId, session);
   }
 
-  async migrateToCoreCrypto() {
-    // No migration needed for cryptobox
-  }
-
-  get isCoreCrypto() {
-    return false;
-  }
+  async wipe() {}
 }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.mocks.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.mocks.ts
@@ -22,7 +22,7 @@ import {ClientType} from '@wireapp/api-client/lib/client';
 import {APIClient} from '@wireapp/api-client';
 import {CoreCrypto} from '@wireapp/core-crypto';
 
-import {CryptoClientType} from './CryptoClient';
+import {CoreCryptoWrapper} from './CryptoClient/CoreCryptoWrapper';
 import {ProteusService} from './ProteusService';
 
 import {getUUID} from '../../../test/PayloadHelper';
@@ -40,9 +40,8 @@ export const buildProteusService = async (
 
   const coreCrypto = await CoreCrypto.deferredInit('store-name', 'key');
 
-  const proteusService = new ProteusService(apiClient, [CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {
+  const proteusService = new ProteusService(apiClient, new CoreCryptoWrapper(coreCrypto, {} as any, {} as any), {
     nbPrekeys: 0,
-    onNewPrekeys: jest.fn(),
     useQualifiedIds: federated,
   });
   return [proteusService, {apiClient, coreCrypto}];

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.mocks.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.mocks.ts
@@ -22,6 +22,7 @@ import {ClientType} from '@wireapp/api-client/lib/client';
 import {APIClient} from '@wireapp/api-client';
 import {CoreCrypto} from '@wireapp/core-crypto';
 
+import {CryptoClientType} from './CryptoClient';
 import {ProteusService} from './ProteusService';
 
 import {getUUID} from '../../../test/PayloadHelper';
@@ -39,7 +40,7 @@ export const buildProteusService = async (
 
   const coreCrypto = await CoreCrypto.deferredInit('store-name', 'key');
 
-  const proteusService = new ProteusService(apiClient, coreCrypto, {} as any, {
+  const proteusService = new ProteusService(apiClient, [CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {
     nbPrekeys: 0,
     onNewPrekeys: jest.fn(),
     useQualifiedIds: federated,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -33,7 +33,7 @@ import logdown from 'logdown';
 import {ClientAction} from '@wireapp/protocol-messaging';
 import {CRUDEngine} from '@wireapp/store-engine';
 
-import {wrapCryptoClient, CryptoClient, CryptoClientDef} from './CryptoClient';
+import {CryptoClient} from './CryptoClient';
 import {cryptoMigrationStore} from './cryptoMigrationStateStore';
 import {generateDecryptionError} from './DecryptionErrorGenerator';
 import type {
@@ -46,7 +46,6 @@ import {migrateToQualifiedSessionIds} from './sessionIdMigrator';
 
 import {GenericMessageType, MessageSendingState, SendResult} from '../../../conversation';
 import {MessageService} from '../../../conversation/message/MessageService';
-import {CoreDatabase} from '../../../storage/CoreDB';
 import type {EventHandlerResult} from '../../common.types';
 import {EventHandlerParams, handleBackendEvent} from '../EventHandler';
 import {getGenericMessageParams} from '../Utility/getGenericMessageParams';
@@ -62,16 +61,13 @@ import {
 export class ProteusService {
   private readonly messageService: MessageService;
   private readonly logger = logdown('@wireapp/core/ProteusService');
-  private readonly cryptoClient: CryptoClient;
 
   constructor(
     private readonly apiClient: APIClient,
-    cryptoClient: CryptoClientDef,
-    db: CoreDatabase,
+    private readonly cryptoClient: CryptoClient,
     private readonly config: ProteusServiceConfig,
   ) {
     this.messageService = new MessageService(this.apiClient, this);
-    this.cryptoClient = wrapCryptoClient(cryptoClient, db, config);
   }
 
   public async handleEvent(params: Pick<EventHandlerParams, 'event' | 'source' | 'dryRun'>): EventHandlerResult {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -30,12 +30,10 @@ import type {
 import type {QualifiedId, QualifiedUserPreKeyBundleMap, UserPreKeyBundleMap} from '@wireapp/api-client/lib/user';
 import logdown from 'logdown';
 
-import {CoreCrypto} from '@wireapp/core-crypto';
-import {Cryptobox} from '@wireapp/cryptobox';
 import {ClientAction} from '@wireapp/protocol-messaging';
 import {CRUDEngine} from '@wireapp/store-engine';
 
-import {wrapCryptoClient, CryptoClient} from './CryptoClient';
+import {wrapCryptoClient, CryptoClient, CryptoClientDef} from './CryptoClient';
 import {cryptoMigrationStore} from './cryptoMigrationStateStore';
 import {generateDecryptionError} from './DecryptionErrorGenerator';
 import type {
@@ -68,7 +66,7 @@ export class ProteusService {
 
   constructor(
     private readonly apiClient: APIClient,
-    cryptoClient: CoreCrypto | Cryptobox,
+    cryptoClient: CryptoClientDef,
     db: CoreDatabase,
     private readonly config: ProteusServiceConfig,
   ) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -106,10 +106,10 @@ export class ProteusService {
       }
     }
 
-    if (!cryptoMigrationStore.coreCrypto.isReady(dbName) && this.cryptoClient.isCoreCrypto) {
+    if (!cryptoMigrationStore.coreCrypto.isReady(dbName) && this.cryptoClient.migrateFromCryptobox) {
       this.logger.info(`Migrating data from cryptobox store (${dbName}) to corecrypto.`);
       try {
-        await this.cryptoClient.migrateToCoreCrypto(dbName);
+        await this.cryptoClient.migrateFromCryptobox(dbName);
         cryptoMigrationStore.coreCrypto.markAsReady(dbName);
         this.logger.info(`Successfully migrated from cryptobox store (${dbName}) to corecrypto.`);
       } catch (error) {
@@ -286,5 +286,9 @@ export class ProteusService {
     }
 
     return qualifiedOTRRecipients;
+  }
+
+  wipe() {
+    return this.cryptoClient.wipe();
   }
 }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.types.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {PreKey} from '@wireapp/api-client/lib/auth';
 import {
   UserClients,
   QualifiedUserClients,
@@ -38,7 +37,6 @@ export type ProteusServiceConfig = {
   useQualifiedIds: boolean;
   onNewClient?: (client: NewClient) => void;
   nbPrekeys: number;
-  onNewPrekeys: (prekeys: PreKey[]) => void;
 };
 
 export type SendProteusMessageParams = SendCommonParams &

--- a/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.test.ts
@@ -21,7 +21,7 @@ import type {UserClients} from '@wireapp/api-client/lib/conversation';
 
 import {constructSessionId, initSession, initSessions} from './SessionHandler';
 
-import {CryptoClientType, wrapCryptoClient} from '../../ProteusService/CryptoClient';
+import {CoreCryptoWrapper} from '../../ProteusService/CryptoClient/CoreCryptoWrapper';
 import {buildProteusService} from '../../ProteusService/ProteusService.mocks';
 
 describe('SessionHandler', () => {
@@ -80,7 +80,7 @@ describe('SessionHandler', () => {
       const sessionFromPrekeySpy = jest.spyOn(coreCrypto, 'proteusSessionFromPrekey');
       await initSession(
         {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'},
-        {apiClient, cryptoClient: wrapCryptoClient([CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {} as any)},
+        {apiClient, cryptoClient: new CoreCryptoWrapper(coreCrypto, {} as any, {} as any)},
       );
 
       expect(sessionFromPrekeySpy).not.toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('SessionHandler', () => {
       const sessionFromPrekeySpy = jest.spyOn(coreCrypto, 'proteusSessionFromPrekey');
       await initSession(
         {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'},
-        {apiClient, cryptoClient: wrapCryptoClient([CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {} as any)},
+        {apiClient, cryptoClient: new CoreCryptoWrapper(coreCrypto, {} as any, {} as any)},
       );
 
       expect(sessionFromPrekeySpy).toHaveBeenCalledWith(sessionId, expect.any(Object));
@@ -153,7 +153,7 @@ describe('SessionHandler', () => {
       const sessions = await initSessions({
         recipients: {...existingUserClients, ...missingUserClients},
         apiClient,
-        cryptoClient: wrapCryptoClient([CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {} as any),
+        cryptoClient: new CoreCryptoWrapper(coreCrypto, {} as any, {} as any),
       });
 
       expect(sessionFromPrekeySpy).toHaveBeenCalledTimes(3);

--- a/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.test.ts
@@ -21,7 +21,7 @@ import type {UserClients} from '@wireapp/api-client/lib/conversation';
 
 import {constructSessionId, initSession, initSessions} from './SessionHandler';
 
-import {wrapCryptoClient} from '../../ProteusService/CryptoClient';
+import {CryptoClientType, wrapCryptoClient} from '../../ProteusService/CryptoClient';
 import {buildProteusService} from '../../ProteusService/ProteusService.mocks';
 
 describe('SessionHandler', () => {
@@ -80,7 +80,7 @@ describe('SessionHandler', () => {
       const sessionFromPrekeySpy = jest.spyOn(coreCrypto, 'proteusSessionFromPrekey');
       await initSession(
         {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'},
-        {apiClient, cryptoClient: wrapCryptoClient(coreCrypto, {} as any, {} as any)},
+        {apiClient, cryptoClient: wrapCryptoClient([CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {} as any)},
       );
 
       expect(sessionFromPrekeySpy).not.toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('SessionHandler', () => {
       const sessionFromPrekeySpy = jest.spyOn(coreCrypto, 'proteusSessionFromPrekey');
       await initSession(
         {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'},
-        {apiClient, cryptoClient: wrapCryptoClient(coreCrypto, {} as any, {} as any)},
+        {apiClient, cryptoClient: wrapCryptoClient([CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {} as any)},
       );
 
       expect(sessionFromPrekeySpy).toHaveBeenCalledWith(sessionId, expect.any(Object));
@@ -153,7 +153,7 @@ describe('SessionHandler', () => {
       const sessions = await initSessions({
         recipients: {...existingUserClients, ...missingUserClients},
         apiClient,
-        cryptoClient: wrapCryptoClient(coreCrypto, {} as any, {} as any),
+        cryptoClient: wrapCryptoClient([CryptoClientType.CORE_CRYPTO, coreCrypto], {} as any, {} as any),
       });
 
       expect(sessionFromPrekeySpy).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
This will avoid loading both CoreCrypto and Cryptobox in the same instance of the webapp (since only one of them is going to be used at a time).

This also cleans up which components are aware of CoreCrypto/Cryptobox. Now only the `CryptoClient` are aware of those classes and know how to build them