### PR TITLE
refactor(core): subconversation group id store

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -272,8 +272,8 @@ export class MLSService extends TypedEventEmitter<Events> {
       SUBCONVERSATION_ID.CONFERENCE,
     );
 
-    for (const {parentConversation} of conversationIds) {
-      await this.leaveConferenceSubconversation(parentConversation);
+    for (const {parentConversationId} of conversationIds) {
+      await this.leaveConferenceSubconversation(parentConversationId);
     }
   }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -240,7 +240,7 @@ export class MLSService extends TypedEventEmitter<Events> {
    * @param conversationId Id of the parent conversation which subconversation we want to leave
    */
   public async leaveConferenceSubconversation(conversationId: QualifiedId): Promise<void> {
-    const subconversationGroupId = await this.getGroupIdFromConversationId(
+    const subconversationGroupId = subconversationGroupIdStore.getGroupId(
       conversationId,
       SUBCONVERSATION_ID.CONFERENCE,
     );
@@ -251,7 +251,8 @@ export class MLSService extends TypedEventEmitter<Events> {
 
     const isSubconversationEstablished = await this.conversationExists(subconversationGroupId);
     if (!isSubconversationEstablished) {
-      return;
+      // if the subconversation was known by a client but is not established anymore, we can remove it from the store
+      return subconversationGroupIdStore.removeGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
     }
 
     try {

--- a/packages/core/src/messagingProtocols/mls/MLSService/stores/subconversationGroupIdStore/subconversationGroupIdStore.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/stores/subconversationGroupIdStore/subconversationGroupIdStore.test.ts
@@ -72,13 +72,13 @@ describe('subconversationGroupIdMapper', () => {
     const result = subconversationGroupIdStore.getAllGroupIdsBySubconversationId(SUBCONVERSATION_ID.CONFERENCE);
     expect(result).toEqual([
       {
-        parentConversation: conversationId,
-        subconversation: subconversation,
+        parentConversationId: conversationId,
+        subconversationId: subconversation,
         subconversationGroupId: groupId,
       },
       {
-        parentConversation: conversationId2,
-        subconversation: subconversation2,
+        parentConversationId: conversationId2,
+        subconversationId: subconversation2,
         subconversationGroupId: groupId2,
       },
     ]);

--- a/packages/core/src/messagingProtocols/mls/MLSService/stores/subconversationGroupIdStore/subconversationGroupIdStore.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/stores/subconversationGroupIdStore/subconversationGroupIdStore.ts
@@ -22,18 +22,20 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 const storageKey = 'subconversationGroupIdStore';
 
-function generateSubconversationId(
-  parentConversation: QualifiedId,
-  subconversation: SUBCONVERSATION_ID,
-): `${string}@${string}:${SUBCONVERSATION_ID}` {
-  return `${parentConversation.id}@${parentConversation.domain}:${subconversation}`;
-}
+const generateSubconversationStoreKey = (
+  parentConversationId: QualifiedId,
+  subconversationId: SUBCONVERSATION_ID,
+): `${string}@${string}:${SUBCONVERSATION_ID}` => {
+  return `${parentConversationId.id}@${parentConversationId.domain}:${subconversationId}`;
+};
 
-function parseSubconversationId(subconversationId: string): {parentConversation: QualifiedId; subconversation: string} {
-  const [parentConversationId, subconversation] = subconversationId.split(':');
+const parseSubconversationStoreKey = (
+  subconversationStoreKey: string,
+): {parentConversationId: QualifiedId; subconversationId: SUBCONVERSATION_ID} => {
+  const [parentConversationId, subconversationId] = subconversationStoreKey.split(':') as [string, SUBCONVERSATION_ID];
   const [id, domain] = parentConversationId.split('@');
-  return {parentConversation: {domain, id}, subconversation};
-}
+  return {parentConversationId: {domain, id}, subconversationId};
+};
 
 const getCurrentMap = (): Map<string, string> => {
   const storedEntry = localStorage.getItem(storageKey);
@@ -52,29 +54,33 @@ const removeItemFromMap = (subconversationId: string) => {
   localStorage.setItem(storageKey, JSON.stringify(Array.from(currentMap.entries())));
 };
 
-function storeGroupId(parentConversation: QualifiedId, subconversation: SUBCONVERSATION_ID, subgroupId: string): void {
-  const subconversationId = generateSubconversationId(parentConversation, subconversation);
-  addItemToMap(subconversationId, subgroupId);
-}
+const storeGroupId = (
+  parentConversationId: QualifiedId,
+  subconversationId: SUBCONVERSATION_ID,
+  subconversationGroupId: string,
+) => {
+  const subconversationStoreKey = generateSubconversationStoreKey(parentConversationId, subconversationId);
+  addItemToMap(subconversationStoreKey, subconversationGroupId);
+};
 
-function getGroupId(parentConversation: QualifiedId, subconversation: SUBCONVERSATION_ID): string | undefined {
-  const subconversationId = generateSubconversationId(parentConversation, subconversation);
-  return getCurrentMap().get(subconversationId);
-}
+const getGroupId = (parentConversationId: QualifiedId, subconversationId: SUBCONVERSATION_ID) => {
+  const subconversationStoreKey = generateSubconversationStoreKey(parentConversationId, subconversationId);
+  return getCurrentMap().get(subconversationStoreKey);
+};
 
-function getAllGroupIdsBySubconversationId(subconversationId: SUBCONVERSATION_ID) {
+const getAllGroupIdsBySubconversationId = (subconversationIdQuery: SUBCONVERSATION_ID) => {
   return Array.from(getCurrentMap().entries())
     .map(([subconversationId, subconversationGroupId]) => ({
-      ...parseSubconversationId(subconversationId),
+      ...parseSubconversationStoreKey(subconversationId),
       subconversationGroupId,
     }))
-    .filter(({subconversation}) => subconversation === subconversationId);
-}
+    .filter(({subconversationId}) => subconversationId === subconversationIdQuery);
+};
 
-function removeGroupId(parentConversation: QualifiedId, subconversation: SUBCONVERSATION_ID) {
-  const subconversationId = generateSubconversationId(parentConversation, subconversation);
-  return removeItemFromMap(subconversationId);
-}
+const removeGroupId = (parentConversationId: QualifiedId, subconversationId: SUBCONVERSATION_ID) => {
+  const subconversationStoreKey = generateSubconversationStoreKey(parentConversationId, subconversationId);
+  return removeItemFromMap(subconversationStoreKey);
+};
 
 export const subconversationGroupIdStore = {
   storeGroupId,


### PR DESCRIPTION
Improves naming inside `subconversationGroupId` store module. 
Covers one extra case where subconversation entry can be removed from the store.