### PR TITLE
fix: [wire-webapp] Add validation of domain for assets in api-client(…

### DIFF
--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -310,6 +310,11 @@ export class AssetAPI {
       throw new TypeError(`Expected asset ID "${assetId}" to only contain alphanumeric values and dashes.`);
     }
 
+    const isValidDomain = (domain: string) => !!domain && /^((([a-zA-Z-0-9]+.)+[a-zA-Z]{2,}))$/.test(domain);
+
+    if (!isValidDomain(assetDomain)) {
+      throw new TypeError(`Invalid asset domain ${assetDomain}`);
+    }
     const assetBaseUrl = this.backendFeatures.version >= 2 ? ASSET_URLS.ASSETS_URL : ASSET_URLS.ASSET_V4_URL;
     return this.getAssetShared(`${assetBaseUrl}/${assetDomain}/${assetId}`, token, forceCaching, progressCallback);
   }

--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -310,7 +310,8 @@ export class AssetAPI {
       throw new TypeError(`Expected asset ID "${assetId}" to only contain alphanumeric values and dashes.`);
     }
 
-    const isValidDomain = (domain: string) => !!domain && /^((([a-zA-Z-0-9]+.)+[a-zA-Z]{2,}))$/.test(domain);
+    const isValidDomain = (domain: string) =>
+      !!domain && /^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,}$/.test(domain);
 
     if (!isValidDomain(assetDomain)) {
       throw new TypeError(`Invalid asset domain ${assetDomain}`);


### PR DESCRIPTION
…SQSERVICES-2015)

<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- getAssetV4 is missing a validation for valid domains, which in the end can lead to path traversal. To resolve this issue, only assets with a valid domain must be accepted. All other requests must be rejected similar to an invalid asset-ID or conversation-ID
