### PR TITLE
refactor(core): use string for group id in conversation exists

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -404,8 +404,7 @@ export class ConversationService {
   }
 
   public async isMLSConversationEstablished(groupId: string) {
-    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
-    return this.mlsService.conversationExists(groupIdBytes);
+    return this.mlsService.conversationExists(groupId);
   }
 
   public async wipeMLSConversation(groupId: string): Promise<void> {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -382,8 +382,9 @@ export class MLSService extends TypedEventEmitter<Events> {
     return commitBundle ? void (await this.uploadCommitBundle(groupId, commitBundle)) : undefined;
   }
 
-  public async conversationExists(conversationId: ConversationId): Promise<boolean> {
-    return this.coreCryptoClient.conversationExists(conversationId);
+  public async conversationExists(groupId: string): Promise<boolean> {
+    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
+    return this.coreCryptoClient.conversationExists(groupIdBytes);
   }
 
   public async clientValidKeypackagesCount(): Promise<number> {
@@ -401,7 +402,7 @@ export class MLSService extends TypedEventEmitter<Events> {
    */
   private async renewKeyMaterial(groupId: string) {
     try {
-      const groupConversationExists = await this.conversationExists(Decoder.fromBase64(groupId).asBytes);
+      const groupConversationExists = await this.conversationExists(groupId);
 
       if (!groupConversationExists) {
         keyMaterialUpdatesStore.deleteLastKeyMaterialUpdateDate({groupId});


### PR DESCRIPTION
Use `string` type for `groupId` instead of `Uint8Array` in exposed api.