### PR TITLE
runfix(core): reduce number of api calls to subconversation endpoint

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -267,9 +267,6 @@ export class MLSService extends TypedEventEmitter<Events> {
     // We store the mapping between the subconversation and the parent conversation
     storeSubconversationGroupId(conversationId, subconversation.subconv_id, subconversation.group_id);
 
-    const parentConversationGroupId = await this.getGroupIdFromConversationId(conversationId);
-    storeSubconversationToParentGroupId(subconversation.group_id, parentConversationGroupId);
-
     return subconversation;
   }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -47,11 +47,7 @@ import {toProtobufCommitBundle} from './commitBundleUtil';
 import {MLSServiceConfig, UploadCommitOptions} from './MLSService.types';
 import {keyMaterialUpdatesStore} from './stores/keyMaterialUpdatesStore';
 import {pendingProposalsStore} from './stores/pendingProposalsStore';
-import {
-  getGroupId,
-  storeSubconversationGroupId,
-  storeSubconversationToParentGroupId,
-} from './subconversationGroupIdMapper';
+import {getGroupId, storeSubconversationGroupId} from './subconversationGroupIdMapper';
 
 import {QualifiedUsers} from '../../../conversation';
 import {sendMessage} from '../../../conversation/message/messageSender';


### PR DESCRIPTION
There's no need to refetch subconversation after joining it. From now consumer will get members from their local client (`corecrypto.getClientIds()`) and use them to update epoch info to AVS. (Will add a follow up PR on webapp side). This way we'll be sure we're updating AVS with our actual state, not with what we fetch from backend.