### PR TITLE
fix: Make sure current client is not duplicated in database

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -269,7 +269,7 @@ export class Account extends TypedEventEmitter<Events> {
     this.logger.info(`Created new client {mls: ${!!this.service.mls}, id: ${client.id}}`);
 
     await this.service.notification.initializeNotificationStream();
-    await this.service.client.synchronizeClients();
+    await this.service.client.synchronizeClients(client.id);
 
     return this.initClient(client);
   }

--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -133,9 +133,13 @@ export class ClientService {
     return this.database.createLocalClient(client, domain);
   }
 
-  public async synchronizeClients(): Promise<MetaClient[]> {
+  /**
+   * Will download all the clients of the self user (excluding the current client) and will store them in the database
+   * @param currentClient - the id of the current client (to be excluded from the list)
+   */
+  public async synchronizeClients(currentClient: string): Promise<MetaClient[]> {
     const registeredClients = await this.backend.getClients();
-    const filteredClients = registeredClients.filter(client => client.id !== this.apiClient.context!.clientId);
+    const filteredClients = registeredClients.filter(client => client.id !== currentClient);
     return this.database.createClientList(
       {id: this.apiClient.context!.userId, domain: this.apiClient.context!.domain ?? ''},
       filteredClients,


### PR DESCRIPTION
This will ensure that we don't try to send messages for a device we will never have a session with (namely the current device)