### PR TITLE
feat: Forward users for which message could not be encrypted to sender

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "@wireapp/store-engine-dexie": "workspace:^",
     "axios": "1.3.4",
     "bazinga64": "6.0.4",
+    "deepmerge-ts": "^4.3.0",
     "hash.js": "1.1.7",
     "http-status-codes": "2.2.0",
     "idb": "7.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "@wireapp/store-engine-dexie": "workspace:^",
     "axios": "1.3.4",
     "bazinga64": "6.0.4",
-    "deepmerge-ts": "^4.3.0",
+    "deepmerge-ts": "4.3.0",
     "hash.js": "1.1.7",
     "http-status-codes": "2.2.0",
     "idb": "7.1.1",

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -124,5 +124,10 @@ export type SendResult = {
   /** The sending state of the payload (has the payload been succesfully sent or canceled) */
   state: MessageSendingState;
   /** In case the message was sent to some federated backend, if the backend was down at the moment of sending the `failedToSend` property will contain all the users/devices that couldn't get the message */
-  failedToSend?: QualifiedUserClients;
+  failedToSend?: {
+    /** the message was encrypted for those recipients but will reach them later (a session existed but their backend is offline) */
+    queued?: QualifiedUserClients;
+    /** the message could not be encrypted for those recipients and thus will never reach them (a session did not exist and their backend if offline) */
+    failed?: QualifiedUserClients;
+  };
 };

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -128,6 +128,6 @@ export type SendResult = {
     /** the message was encrypted for those recipients but will reach them later (a session existed but their backend is offline) */
     queued?: QualifiedUserClients;
     /** the message could not be encrypted for those recipients and thus will never reach them (a session did not exist and their backend if offline) */
-    failed?: QualifiedUserClients;
+    failed?: QualifiedId[];
   };
 };

--- a/packages/core/src/conversation/message/MessageService.test.ts
+++ b/packages/core/src/conversation/message/MessageService.test.ts
@@ -126,7 +126,7 @@ describe('MessageService', () => {
         conversationId: {id: 'convid', domain: 'domain'},
       });
       expect(apiClient.api.conversation.postOTRMessage).toHaveBeenCalled();
-      expect(result).toEqual(baseMessageSendingStatus);
+      expect(result).toEqual({...baseMessageSendingStatus, failed: undefined});
     });
 
     it('should send regular to conversation', async () => {

--- a/packages/core/src/conversation/message/MessageService.ts
+++ b/packages/core/src/conversation/message/MessageService.ts
@@ -66,7 +66,7 @@ export class MessageService {
 
     const send = async ({payloads, unknowns, failed}: EncryptionResult): Promise<MessageSendingStatus> => {
       const result = await this.sendOtrMessage(sendingClientId, payloads, options);
-      const extras = {failed, deleted: unknowns};
+      const extras = {failed, deleted: unknowns ?? {}};
       return deepmerge(result, extras) as MessageSendingStatus & {failed?: QualifiedId[]};
     };
 

--- a/packages/core/src/conversation/message/MessageService.ts
+++ b/packages/core/src/conversation/message/MessageService.ts
@@ -61,12 +61,13 @@ export class MessageService {
       nativePush?: boolean;
       onClientMismatch?: (mismatch: MessageSendingStatus) => void | boolean | Promise<boolean>;
     } = {},
-  ): Promise<MessageSendingStatus & {canceled?: boolean}> {
+  ): Promise<MessageSendingStatus & {canceled?: boolean; failed?: QualifiedId[]}> {
     const encryptionResults = await this.proteusService.encrypt(plainText, recipients);
 
-    const send = async ({payloads, unknowns}: EncryptionResult): Promise<MessageSendingStatus> => {
+    const send = async ({payloads, unknowns, failed}: EncryptionResult): Promise<MessageSendingStatus> => {
       const result = await this.sendOtrMessage(sendingClientId, payloads, options);
-      return unknowns ? {...result, deleted: {...result.deleted, ...unknowns}} : result;
+      const extras = {failed, deleted: unknowns};
+      return deepmerge(result, extras) as MessageSendingStatus & {failed?: QualifiedId[]};
     };
 
     try {

--- a/packages/core/src/conversation/message/MessageService.ts
+++ b/packages/core/src/conversation/message/MessageService.ts
@@ -22,6 +22,7 @@ import {QualifiedId, QualifiedUserPreKeyBundleMap} from '@wireapp/api-client/lib
 import {uuidToBytes} from '@wireapp/commons/lib/util/StringUtil';
 import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
 import {AxiosError} from 'axios';
+import {deepmerge} from 'deepmerge-ts';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import Long from 'long';
 
@@ -29,7 +30,7 @@ import {APIClient} from '@wireapp/api-client';
 
 import {flattenUserMap} from './UserClientsUtil';
 
-import type {ProteusService} from '../../messagingProtocols/proteus';
+import type {EncryptionResult, ProteusService} from '../../messagingProtocols/proteus';
 import {isQualifiedIdArray} from '../../util';
 
 type ClientMismatchError = AxiosError<MessageSendingStatus>;
@@ -61,15 +62,15 @@ export class MessageService {
       onClientMismatch?: (mismatch: MessageSendingStatus) => void | boolean | Promise<boolean>;
     } = {},
   ): Promise<MessageSendingStatus & {canceled?: boolean}> {
-    const {payloads: encryptedPayload, unknowns: unknows} = await this.proteusService.encrypt(plainText, recipients);
+    const encryptionResults = await this.proteusService.encrypt(plainText, recipients);
 
-    const send = async (payload: QualifiedOTRRecipients) => {
-      const result = await this.sendOtrMessage(sendingClientId, payload, options);
-      return unknows ? {...result, deleted: {...result.deleted, ...unknows}} : result;
+    const send = async ({payloads, unknowns}: EncryptionResult): Promise<MessageSendingStatus> => {
+      const result = await this.sendOtrMessage(sendingClientId, payloads, options);
+      return unknowns ? {...result, deleted: {...result.deleted, ...unknowns}} : result;
     };
 
     try {
-      return await send(encryptedPayload);
+      return await send(encryptionResults);
     } catch (error) {
       if (!this.isClientMismatchError(error)) {
         throw error;
@@ -79,7 +80,7 @@ export class MessageService {
       if (shouldStopSending) {
         return {...mismatch, canceled: true};
       }
-      const reEncryptedPayload = await this.reencryptAfterMismatch(mismatch, encryptedPayload, plainText);
+      const reEncryptedPayload = await this.reencryptAfterMismatch(mismatch, encryptionResults, plainText);
       return send(reEncryptedPayload);
     }
   }
@@ -163,24 +164,19 @@ export class MessageService {
    */
   private async reencryptAfterMismatch(
     mismatch: {missing: QualifiedUserClients; deleted: QualifiedUserClients},
-    recipients: QualifiedOTRRecipients,
+    initialPayloads: EncryptionResult,
     plainText: Uint8Array,
-  ): Promise<QualifiedOTRRecipients> {
+  ): Promise<EncryptionResult> {
     const deleted = flattenUserMap(mismatch.deleted);
     // remove deleted clients to the recipients
     deleted.forEach(({userId, data}) =>
-      data.forEach(clientId => delete recipients[userId.domain][userId.id][clientId]),
+      data.forEach(clientId => delete initialPayloads.payloads[userId.domain][userId.id][clientId]),
     );
 
-    if (Object.keys(mismatch.missing).length) {
-      const {payloads} = await this.proteusService.encrypt(plainText, mismatch.missing);
-      const reEncryptedPayloads = flattenUserMap<{[client: string]: Uint8Array}>(payloads);
-      reEncryptedPayloads.forEach(({data, userId}) => {
-        const domainRecipients = recipients[userId.domain] ?? {};
-        domainRecipients[userId.id] = {...domainRecipients[userId.id], ...data};
-        recipients[userId.domain] = domainRecipients;
-      });
+    if (Object.keys(mismatch.missing).length === 0) {
+      return initialPayloads;
     }
-    return recipients;
+    const reencryptedResults = await this.proteusService.encrypt(plainText, mismatch.missing);
+    return deepmerge(initialPayloads, reencryptedResults);
   }
 }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -535,7 +535,7 @@ describe('ProteusService', () => {
         });
       });
 
-      it(`returns the recipients that could not receive the message`, async () => {
+      it(`returns the recipients that will receive the message later`, async () => {
         const [proteusService] = await buildProteusService();
         const recipients: QualifiedUserClients = {
           domain1: {user1: ['client1'], user2: ['client11', 'client12']},
@@ -559,7 +559,7 @@ describe('ProteusService', () => {
         });
 
         expect(result.state).toBe(MessageSendingState.OUTGOING_SENT);
-        expect(result.failedToSend).toEqual({domain2: recipients.domain2});
+        expect(result.failedToSend?.queued).toEqual({domain2: recipients.domain2});
       });
     });
   });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -211,7 +211,7 @@ export class ProteusService {
     const sendingState = response.canceled ? MessageSendingState.CANCELED : MessageSendingState.OUTGOING_SENT;
 
     const failedToSend =
-      response.failed || Object.keys(response.failed_to_send).length > 0
+      response.failed || Object.keys(response.failed_to_send ?? {}).length > 0
         ? {
             queued: response.failed_to_send,
             failed: response.failed,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -65,6 +65,7 @@ export type EncryptionResult = {
   /** users for whom we could retrieve a prekey and, thus, for which we could not encrypt the message */
   failed?: QualifiedId[];
 };
+
 export class ProteusService {
   private readonly messageService: MessageService;
   private readonly logger = logdown('@wireapp/core/ProteusService');

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -57,7 +57,7 @@ import {
   initSessions,
 } from '../Utility/SessionHandler';
 
-type EncryptionResult = {
+export type EncryptionResult = {
   /** the encrypted payloads for the clients that have a valid sessions */
   payloads: QualifiedOTRRecipients;
   /** user-client that do not have prekeys on backend (deleted clients) */

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -210,16 +210,14 @@ export class ProteusService {
 
     const sendingState = response.canceled ? MessageSendingState.CANCELED : MessageSendingState.OUTGOING_SENT;
 
-    const failedToSend =
-      'failed_to_send' in response && Object.keys(response.failed_to_send).length > 0
-        ? response.failed_to_send
-        : undefined;
-
     return {
       id: payload.messageId,
       sentAt: response.time,
       state: sendingState,
-      failedToSend,
+      failedToSend: {
+        queued: response.failed_to_send,
+        failed: response.failed,
+      },
     };
   }
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -210,14 +210,19 @@ export class ProteusService {
 
     const sendingState = response.canceled ? MessageSendingState.CANCELED : MessageSendingState.OUTGOING_SENT;
 
+    const failedToSend =
+      response.failed || Object.keys(response.failed_to_send).length > 0
+        ? {
+            queued: response.failed_to_send,
+            failed: response.failed,
+          }
+        : undefined;
+
     return {
       id: payload.messageId,
       sentAt: response.time,
       state: sendingState,
-      failedToSend: {
-        queued: response.failed_to_send,
-        failed: response.failed,
-      },
+      failedToSend,
     };
   }
 

--- a/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.ts
+++ b/packages/core/src/messagingProtocols/proteus/Utility/SessionHandler/SessionHandler.ts
@@ -112,7 +112,7 @@ const createSessions = async ({recipients, apiClient, cryptoClient}: CreateSessi
 
   return {
     ...result,
-    failed,
+    failed: failed?.length ? failed : undefined,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4757,7 +4757,7 @@ __metadata:
     bazinga64: 6.0.4
     commander: 10.0.0
     cross-env: 7.0.3
-    deepmerge-ts: ^4.3.0
+    deepmerge-ts: 4.3.0
     dotenv-defaults: 5.0.2
     fake-indexeddb: ^4.0.0
     hash.js: 1.1.7
@@ -7549,7 +7549,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge-ts@npm:^4.3.0":
+"deepmerge-ts@npm:4.3.0":
   version: 4.3.0
   resolution: "deepmerge-ts@npm:4.3.0"
   checksum: d5f8a96df9a2bc7177d59544b9390ba76e50fb725f776669068ca04eef319e98ee8870cf7b7ecca9f636b711d57cea571ac61553ee01101a614c045f7a86e0be

--- a/yarn.lock
+++ b/yarn.lock
@@ -4757,6 +4757,7 @@ __metadata:
     bazinga64: 6.0.4
     commander: 10.0.0
     cross-env: 7.0.3
+    deepmerge-ts: ^4.3.0
     dotenv-defaults: 5.0.2
     fake-indexeddb: ^4.0.0
     hash.js: 1.1.7
@@ -7545,6 +7546,13 @@ __metadata:
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
   checksum: edb65dd0d7d1b9c40b2f50219aef30e116cedd6fc79290e740972c132c09106d2e80aa0bc8826673dd5a00222d4179c84b36a790eef63a4c4bca75a37ef90804
+  languageName: node
+  linkType: hard
+
+"deepmerge-ts@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "deepmerge-ts@npm:4.3.0"
+  checksum: d5f8a96df9a2bc7177d59544b9390ba76e50fb725f776669068ca04eef319e98ee8870cf7b7ecca9f636b711d57cea571ac61553ee01101a614c045f7a86e0be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When a prekey could not be retrieved from backend, we need to warn the consumer that sending the message failed for those users