### PR TITLE
refactor(core): remove unused deprecated method and improve fetchAll api

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -396,15 +396,7 @@ export class Account<T = any> extends TypedEventEmitter<Events> {
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);
     const notificationService = new NotificationService(this.apiClient, proteusService, this.storeEngine, mlsService);
-    const conversationService = new ConversationService(
-      this.apiClient,
-      {
-        // We can use qualified ids to send messages as long as the backend supports federated endpoints
-        useQualifiedIds: this.backendFeatures.federationEndpoints,
-      },
-      proteusService,
-      mlsService,
-    );
+    const conversationService = new ConversationService(this.apiClient, proteusService, mlsService);
 
     const selfService = new SelfService(this.apiClient);
     const teamService = new TeamService(this.apiClient);

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -249,49 +249,6 @@ describe('ConversationService', () => {
       expect(fetchedMembers).toEqual(members);
     });
   });
-
-  describe('getAllParticipantsClients', () => {
-    it('gives the members and clients of a federated conversation', async () => {
-      const members = {
-        user1: ['client1', 'client2'],
-        user2: ['client1', 'client2'],
-        user3: ['client1', 'client2'],
-      };
-      const [conversationService] = buildConversationService(true);
-      jest
-        .spyOn(conversationService['messageService'], 'sendMessage')
-        .mockImplementation((_client, _recipients, _text, options) => {
-          void options?.onClientMismatch?.({missing: members, deleted: {}, redundant: {}, time: ''});
-          return {} as any;
-        });
-      const fetchedMembers = await conversationService.getAllParticipantsClients({id: 'convid', domain: ''});
-
-      expect(fetchedMembers).toEqual(members);
-    });
-
-    it('gives the members and clients of a federated conversation 2', async () => {
-      const members = {
-        domain1: {user1: ['client1', 'client2']},
-        domain2: {user2: ['client1', 'client2'], user3: ['client1', 'client2']},
-      };
-      const [conversationService] = buildConversationService(true);
-      jest
-        .spyOn(conversationService['messageService'], 'sendFederatedMessage')
-        .mockImplementation((_client, _recipients, _text, options) => {
-          void options?.onClientMismatch?.({
-            missing: members,
-            deleted: {},
-            redundant: {},
-            failed_to_send: {},
-            time: '',
-          });
-          return {} as any;
-        });
-      const fetchedMembers = await conversationService.getAllParticipantsClients({id: 'convid', domain: 'domain1'});
-
-      expect(fetchedMembers).toEqual(members);
-    });
-  });
 });
 
 function generateImage() {

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -61,7 +61,7 @@ describe('ConversationService', () => {
     jest.setSystemTime(new Date(0));
   });
 
-  function buildConversationService(federated?: boolean) {
+  function buildConversationService() {
     const client = new APIClient({urls: APIClient.BACKEND.STAGING});
     jest.spyOn(client.api.conversation, 'postMlsMessage').mockReturnValue(
       Promise.resolve({
@@ -90,14 +90,7 @@ describe('ConversationService', () => {
       clientId: PayloadHelper.getUUID(),
     };
 
-    const conversationService = new ConversationService(
-      client,
-      {
-        useQualifiedIds: federated,
-      },
-      mockedProteusService,
-      mockedMLSService,
-    );
+    const conversationService = new ConversationService(client, mockedProteusService, mockedMLSService);
 
     jest.spyOn(conversationService, 'joinByExternalCommit');
 
@@ -223,7 +216,7 @@ describe('ConversationService', () => {
 
   describe('fetchAllParticipantsClients', () => {
     it('gives the members and clients of a federated conversation', async () => {
-      const [conversationService, {apiClient}] = buildConversationService(true);
+      const [conversationService, {apiClient}] = buildConversationService();
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValue({
         members: {
           others: [

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -80,53 +80,16 @@ export class ConversationService {
 
   /**
    * Get a fresh list from backend of clients for all the participants of the conversation.
-   * This is a hacky way of getting all the clients for a conversation.
-   * The idea is to send an empty message to the backend to absolutely no users and let backend reply with a mismatch error.
-   * We then get the missing members in the mismatch, that is our fresh list of participants' clients.
-   *
-   * @deprecated
-   * @param {string} conversationId
-   * @param {string} conversationDomain? - If given will send the message to the new qualified endpoint
-   */
-  public getAllParticipantsClients(conversationId: QualifiedId): Promise<UserClients | QualifiedUserClients> {
-    const sendingClientId = this.apiClient.validatedClientId;
-    const recipients = {};
-    const text = new Uint8Array();
-    return new Promise(async resolve => {
-      const onClientMismatch = (mismatch: ClientMismatch | MessageSendingStatus) => {
-        resolve(mismatch.missing);
-        // When the mismatch happens, we ask the messageService to cancel the sending
-        return false;
-      };
-
-      if (conversationId.domain && this.config.useQualifiedIds) {
-        await this.messageService.sendFederatedMessage(sendingClientId, recipients, text, {
-          conversationId,
-          onClientMismatch,
-          reportMissing: true,
-        });
-      } else {
-        await this.messageService.sendMessage(sendingClientId, recipients, text, {
-          conversationId,
-          onClientMismatch,
-        });
-      }
-    });
-  }
-
-  /**
-   * Get a fresh list from backend of clients for all the participants of the conversation.
    * @fixme there are some case where this method is not enough to detect removed devices
    * @param {string} conversationId
    * @param {string} conversationDomain? - If given will send the message to the new qualified endpoint
    */
   public async fetchAllParticipantsClients(
-    conversationId: string,
-    conversationDomain?: string,
+    conversationId: QualifiedId | string,
   ): Promise<UserClients | QualifiedUserClients> {
     const qualifiedMembers = await getConversationQualifiedMembers({
       apiClient: this.apiClient,
-      conversationId: conversationDomain ? {id: conversationId, domain: conversationDomain} : conversationId,
+      conversationId,
     });
     const allClients = await this.apiClient.api.user.postListClients({qualified_users: qualifiedMembers});
     const qualifiedUserClients: QualifiedUserClients = {};

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -18,14 +18,12 @@
  */
 
 import {
-  MessageSendingStatus,
   Conversation,
   DefaultConversationRoleName,
   MutedStatus,
   NewConversation,
   QualifiedUserClients,
   UserClients,
-  ClientMismatch,
   ConversationProtocol,
   RemoteConversations,
 } from '@wireapp/api-client/lib/conversation';
@@ -54,21 +52,17 @@ import {isMLSConversation} from '../../util';
 import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/fullyQualifiedClientIdUtils';
 import {RemoteData} from '../content';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
-import {MessageService} from '../message/MessageService';
 
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
-  private readonly messageService: MessageService;
   private readonly logger = logdown('@wireapp/core/ConversationService');
 
   constructor(
     private readonly apiClient: APIClient,
-    private readonly config: {useQualifiedIds?: boolean},
     private readonly proteusService: ProteusService,
     private readonly _mlsService?: MLSService,
   ) {
     this.messageTimer = new MessageTimer();
-    this.messageService = new MessageService(this.apiClient, this.proteusService);
   }
 
   get mlsService(): MLSService {


### PR DESCRIPTION
Removes the method that was used to fetch all conversation's participants in a hacky way + removes ConversationService dependencies that are not needed anymore.

Improves the api of the method we're using instead.