### PR TITLE
feat: allow iOS runtimes

### DIFF
--- a/packages/commons/src/util/Runtime.ts
+++ b/packages/commons/src/util/Runtime.ts
@@ -88,6 +88,9 @@ export class Runtime {
     if (Runtime.isFranz()) {
       return false;
     }
+    if (Runtime.isIOS() && Runtime.getBrowserName() === BROWSER.SAFARI && Runtime.getBrowserVersion().major >= 11) {
+      return true;
+    }
 
     return Object.entries(WEBAPP_SUPPORTED_BROWSERS).some(([browser, supportedVersion]) => {
       const isBrowserSupported = Runtime.getBrowserName() === browser;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes

Waiting for a product decision, simply updating the runtime file to allow ios/safari. its possible that the `commonconfig.ts` gets extended to include safari also; idk. 