### PR TITLE
feat(api-client): improve conversation protocol put request handler

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -941,13 +941,14 @@ export class ConversationAPI {
    * - changing the protocol from "proteus" to "mixed" will assign a groupId to the conversation.
    * - changing the protocol from "mixed" to "mls" will finalise the migration of the conversation.
    * @param conversationId id of the conversation
-   * @param memberData the new conversation
+   * @param protocol new protocol of the conversation
+   * @returns ConversationProtocolUpdateEvent if the protocol was updated, null if the protocol was not changed
    * @see https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/746488003/Proteus+to+MLS+Migration for more details
    */
   public async putConversationProtocol(
     conversationId: QualifiedId,
     protocol: ConversationProtocol.MIXED | ConversationProtocol.MLS,
-  ): Promise<ConversationProtocolUpdateEvent> {
+  ): Promise<ConversationProtocolUpdateEvent | null> {
     const config: AxiosRequestConfig = {
       data: {protocol},
       method: 'put',
@@ -955,6 +956,12 @@ export class ConversationAPI {
     };
 
     const response = await this.client.sendJSON<ConversationProtocolUpdateEvent>(config);
+
+    //if the protocol was not changed (it already was the same), the response will be 204, response data is empty
+    if (response.status === 204) {
+      return null;
+    }
+
     return response.data;
   }
 }

--- a/packages/api-client/src/event/ConversationEvent.ts
+++ b/packages/api-client/src/event/ConversationEvent.ts
@@ -77,6 +77,7 @@ export type ConversationEventData =
 
 export type ConversationEvent =
   | ConversationAccessUpdateEvent
+  | ConversationProtocolUpdateEvent
   | ConversationCodeDeleteEvent
   | ConversationConnectRequestEvent
   | ConversationCreateEvent


### PR DESCRIPTION
- add event to ConversationEvent union type
- improve js doc of the method
- return null as response if request status was 204 - it means that protocol was not updated (it already had the value we wanted it to update to) (see https://nginz-https.anta.wire.link/v4/api/swagger-ui/#/default/put_conversations__cnv_domain___cnv__protocol)