### PR TITLE
feat(api-client): put conversation protocol [FS-1888]

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -942,7 +942,7 @@ export class ConversationAPI {
    * - changing the protocol from "mixed" to "mls" will finalise the migration of the conversation.
    * @param conversationId id of the conversation
    * @param memberData the new conversation
-   * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateSelf
+   * @see https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/746488003/Proteus+to+MLS+Migration for more details
    */
   public async putConversationProtocol(
     conversationId: QualifiedId,

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -45,6 +45,7 @@ import {
   ConversationMemberJoinEvent,
   ConversationMemberLeaveEvent,
   ConversationMessageTimerUpdateEvent,
+  ConversationProtocolUpdateEvent,
   ConversationReceiptModeUpdateEvent,
   ConversationRenameEvent,
 } from '../../event';
@@ -946,13 +947,14 @@ export class ConversationAPI {
   public async putConversationProtocol(
     conversationId: QualifiedId,
     protocol: ConversationProtocol.MIXED | ConversationProtocol.MLS,
-  ): Promise<void> {
+  ): Promise<ConversationProtocolUpdateEvent> {
     const config: AxiosRequestConfig = {
       data: {protocol},
       method: 'put',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.PROTOCOL}`,
     };
 
-    await this.client.sendJSON(config);
+    const response = await this.client.sendJSON<ConversationProtocolUpdateEvent>(config);
+    return response.data;
   }
 }

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -24,6 +24,7 @@ import {AxiosRequestConfig} from 'axios';
 import {
   Conversation,
   ConversationCode,
+  ConversationProtocol,
   ConversationRolesList,
   Conversations,
   DefaultConversationRoleName,
@@ -94,6 +95,7 @@ export class ConversationAPI {
     NAME: 'name',
     OTR: 'otr',
     PROTEUS: 'proteus',
+    PROTOCOL: 'protocol',
     RECEIPT_MODE: 'receipt-mode',
     ROLES: 'roles',
     SELF: 'self',
@@ -927,6 +929,28 @@ export class ConversationAPI {
       data: memberData,
       method: 'put',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.SELF}`,
+    };
+
+    await this.client.sendJSON(config);
+  }
+
+  /**
+   * Update the protocol of the conversation.
+   * Used in MLS Migration feature:
+   * - changing the protocol from "proteus" to "mixed" will assign a groupId to the conversation.
+   * - changing the protocol from "mixed" to "mls" will finalise the migration of the conversation.
+   * @param conversationId id of the conversation
+   * @param memberData the new conversation
+   * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateSelf
+   */
+  public async putConversationProtocol(
+    conversationId: QualifiedId,
+    protocol: ConversationProtocol.MIXED | ConversationProtocol.MLS,
+  ): Promise<void> {
+    const config: AxiosRequestConfig = {
+      data: {protocol},
+      method: 'put',
+      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.PROTOCOL}`,
     };
 
     await this.client.sendJSON(config);

--- a/packages/api-client/src/conversation/NewConversation.ts
+++ b/packages/api-client/src/conversation/NewConversation.ts
@@ -27,6 +27,7 @@ import {QualifiedId} from '../user/';
 export enum ConversationProtocol {
   MLS = 'mls',
   PROTEUS = 'proteus',
+  MIXED = 'mixed',
 }
 
 export interface NewConversation

--- a/packages/api-client/src/conversation/data/ConversationProtocolUpdateData.ts
+++ b/packages/api-client/src/conversation/data/ConversationProtocolUpdateData.ts
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ConversationProtocol} from '../NewConversation';
+
+export interface ConversationProtocolUpdateData {
+  protocol: ConversationProtocol.MIXED | ConversationProtocol.MLS;
+}

--- a/packages/api-client/src/event/ConversationEvent.ts
+++ b/packages/api-client/src/event/ConversationEvent.ts
@@ -34,10 +34,12 @@ import {
   ConversationMLSWelcomeData,
   ConversationMLSMessageAddData,
 } from '../conversation/data/';
+import {ConversationProtocolUpdateData} from '../conversation/data/ConversationProtocolUpdateData';
 import {QualifiedId} from '../user';
 
 export enum CONVERSATION_EVENT {
   ACCESS_UPDATE = 'conversation.access-update',
+  PROTOCOL_UPDATE = 'conversation.protocol-update',
   CODE_DELETE = 'conversation.code-delete',
   CODE_UPDATE = 'conversation.code-update',
   CONNECT_REQUEST = 'conversation.connect-request',
@@ -57,6 +59,7 @@ export enum CONVERSATION_EVENT {
 
 export type ConversationEventData =
   | ConversationAccessUpdateData
+  | ConversationProtocolUpdateData
   | ConversationCodeUpdateData
   | ConversationConnectRequestData
   | ConversationCreateData
@@ -103,6 +106,11 @@ export interface BaseConversationEvent {
 export interface ConversationAccessUpdateEvent extends BaseConversationEvent {
   data: ConversationAccessUpdateData;
   type: CONVERSATION_EVENT.ACCESS_UPDATE;
+}
+
+export interface ConversationProtocolUpdateEvent extends BaseConversationEvent {
+  data: ConversationProtocolUpdateData;
+  type: CONVERSATION_EVENT.PROTOCOL_UPDATE;
 }
 
 export interface ConversationCodeDeleteEvent extends BaseConversationEvent {


### PR DESCRIPTION
Adds a request handler for `PUT: /conversations/{domain}/{id}/protocol`.

Protocol field value update from `"proteus"` to `"mixed"` is the first step of conversation migration flow. For more details see tech use cases under https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/746488003/Proteus+to+MLS+Migration.

[swagger doc](https://nginz-https.anta.wire.link/v4/api/swagger-ui/#/default/put_conversations__cnv_domain___cnv__protocol)