### PR TITLE
feat: Emit event when MLS conversation epoch changes

### DIFF
--- a/packages/core/src/messagingProtocols/mls/EventHandler/EventHandler.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/EventHandler.ts
@@ -22,13 +22,16 @@ import {handleMLSMessageAdd, handleWelcomeMessage, isMLSMessageAddEvent, isWelco
 
 import {EventHandlerResult} from '../../common.types';
 
-const handleBackendEvent = async (params: EventHandlerParams): EventHandlerResult => {
+const handleBackendEvent = async (
+  params: EventHandlerParams,
+  onEpochChanged: (groupId: string) => void,
+): EventHandlerResult => {
   const {event} = params;
   if (isWelcomeMessageEvent(event)) {
     return handleWelcomeMessage({...params, event});
   }
   if (isMLSMessageAddEvent(event)) {
-    return handleMLSMessageAdd({...params, event});
+    return handleMLSMessageAdd({...params, event}, onEpochChanged);
   }
 };
 


### PR DESCRIPTION
Allows the consumer to subscribe to epoch changes. 

`mlsService.on('newEpoch', ({epoch, groupId}) => {/*...*/});`