### PR TITLE
fix: Align failed_to_send signature with backend

### DIFF
--- a/packages/api-client/src/conversation/MessageSendingStatus.ts
+++ b/packages/api-client/src/conversation/MessageSendingStatus.ts
@@ -21,7 +21,7 @@ import {QualifiedUserClients} from './QualifiedUserClients';
 
 export interface MessageSendingStatus {
   deleted: QualifiedUserClients;
-  failed_to_send: QualifiedUserClients;
+  failed_to_send?: QualifiedUserClients;
   missing: QualifiedUserClients;
   redundant: QualifiedUserClients;
   time: string;


### PR DESCRIPTION
`failed_to_send` is optional on backend side. We need to align this in the types