### PR TITLE
refactor: factorize session creation logic

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -153,9 +153,9 @@ describe('ProteusService', () => {
       const [proteusService, {apiClient, cryptoClient}] = await buildProteusService();
       const expectedFingerprint = 'fingerprint-client1';
 
-      const getPrekeyMock = jest.spyOn(apiClient.api.user, 'getClientPreKey');
+      const getPrekeysSpy = jest.spyOn(apiClient.api.user, 'postQualifiedMultiPreKeyBundles');
       jest.spyOn(cryptoClient, 'getRemoteFingerprint').mockResolvedValue(expectedFingerprint);
-      jest.spyOn(cryptoClient, 'sessionFromPrekey').mockResolvedValue(undefined);
+      const saveSessionSpy = jest.spyOn(cryptoClient, 'sessionFromPrekey').mockResolvedValue(undefined);
       jest.spyOn(cryptoClient, 'saveSession').mockResolvedValue(undefined);
       jest.spyOn(cryptoClient, 'sessionExists').mockResolvedValue(false);
 
@@ -167,7 +167,8 @@ describe('ProteusService', () => {
         id: 123,
       });
 
-      expect(getPrekeyMock).not.toHaveBeenCalled();
+      expect(saveSessionSpy).toHaveBeenCalled();
+      expect(getPrekeysSpy).not.toHaveBeenCalled();
       expect(result).toBe(expectedFingerprint);
     });
 

--- a/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.ts
+++ b/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.ts
@@ -137,19 +137,9 @@ const initSession = async (
   {userId, clientId, initialPrekey}: {userId: QualifiedId; clientId: string; initialPrekey?: PreKey},
   {cryptoClient, apiClient}: {apiClient: APIClient; cryptoClient: CryptoClient},
 ): Promise<string> => {
-  const sessionId = constructSessionId({userId, clientId, useQualifiedIds: !!userId.domain});
-  const sessionExists = await cryptoClient.sessionExists(sessionId);
-  if (sessionExists) {
-    return sessionId;
-  }
-  if (initialPrekey) {
-    const prekeyBuffer = Decoder.fromBase64(initialPrekey.key).asBytes;
-    await cryptoClient.sessionFromPrekey(sessionId, prekeyBuffer);
-    await cryptoClient.saveSession(sessionId);
-    return sessionId;
-  }
+  const recipients = initialPrekey ? {[userId.id]: {[clientId]: initialPrekey}} : {[userId.id]: [clientId]};
   const sessions = await initSessions({
-    recipients: {[userId.id]: [clientId]},
+    recipients,
     domain: userId.domain,
     apiClient,
     cryptoClient,


### PR DESCRIPTION
Since `initSessions` and `initSession` share the same logic, `initSession` could actually use the former to generate a single session 