### PR TITLE
feat: expose material key renewal api

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -403,7 +403,7 @@ export class MLSService extends TypedEventEmitter<Events> {
    *
    * @param groupId groupId of the conversation
    */
-  private async renewKeyMaterial(groupId: string) {
+  public async renewKeyMaterial(groupId: string) {
     try {
       const groupConversationExists = await this.conversationExists(groupId);
 


### PR DESCRIPTION
req_new_epoch callback from AVS require client to advance epoch number by calling `corecrypto.updateKeyingMaterial()`, this PR will makes `renewKeyMaterial` public that will enable webapp to use the api.