### PR TITLE
feat: Warn consumer that some prekeys could not be fetch when encrypting a message

### DIFF
--- a/packages/core/src/broadcast/BroadcastService.ts
+++ b/packages/core/src/broadcast/BroadcastService.ts
@@ -18,7 +18,6 @@
  */
 
 import {ClientMismatch, MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
-import {UserPreKeyBundleMap} from '@wireapp/api-client/lib/user/';
 
 import {APIClient} from '@wireapp/api-client';
 import {GenericMessage} from '@wireapp/protocol-messaging';
@@ -33,42 +32,6 @@ export class BroadcastService {
 
   constructor(private readonly apiClient: APIClient, private readonly proteusService: ProteusService) {
     this.messageService = new MessageService(this.apiClient, this.proteusService);
-  }
-
-  /**
-   * Will create a key bundle for all the users of the team
-   *
-   * @param teamId
-   * @param skipOwnClients=false
-   * @param onlyDirectConnections=false Will generate a bundle only for directly connected users (users the self user has conversation with). Allows avoiding broadcasting messages to too many people
-   */
-  public async getPreKeyBundlesFromTeam(
-    teamId: string,
-    skipOwnClients = false,
-    onlyDirectConnections = false,
-  ): Promise<UserPreKeyBundleMap> {
-    const teamMembers = onlyDirectConnections
-      ? (await this.apiClient.api.conversation.getConversations()).conversations
-          .map(({members}) => members.others.map(user => user.id).concat(members.self.id))
-          .flat()
-      : (await this.apiClient.api.teams.member.getAllMembers(teamId)).members.map(({user}) => user);
-
-    let members = Array.from(new Set(teamMembers)).map(member => ({id: member}));
-
-    if (skipOwnClients) {
-      const selfUser = await this.apiClient.api.self.getSelf();
-      members = members.filter(member => member.id !== selfUser.id);
-    }
-
-    const preKeys = await Promise.all(members.map(member => this.apiClient.api.user.getUserPreKeys(member.id)));
-
-    return preKeys.reduce<UserPreKeyBundleMap>((bundleMap, bundle) => {
-      bundleMap[bundle.user] = {};
-      for (const client of bundle.clients) {
-        bundleMap[bundle.user][client.client] = client.prekey;
-      }
-      return bundleMap;
-    }, {});
   }
 
   public async broadcastGenericMessage(

--- a/packages/core/src/conversation/message/MessageService.test.ts
+++ b/packages/core/src/conversation/message/MessageService.test.ts
@@ -188,7 +188,9 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseClientMismatch);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateRecipients([]);
 
@@ -220,7 +222,9 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseClientMismatch);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateRecipients([user1, user2]);
 
@@ -249,7 +253,9 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseClientMismatch);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateRecipients([user1, user2]);
 
@@ -275,7 +281,9 @@ describe('MessageService', () => {
           };
           return Promise.reject(error);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateRecipients([user1, user2]);
 
@@ -311,7 +319,9 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseMessageSendingStatus);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -340,7 +350,9 @@ describe('MessageService', () => {
           }
           return Promise.resolve(baseMessageSendingStatus);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 
@@ -391,7 +403,9 @@ describe('MessageService', () => {
           };
           return Promise.reject(error);
         });
-        jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockReturnValue(Promise.resolve({}));
+        jest
+          .spyOn(apiClient.api.user, 'postMultiPreKeyBundles')
+          .mockReturnValue(Promise.resolve({qualified_user_client_prekeys: {}}));
 
         const recipients = generateQualifiedRecipients([user1, user2]);
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -328,18 +328,20 @@ describe('ProteusService', () => {
       ]);
 
       jest.spyOn(services.apiClient.api.user, 'postMultiPreKeyBundles').mockResolvedValue({
-        [domain]: {
-          [firstUser.id.id]: {
-            [firstUser.clients.first]: null,
-            [firstUser.clients.second]: {
-              id: 123,
-              key: 'pQABARhIAqEAWCCaJpFa9c626ORmjj1aV6OnOYgmTjfoiE3ynOfNfGAOmgOhAKEAWCD60VMzRrLfO+1GSjgyhnVp2N7L58DM+eeJhZJi1tBLfQT2',
+        qualified_user_client_prekeys: {
+          [domain]: {
+            [firstUser.id.id]: {
+              [firstUser.clients.first]: null,
+              [firstUser.clients.second]: {
+                id: 123,
+                key: 'pQABARhIAqEAWCCaJpFa9c626ORmjj1aV6OnOYgmTjfoiE3ynOfNfGAOmgOhAKEAWCD60VMzRrLfO+1GSjgyhnVp2N7L58DM+eeJhZJi1tBLfQT2',
+              },
             },
-          },
-          [secondUser.id.id]: {
-            [secondUser.clients.first]: {
-              id: 123,
-              key: 'pQABARhIAqEAWCCaJpFa9c626ORmjj1aV6OnOYgmTjfoiE3ynOfNfGAOmgOhAKEAWCD60VMzRrLfO+1GSjgyhnVp2N7L58DM+eeJhZJi1tBLfQT2',
+            [secondUser.id.id]: {
+              [secondUser.clients.first]: {
+                id: 123,
+                key: 'pQABARhIAqEAWCCaJpFa9c626ORmjj1aV6OnOYgmTjfoiE3ynOfNfGAOmgOhAKEAWCD60VMzRrLfO+1GSjgyhnVp2N7L58DM+eeJhZJi1tBLfQT2',
+              },
             },
           },
         },

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -124,11 +124,13 @@ describe('ProteusService', () => {
       const clientId = 'client1';
 
       jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockResolvedValue({
-        [userId.domain]: {
-          [userId.id]: {
-            [clientId]: {
-              id: 123,
-              key: 'pQABARhIAqEAWCCaJpFa9c626ORmjj1aV6OnOYgmTjfoiE3ynOfNfGAOmgOhAKEAWCD60VMzRrLfO+1GSjgyhnVp2N7L58DM+eeJhZJi1tBLfQT2',
+        qualified_user_client_prekeys: {
+          [userId.domain]: {
+            [userId.id]: {
+              [clientId]: {
+                id: 123,
+                key: 'pQABARhIAqEAWCCaJpFa9c626ORmjj1aV6OnOYgmTjfoiE3ynOfNfGAOmgOhAKEAWCD60VMzRrLfO+1GSjgyhnVp2N7L58DM+eeJhZJi1tBLfQT2',
+              },
             },
           },
         },

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -62,8 +62,8 @@ type EncryptionResult = {
   payloads: QualifiedOTRRecipients;
   /** user-client that do not have prekeys on backend (deleted clients) */
   unknowns?: QualifiedUserClients;
-  /** user-client for which we could retrieve a prekey and, thus, for which we could not create a session */
-  failed?: QualifiedUserClients;
+  /** users for whom we could retrieve a prekey and, thus, for which we could not encrypt the message */
+  failed?: QualifiedId[];
 };
 export class ProteusService {
   private readonly messageService: MessageService;

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -62,6 +62,8 @@ type EncryptionResult = {
   payloads: QualifiedOTRRecipients;
   /** user-client that do not have prekeys on backend (deleted clients) */
   unknowns?: QualifiedUserClients;
+  /** user-client for which we could retrieve a prekey and, thus, for which we could not create a session */
+  failed?: QualifiedUserClients;
 };
 export class ProteusService {
   private readonly messageService: MessageService;
@@ -255,7 +257,7 @@ export class ProteusService {
     plainText: Uint8Array,
     recipients: QualifiedUserPreKeyBundleMap | QualifiedUserClients,
   ): Promise<EncryptionResult> {
-    const {sessions, unknowns} = await initSessions({
+    const {sessions, unknowns, failed} = await initSessions({
       recipients,
       apiClient: this.apiClient,
       cryptoClient: this.cryptoClient,
@@ -267,6 +269,7 @@ export class ProteusService {
     return {
       payloads: buildEncryptedPayloads(payloads),
       unknowns,
+      failed,
     };
   }
 


### PR DESCRIPTION
When we want to encrypt a message for recipients for whom we do not have a session already we need to:
- fetch some prekeys for those users 
- create a session from those prekeys
- encrypt the message for those sessions

If a backend holding those users is down, the prekeys listing will partially fail (and return and error object containing the users we could fetch prekeys for). 
That list is then forwarded to the `encrypt` method that will return a `failed` user list