### PR TITLE
fix: Move MLS endpoints to api v4

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -234,7 +234,7 @@ export class APIClient extends EventEmitter {
       version: backendVersion,
       federationEndpoints: backendVersion > 0,
       isFederated: responsePayload?.federation || false,
-      supportsMLS: backendVersion >= 2,
+      supportsMLS: backendVersion >= 4,
     };
   }
 


### PR DESCRIPTION
MLS endpoints have been pushed to api v4