### PR TITLE
feat(core): allow retrying to send asset metadatas on an existing message

### DIFF
--- a/packages/core/src/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/conversation/message/MessageBuilder.ts
@@ -145,7 +145,10 @@ export function buildFileDataMessage(
   return genericMessage;
 }
 
-export function buildFileMetaDataMessage(payloadBundle: FileAssetMetaDataMessage['content']): GenericMessage {
+export function buildFileMetaDataMessage(
+  payloadBundle: FileAssetMetaDataMessage['content'],
+  messageId: string = createId(),
+): GenericMessage {
   const {expectsReadConfirmation, legalHoldStatus, metaData} = payloadBundle;
 
   const original = Asset.Original.create({
@@ -165,7 +168,7 @@ export function buildFileMetaDataMessage(payloadBundle: FileAssetMetaDataMessage
 
   const genericMessage = GenericMessage.create({
     [GenericMessageType.ASSET]: assetMessage,
-    messageId: createId(),
+    messageId,
   });
 
   return genericMessage;


### PR DESCRIPTION
#### Feat

Adding the `messageId` to the parameters of `buildFileMetaDataMessage` allows for overwriting the optimistic event of a message that failed to be sent in database with newly sent metadatas