### PR TITLE
fix(core): wait until corecrypto is ready to call .wipe method [FS-1562]

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -178,9 +178,11 @@ export class CoreCryptoWrapper implements CryptoClient {
   }
 
   async handleSafeWipe() {
+    //See https://github.com/wireapp/wire-web-packages/pull/4972 for more details
     const wipeWhenReady = async (onReady: () => void) => {
       const strongRefCount = this.coreCrypto.strongRefCount();
-      if (strongRefCount <= 1) {
+      const isCoreCryptoReady = strongRefCount <= 1;
+      if (isCoreCryptoReady) {
         await this.coreCrypto.wipe();
         return onReady();
       }

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -182,20 +182,20 @@ export class CoreCryptoWrapper implements CryptoClient {
    * @param callback - Function to be called once corecrypto is ready.
    * @see https://github.com/wireapp/wire-web-packages/pull/4972
    */
-  private async onReady(callback: () => Promise<void>) {
-    const isCoreCryptoReady = async () => {
+  private onReady(callback: () => Promise<void>) {
+    const isCoreCryptoReady = () => {
       const strongRefCount = this.coreCrypto.strongRefCount();
       const isCoreCryptoReady = strongRefCount <= 1;
       return isCoreCryptoReady;
     };
 
-    if (await isCoreCryptoReady()) {
+    if (isCoreCryptoReady()) {
       return callback();
     }
 
-    return new Promise<void>(async resolve => {
+    return new Promise<void>(resolve => {
       const intervalId = setInterval(async () => {
-        if (await isCoreCryptoReady()) {
+        if (isCoreCryptoReady()) {
           clearInterval(intervalId);
           await callback();
           return resolve();


### PR DESCRIPTION
## Cause
User logged in on removed device ended up crushing on conversation view and not getting logged out properly (device was not completely deleted, storage was not cleared). For more details see [ticket](https://wearezeta.atlassian.net/browse/FS-1562).

## Problem
Due to rust lang specificity, only 1 "strong reference" is being allowed to be alive at a time - reference gets created every time we call any `corecrypto` method (and gets cleared after the method is done executing). It was possible that in case of deleting other self device, it was not logged out properly because client tried to call `.wipe()` method while it was decrypting a message (`.decryptMessage()` was still executing).

## Solution
CoreCrypto implemented new api - `.strongRefCount()` method, allowing us to check whether corecrypto is ready to call new method.

See https://github.com/wireapp/core-crypto/pull/272/files#diff-d259ed7cc527064fee3325e07d38c1a4921ebc42ec92fddfc36e947e4c898c08R679 for more details.

**NOTE:**
CoreCrypto team will release better api in the future that hides implementation details (consumer won't need to be aware of strong refs related logic)