### PR TITLE
fix: Reset CoreCrypto instance when client is registered

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -254,6 +254,8 @@ export class Account extends TypedEventEmitter<Events> {
     if (!this.service || !this.apiClient.context || !this.storeEngine) {
       throw new Error('Services are not set or context not initialized.');
     }
+    // we reset the services to re-instantiate a new CryptoClient instance
+    await this.initServices(this.apiClient.context);
     const initialPreKeys = await this.service.proteus.createClient(entropyData);
     await this.service.proteus.initClient(this.storeEngine, this.apiClient.context);
 

--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -118,12 +118,11 @@ export class ClientService {
       if (notFoundOnBackend && this.storeEngine) {
         this.logger.log('Could not find valid client on backend');
         const shouldDeleteWholeDatabase = loadedClient.type === ClientType.TEMPORARY;
+        this.logger.log('Deleting previous identity');
+        await this.proteusService.wipe(this.storeEngine);
         if (shouldDeleteWholeDatabase) {
-          this.logger.log('Last client was temporary - Deleting database');
+          this.logger.log('Last client was temporary - Deleting content database');
           await this.storeEngine.clearTables();
-        } else {
-          this.logger.log('Last client was permanent - Deleting previous identity');
-          await this.proteusService.wipe(this.storeEngine);
         }
       }
     }


### PR DESCRIPTION
When the user tries to login to a device that was deleted from backend, we need to make sure we wipe the previous stored identity and completely reset the CoreCrypto instance in order for a new device to be created