### PR TITLE
runfix: refetch epoch number after joining subconversation

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -238,7 +238,7 @@ export class MLSService extends TypedEventEmitter<Events> {
    *
    * @param conversationId Id of the parent conversation in which the call should happen
    */
-  public async joinConferenceSubconversation(conversationId: QualifiedId): Promise<Subconversation> {
+  public async joinConferenceSubconversation(conversationId: QualifiedId): Promise<{groupId: string; epoch: number}> {
     const subconversation = await this.getConferenceSubconversation(conversationId);
 
     if (subconversation.epoch === 0) {
@@ -264,10 +264,12 @@ export class MLSService extends TypedEventEmitter<Events> {
       );
     }
 
+    const epoch = Number(await this.getEpoch(subconversation.group_id));
+
     // We store the mapping between the subconversation and the parent conversation
     storeSubconversationGroupId(conversationId, subconversation.subconv_id, subconversation.group_id);
 
-    return subconversation;
+    return {groupId: subconversation.group_id, epoch};
   }
 
   public async exportSecretKey(groupId: string, keyLength: number): Promise<string> {


### PR DESCRIPTION
Yesterday https://github.com/wireapp/wire-web-packages/pull/4853 introduced small regression - even though we don't need to refetch the subconversation from backend to get the fresh members list (this is handled by consumer now by getting members list from `corecrypto.getClientIds`) we still need to get new epoch number that increased after joining a subconversation.

I've also narrowed down what we're returning from `joinConferenceSubconversation` method as most of it was not used at all.