### PR TITLE
docs(license-collector): Fix broken licenses link

### DIFF
--- a/packages/license-collector/#legal5
+++ b/packages/license-collector/#legal5
@@ -4,7 +4,7 @@ This repository is part of the source code of Wire. You can find more informatio
 
 You can find the published source code at [github.com/wireapp](https://github.com/wireapp).
 
-For licensing information, see the attached LICENSE file and the list of third-party licenses at [wire.com/legal/licenses/](https://wire.com/legal/licenses/).
+For licensing information, see the attached LICENSE file and the list of third-party licenses at [wire.com/legal/](https://wire.com/legal/#legal5).
 
 ## LicenseCollector
 


### PR DESCRIPTION
The website https://wire.com/legal/licenses/ shows a "Page not found" error. Possible fixes are to update all links in this monorepo to use https://wire.com/legal/#legal5 or to fix the redirect of the website.