### PR TITLE
fix: Do call onNewPrekeys handler on cryptobox wrapper

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
@@ -30,8 +30,9 @@ type Config = {
 
 export function buildClient(storeEngine: CRUDEngine, config: Config & {nbPrekeys: number}) {
   const cryptobox = new Cryptobox(storeEngine, config.nbPrekeys);
-  return new CryptoboxWrapper(cryptobox, {onNewPrekeys: () => {}});
+  return new CryptoboxWrapper(cryptobox, config);
 }
+
 export class CryptoboxWrapper implements CryptoClient {
   constructor(private readonly cryptobox: Cryptobox, config: Config) {
     this.cryptobox.on(Cryptobox.TOPIC.NEW_PREKEYS, prekeys => {


### PR DESCRIPTION
We currently do not upload new prekeys to the backend when they are generated. This fixes it