### PR TITLE
refactor: Sync user endpoint with backend types

### DIFF
--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -56,7 +56,7 @@ function isPrekeysResponse(object: any): object is PrekeysResponse {
 }
 
 type UsersReponse = {
-  found?: User[];
+  found: User[];
   failed?: QualifiedId[];
   not_found?: QualifiedId[];
 };


### PR DESCRIPTION
the `found` field will always be present (even if empty)