### PR TITLE
fix: Trigger reconnect method on ping pong failure (SQSERVICES-1896)

### DIFF
--- a/packages/api-client/src/tcp/ReconnectingWebsocket.ts
+++ b/packages/api-client/src/tcp/ReconnectingWebsocket.ts
@@ -161,6 +161,7 @@ export class ReconnectingWebsocket {
       if (this.hasUnansweredPing) {
         this.logger.warn('Ping interval check failed');
         this.stopPinging();
+        this.socket.reconnect();
         return;
       }
       this.hasUnansweredPing = true;


### PR DESCRIPTION
we already have a ping/pong implementation but it is only used to keep the web socket connection alive.
this PR will change the implementation of our ping/pong system to trigger a reconnect if the ping pong is is timed out