### PR TITLE
feat: expose get subconversation in conversation service

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -27,6 +27,8 @@ import {
   UserClients,
   ClientMismatch,
   ConversationProtocol,
+  SUBCONVERSATION_ID,
+  Subconversation,
 } from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_TYPING, ConversationMemberUpdateData} from '@wireapp/api-client/lib/conversation/data';
 import {ConversationMemberLeaveEvent} from '@wireapp/api-client/lib/event';
@@ -167,6 +169,13 @@ export class ConversationService {
       return this.apiClient.api.conversation.getConversation(conversationIds);
     }
     return this.apiClient.api.conversation.getConversationsByIds(conversationIds);
+  }
+
+  public async getSubconversation(
+    conversationId: QualifiedId,
+    subconversationId: SUBCONVERSATION_ID,
+  ): Promise<Subconversation> {
+    return this.apiClient.api.conversation.getSubconversation(conversationId, subconversationId);
   }
 
   public async getAsset({assetId, assetToken, otrKey, sha256}: RemoteData): Promise<Uint8Array> {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -234,14 +234,19 @@ export class MLSService {
     storeSubconversationGroupId(conversationId, subconversation.subconv_id, subconversation.group_id);
 
     const keyLength = 32;
-    const groupIdBytes = Decoder.fromBase64(subconversation.group_id).asBytes;
-    const secretKey = await this.coreCryptoClient.exportSecretKey(groupIdBytes, keyLength);
+    const secretKey = await this.exportSecretKey(subconversation.group_id, keyLength);
 
     return {
       subconversation,
-      secretKey: Encoder.toBase64(secretKey).asString,
+      secretKey,
       keyLength,
     };
+  }
+
+  public async exportSecretKey(groupId: string, keyLength: number): Promise<string> {
+    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
+    const key = await this.coreCryptoClient.exportSecretKey(groupIdBytes, keyLength);
+    return Encoder.toBase64(key).asString;
   }
 
   public async newExternalProposal(

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -224,6 +224,7 @@ export class MLSService {
     if (subconversation.epoch === 0) {
       await this.registerConversation(subconversation.group_id, []);
     } else {
+      //todo: check timestamp, if subconf is older than 24h -> delete and create subconversation
       await this.joinByExternalCommit(() =>
         this.apiClient.api.conversation.getSubconversationGroupInfo(conversationId, SUBCONVERSATION_ID.CONFERENCE),
       );
@@ -232,13 +233,13 @@ export class MLSService {
     // We store the mapping between the subconversation and the parent conversation
     storeSubconversationGroupId(conversationId, subconversation.subconv_id, subconversation.group_id);
 
-    const keyLength = 256;
+    const keyLength = 32;
     const groupIdBytes = Decoder.fromBase64(subconversation.group_id).asBytes;
     const secretKey = await this.coreCryptoClient.exportSecretKey(groupIdBytes, keyLength);
 
     return {
       subconversation,
-      secretKey: new TextDecoder().decode(secretKey),
+      secretKey: Encoder.toBase64(secretKey).asString,
       keyLength,
     };
   }


### PR DESCRIPTION
- Exposes getSubconversation to `ConversationService`, 
- changes key bytesize to 32,
- improves exportsecretkey method