### PR TITLE
fix: Avoid crashing when a mismatch happens on a domain we are not aware of

### DIFF
--- a/packages/core/src/conversation/message/MessageService.ts
+++ b/packages/core/src/conversation/message/MessageService.ts
@@ -180,9 +180,11 @@ export class MessageService {
     if (Object.keys(mismatch.missing).length) {
       const {payloads} = await this.proteusService.encrypt(plainText, mismatch.missing);
       const reEncryptedPayloads = flattenQualifiedUserClients<{[client: string]: Uint8Array}>(payloads);
-      reEncryptedPayloads.forEach(
-        ({data, userId}) => (recipients[userId.domain][userId.id] = {...recipients[userId.domain][userId.id], ...data}),
-      );
+      reEncryptedPayloads.forEach(({data, userId}) => {
+        const domainRecipients = recipients[userId.domain] ?? {};
+        domainRecipients[userId.id] = {...domainRecipients[userId.id], ...data};
+        recipients[userId.domain] = domainRecipients;
+      });
     }
     return recipients;
   }


### PR DESCRIPTION
When a mismatch happens but we do not already have a recipients that is part of the `domain` of the mismatch, the app currently crashes. 