### PR TITLE
fix: Await incoming event handler

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -518,7 +518,7 @@ export class Account<T = any> extends TypedEventEmitter<Events> {
           break;
         }
       }
-      onEvent(payload, source);
+      await onEvent(payload, source);
     };
 
     const handleNotification = async (notification: Notification, source: NotificationSource): Promise<void> => {


### PR DESCRIPTION
There are cases where a race condition could happen because we are not awaiting the external incoming event handler to be finished before processing the next event. 
If the consumer needs to do some async task (like saving the event to the DB) it might not expect the next event to come in **before** this task is actually done. 

It is important here to await for the consumer to be done before processing the next event