### PR TITLE
feat: allow partial user listing for federated backends

### DIFF
--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -51,9 +51,17 @@ type PrekeysResponse = {
   qualified_user_client_prekeys: QualifiedUserPreKeyBundleMap;
   failed_to_list?: QualifiedId[];
 };
-
 function isPrekeysResponse(object: any): object is PrekeysResponse {
   return object.qualified_user_client_prekeys && object.failed_to_list;
+}
+
+type UsersReponse = {
+  found?: User[];
+  failed?: QualifiedId[];
+  not_found?: QualifiedId[];
+};
+function isUsersResponse(object: any): object is UsersReponse {
+  return object.found || object.failed || object.not_found;
 }
 
 export class UserAPI {
@@ -519,15 +527,18 @@ export class UserAPI {
    */
   public async postListUsers(
     users: {qualified_ids: QualifiedId[]} | {qualified_handles: QualifiedHandle[]},
-  ): Promise<User[]> {
+  ): Promise<UsersReponse> {
     const config: AxiosRequestConfig = {
       data: users,
       method: 'post',
       url: UserAPI.URL.LIST_USERS,
     };
 
-    const response = await this.client.sendJSON<User[]>(config);
-    return response.data;
+    const {data} = await this.client.sendJSON<User[] | UsersReponse>(config);
+    if (isUsersResponse(data)) {
+      return data;
+    }
+    return {found: data};
   }
 
   /**

--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -534,11 +534,11 @@ export class UserAPI {
       url: UserAPI.URL.LIST_USERS,
     };
 
-    const {data} = await this.client.sendJSON<User[] | UsersReponse>(config);
-    if (isUsersResponse(data)) {
-      return data;
+    const {data: userData} = await this.client.sendJSON<User[] | UsersReponse>(config);
+    if (isUsersResponse(userData)) {
+      return userData;
     }
-    return {found: data};
+    return {found: userData};
   }
 
   /**

--- a/packages/core/src/user/UserService.ts
+++ b/packages/core/src/user/UserService.ts
@@ -21,8 +21,6 @@ import {QualifiedId, User} from '@wireapp/api-client/lib/user/';
 
 import {APIClient} from '@wireapp/api-client';
 
-import {isQualifiedIdArray} from '../util/TypePredicateUtil';
-
 export class UserService {
   private readonly apiClient: APIClient;
 
@@ -34,12 +32,10 @@ export class UserService {
     return this.apiClient.api.user.getUser(userId as QualifiedId);
   }
 
-  public async getUsers(userIds: string[] | QualifiedId[]): Promise<User[]> {
+  public async getUsers(userIds: QualifiedId[]) {
     if (!userIds.length) {
       return [];
     }
-    return isQualifiedIdArray(userIds)
-      ? this.apiClient.api.user.postListUsers({qualified_ids: userIds})
-      : this.apiClient.api.user.getUsers({ids: userIds});
+    return this.apiClient.api.user.postListUsers({qualified_ids: userIds});
   }
 }

--- a/packages/core/src/util/TypePredicateUtil.ts
+++ b/packages/core/src/util/TypePredicateUtil.ts
@@ -31,7 +31,7 @@ export function isStringArray(obj: any): obj is string[] {
   return Array.isArray(obj) && (obj.length === 0 || typeof obj[0] === 'string');
 }
 
-export function isQualifiedId(obj: any): obj is QualifiedId {
+function isQualifiedId(obj: any): obj is QualifiedId {
   return typeof obj === 'object' && typeof obj['domain'] === 'string';
 }
 


### PR DESCRIPTION
This will adapt the API client to receive partial list of users (for when one federated backend is down). 

BREAKING CHANGE: The return type of `postListUser` will now always wrap the result in a full `UsersResponse` 