### PR TITLE
feat(core): access last resort prekey and its id from corecrypto [FS-1542]

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper.ts
@@ -23,7 +23,7 @@ import {Encoder} from 'bazinga64';
 import {CoreCrypto} from '@wireapp/core-crypto';
 import type {CRUDEngine} from '@wireapp/store-engine';
 
-import {CryptoClient, LAST_PREKEY_ID} from './CryptoClient.types';
+import {CryptoClient} from './CryptoClient.types';
 import {PrekeyTracker} from './PrekeysTracker';
 
 import {CoreDatabase} from '../../../../storage/CoreDB';
@@ -82,9 +82,14 @@ export class CoreCryptoWrapper implements CryptoClient {
     }
     await this.prekeyTracker.setInitialState(prekeys.length);
 
+    const lastPrekeyBytes = await this.coreCrypto.proteusLastResortPrekey();
+    const lastPrekey = Encoder.toBase64(lastPrekeyBytes).asString;
+
+    const lastPrekeyId = CoreCrypto.proteusLastResortPrekeyId();
+
     return {
       prekeys,
-      lastPrekey: await this.newPrekey(LAST_PREKEY_ID),
+      lastPrekey: {id: lastPrekeyId, key: lastPrekey},
     };
   }
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
@@ -19,7 +19,6 @@
 
 import {PreKey} from '@wireapp/api-client/lib/auth';
 
-export const LAST_PREKEY_ID = 65535;
 export type InitialPrekeys = {prekeys: PreKey[]; lastPrekey: PreKey};
 
 export interface CryptoClient<T = unknown> {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
@@ -20,9 +20,10 @@
 import {PreKey} from '@wireapp/api-client/lib/auth';
 
 import {Cryptobox} from '@wireapp/cryptobox';
+import {keys as ProteusKeys} from '@wireapp/proteus';
 import {CRUDEngine} from '@wireapp/store-engine';
 
-import {CryptoClient, LAST_PREKEY_ID} from './CryptoClient.types';
+import {CryptoClient} from './CryptoClient.types';
 
 type Config = {
   onNewPrekeys: (prekeys: PreKey[]) => void;
@@ -67,7 +68,7 @@ export class CryptoboxWrapper implements CryptoClient {
     const prekeys = initialPrekeys
       .map(preKey => {
         const preKeyJson = this.cryptobox.serialize_prekey(preKey);
-        if (preKeyJson.id !== LAST_PREKEY_ID) {
+        if (preKeyJson.id !== ProteusKeys.PreKey.MAX_PREKEY_ID) {
           return preKeyJson;
         }
         return {id: -1, key: ''};


### PR DESCRIPTION
https://wearezeta.atlassian.net/browse/FS-1542

Access last resort prekey from `corecrypto` directly - no need to generate it using hardcoded last key id number (`65535`).

Last prekey and its id remained the same after changes:
![Screenshot 2023-02-16 at 09 59 43](https://user-images.githubusercontent.com/45733298/219324561-078b155f-152c-4331-aea8-91a5353c6181.png)

I've also removed `LAST_PREKEY_ID` from our types as it did already exist in `@wireapp/proteus` package and will be consumed by `cryptobox` implementation only (Did a `console.log` to make sure the value is exactly the same). 
![Screenshot 2023-02-16 at 10 25 44](https://user-images.githubusercontent.com/45733298/219325086-2a80da43-3265-4bab-946c-e08a485160ee.png)
