### PR TITLE
fix: Add empty body to code creation endpoint (FS-1836)

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -566,6 +566,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       method: 'post',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
+      data: {},
     };
 
     if (password) {


### PR DESCRIPTION
From version 4 this endpoint needs at least an empty body.
https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/createConversationCode