### PR TITLE
fix: Improve prekeys tracking between client and backend

### DIFF
--- a/packages/api-client/src/client/ClientAPI.ts
+++ b/packages/api-client/src/client/ClientAPI.ts
@@ -131,13 +131,13 @@ export class ClientAPI {
     return response.data;
   }
 
-  public async getClientPreKeys(clientId: string): Promise<PreKeyBundle> {
+  public async getClientPreKeys(clientId: string): Promise<number[]> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${ClientAPI.URL.CLIENTS}/${clientId}/${ClientAPI.URL.PREKEYS}`,
     };
 
-    const response = await this.client.sendJSON<PreKeyBundle>(config, true);
+    const response = await this.client.sendJSON<number[]>(config, true);
     return response.data;
   }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "0.6.2",
+    "@wireapp/core-crypto": "0.7.0-rc.2",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "0.7.0-rc.2",
+    "@wireapp/core-crypto": "0.7.0-rc.3",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -259,7 +259,6 @@ export class Account extends TypedEventEmitter<Events> {
     // we reset the services to re-instantiate a new CryptoClient instance
     await this.initServices(this.apiClient.context);
     const initialPreKeys = await this.service.proteus.createClient(entropyData);
-    await this.service.proteus.initClient(this.storeEngine, this.apiClient.context);
 
     const client = await this.service.client.register(loginData, clientInfo, initialPreKeys);
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -271,8 +271,7 @@ export class Account extends TypedEventEmitter<Events> {
     await this.service.notification.initializeNotificationStream();
     await this.service.client.synchronizeClients();
 
-    await this.initClient(client);
-    return client;
+    return this.initClient(client);
   }
 
   /**
@@ -280,6 +279,7 @@ export class Account extends TypedEventEmitter<Events> {
    *
    * @returns The local existing client or undefined if the client does not exist or is not valid (non existing on backend)
    */
+  public async initClient(client: RegisteredClient): Promise<RegisteredClient>;
   public async initClient(client?: RegisteredClient): Promise<RegisteredClient | undefined> {
     if (!this.service || !this.apiClient.context || !this.storeEngine) {
       throw new Error('Services are not set.');

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -317,7 +317,7 @@ export class Account extends TypedEventEmitter<Events> {
     return validClient;
   }
 
-  private async buildCryptoClient(context: Context, storeEngine: CRUDEngine, db: CoreDatabase, enableMLS: boolean) {
+  private async buildCryptoClient(context: Context, storeEngine: CRUDEngine, enableMLS: boolean) {
     /* There are 3 cases where we want to instantiate CoreCrypto:
      * 1. MLS is enabled
      * 2. The user has enabled CoreCrypto in the config
@@ -330,7 +330,7 @@ export class Account extends TypedEventEmitter<Events> {
         ? CryptoClientType.CORE_CRYPTO
         : CryptoClientType.CRYPTOBOX;
 
-    return buildCryptoClient(clientType, db, {
+    return buildCryptoClient(clientType, {
       storeEngine,
       nbPrekeys: this.nbPrekeys,
       coreCryptoWasmFilePath: this.cryptoProtocolConfig?.coreCrypoWasmFilePath,
@@ -362,7 +362,7 @@ export class Account extends TypedEventEmitter<Events> {
     const accountService = new AccountService(this.apiClient);
     const assetService = new AssetService(this.apiClient);
 
-    const cryptoClientDef = await this.buildCryptoClient(context, this.storeEngine, this.db, enableMLS);
+    const cryptoClientDef = await this.buildCryptoClient(context, this.storeEngine, enableMLS);
     const [clientType, cryptoClient] = cryptoClientDef;
 
     const mlsService =

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -93,8 +93,10 @@ export class CoreCryptoWrapper implements CryptoClient {
     return this.coreCrypto.proteusDecrypt(sessionId, message);
   }
 
-  init(nbInitialPrekeys: number) {
-    this.prekeyTracker.setInitialState(nbInitialPrekeys);
+  init(nbInitialPrekeys?: number) {
+    if (nbInitialPrekeys) {
+      this.prekeyTracker.setInitialState(nbInitialPrekeys);
+    }
     return this.coreCrypto.proteusInit();
   }
 
@@ -102,7 +104,7 @@ export class CoreCryptoWrapper implements CryptoClient {
     if (entropy) {
       await this.coreCrypto.reseedRng(entropy);
     }
-    await this.init(nbPrekeys);
+    await this.init();
     const prekeys: PreKey[] = [];
     for (let id = 0; id < nbPrekeys; id++) {
       prekeys.push(await this.newPrekey());

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -153,8 +153,8 @@ export class CoreCryptoWrapper implements CryptoClient {
   }
 
   async newPrekey() {
-    const [id, key] = await this.coreCrypto.proteusNewPrekeyAuto();
-    return {id, key: Encoder.toBase64(key).asString};
+    const {id, pkb} = await this.coreCrypto.proteusNewPrekeyAuto();
+    return {id, key: Encoder.toBase64(pkb).asString};
   }
 
   async debugBreakSession(sessionId: string) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/PrekeysTracker/PrekeysTracker.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/PrekeysTracker/PrekeysTracker.test.ts
@@ -19,10 +19,7 @@
 
 import {PrekeyTracker} from './PrekeysTracker';
 
-import {CoreDatabase, openDB} from '../../../../../../storage/CoreDB';
-
 describe('PrekeysGenerator', () => {
-  let db: CoreDatabase;
   const baseConfig = {
     nbPrekeys: 10,
     onNewPrekeys: jest.fn(),
@@ -31,18 +28,10 @@ describe('PrekeysGenerator', () => {
     newPrekey: jest.fn().mockResolvedValue(Uint8Array.from([])),
   };
 
-  beforeEach(async () => {
-    db = await openDB('test');
-  });
-
-  afterEach(async () => {
-    await db.clear('prekeys');
-  });
-
   it('triggers the threshold callback when number of prekeys hits the limit', async () => {
     const prekeyTracker = new PrekeyTracker(mockPrekeyTracker, baseConfig);
 
-    await prekeyTracker.setInitialState(baseConfig.nbPrekeys);
+    prekeyTracker.setInitialState(baseConfig.nbPrekeys);
 
     expect(baseConfig.onNewPrekeys).not.toHaveBeenCalled();
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/PrekeysTracker/PrekeysTracker.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/PrekeysTracker/PrekeysTracker.test.ts
@@ -40,7 +40,7 @@ describe('PrekeysGenerator', () => {
   });
 
   it('triggers the threshold callback when number of prekeys hits the limit', async () => {
-    const prekeyTracker = new PrekeyTracker(mockPrekeyTracker, db, baseConfig);
+    const prekeyTracker = new PrekeyTracker(mockPrekeyTracker, baseConfig);
 
     await prekeyTracker.setInitialState(baseConfig.nbPrekeys);
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.ts
@@ -24,7 +24,6 @@ import type {CRUDEngine} from '@wireapp/store-engine';
 import type {CoreCryptoWrapper} from './CoreCryptoWrapper/CoreCryptoWrapper';
 import type {CryptoboxWrapper} from './CryptoboxWrapper';
 
-import {CoreDatabase} from '../../../../storage/CoreDB';
 import {SecretCrypto} from '../../../mls/types';
 
 export enum CryptoClientType {
@@ -49,12 +48,11 @@ type InitConfig = WrapConfig & {
 
 export async function buildCryptoClient(
   clientType: CryptoClientType,
-  db: CoreDatabase,
   {storeEngine, nbPrekeys, systemCrypto, coreCryptoWasmFilePath, onNewPrekeys}: InitConfig,
 ): Promise<CryptoClientDef> {
   if (clientType === CryptoClientType.CORE_CRYPTO) {
     const {buildClient} = await import('./CoreCryptoWrapper');
-    const client = await buildClient(storeEngine, coreCryptoWasmFilePath ?? '', db, {
+    const client = await buildClient(storeEngine, coreCryptoWasmFilePath ?? '', {
       systemCrypto,
       nbPrekeys,
       onNewPrekeys,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoClient.types.ts
@@ -29,7 +29,7 @@ export interface CryptoClient<T = unknown> {
   /**
    * Will init an already existing client. The client should already exist in the database. If the client doesn't exist, it needs to be created using the `create` method.
    */
-  init(): Promise<void>;
+  init(nbPrekeys: number): Promise<void>;
 
   /**
    * Will create a new client and store it in the database
@@ -43,7 +43,7 @@ export interface CryptoClient<T = unknown> {
   saveSession(sessionId: string): Promise<void>;
   consumePrekey: () => Promise<void>;
   deleteSession(sessionId: string): Promise<void>;
-  newPrekey(id: number): Promise<PreKey>;
+  newPrekey(): Promise<PreKey>;
   debugBreakSession(sessionId: string): void;
   debugResetIdentity(): Promise<void>;
   /**

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper.ts
@@ -118,9 +118,9 @@ export class CryptoboxWrapper implements CryptoClient {
     await this.cryptobox.session_delete(sessionId);
   }
 
-  async newPrekey(id: number) {
+  async newPrekey() {
     // CryptoBox is generating prekeys internally
-    return {id, key: ''};
+    return {id: 0, key: ''};
   }
 
   async debugBreakSession(sessionId: string) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.mocks.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.mocks.ts
@@ -38,7 +38,7 @@ export const buildProteusService = async (): Promise<
     clientId: getUUID(),
   };
 
-  const cryptoClient = new CoreCryptoWrapper({} as any, {} as any, {} as any);
+  const cryptoClient = new CoreCryptoWrapper({} as any, {} as any);
 
   const proteusService = new ProteusService(apiClient, cryptoClient, {
     nbPrekeys: 0,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -117,7 +117,8 @@ export class ProteusService {
         this.logger.error('Client was not able to perform DB migration: ', error);
       }
     }
-    return this.cryptoClient.init();
+    const backendPrekeys = await this.apiClient.api.client.getClientPreKeys(context.clientId ?? '');
+    return this.cryptoClient.init(backendPrekeys.length);
   }
 
   public createClient(entropy?: Uint8Array) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -118,7 +118,8 @@ export class ProteusService {
       }
     }
     const backendPrekeys = await this.apiClient.api.client.getClientPreKeys(context.clientId ?? '');
-    return this.cryptoClient.init(backendPrekeys.length);
+    const totalUsableBackedPrekeys = backendPrekeys.length - 1; // we remove the last resort prekey from the total number of available prekeys
+    return this.cryptoClient.init(totalUsableBackedPrekeys);
   }
 
   public createClient(entropy?: Uint8Array) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:0.6.2":
-  version: 0.6.2
-  resolution: "@wireapp/core-crypto@npm:0.6.2"
-  checksum: 0bdf7f60b2a913954b6f5a70a364aea4768a310be5e9a62dc35d2255c2dbb0b3e1634e945744cb621b1ab66989397b722c87f583c047d1d3e1be3c843557fb56
+"@wireapp/core-crypto@npm:0.7.0-rc.2":
+  version: 0.7.0-rc.2
+  resolution: "@wireapp/core-crypto@npm:0.7.0-rc.2"
+  checksum: 4436dcd71609427126e1567e78af3e81ccfd911117a7803dc8a92bb6b60fcb594c3d4cedc46b16bd19665771b2e960249db05aff4a6c92fa1ef80ff3f8d7b293
   languageName: node
   linkType: hard
 
@@ -4765,7 +4765,7 @@ __metadata:
     "@types/tough-cookie": 4.0.2
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 0.6.2
+    "@wireapp/core-crypto": 0.7.0-rc.2
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:0.7.0-rc.2":
-  version: 0.7.0-rc.2
-  resolution: "@wireapp/core-crypto@npm:0.7.0-rc.2"
-  checksum: 4436dcd71609427126e1567e78af3e81ccfd911117a7803dc8a92bb6b60fcb594c3d4cedc46b16bd19665771b2e960249db05aff4a6c92fa1ef80ff3f8d7b293
+"@wireapp/core-crypto@npm:0.7.0-rc.3":
+  version: 0.7.0-rc.3
+  resolution: "@wireapp/core-crypto@npm:0.7.0-rc.3"
+  checksum: 76b70a66d094117f44dcffb05ac850333825a0acbf63e483c5e7cb50ca322f6295b0444adbb64d135d7b4cf7aaf25f1051e03c64732d8aa947d607d73f03d2a5
   languageName: node
   linkType: hard
 
@@ -4765,7 +4765,7 @@ __metadata:
     "@types/tough-cookie": 4.0.2
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 0.7.0-rc.2
+    "@wireapp/core-crypto": 0.7.0-rc.3
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
Currently the number of prekeys that are available are only computed by the client. 
Which can easily lead to an out-of-sync state between client and backend. 

In order to make sure we are in sync, when we init the device, we query the backend for all the prekey ids we have for this client and store this in a local state. 

This way backend is always the single source of truth 