### PR TITLE
runfix(core): don't call addUsersToExistingConversation with empty list

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -153,6 +153,9 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   public addUsersToExistingConversation(groupId: Uint8Array, invitee: Invitee[]) {
+    if (invitee.length < 1) {
+      return null;
+    }
     return this.processCommitAction(groupId, () => this.coreCryptoClient.addClientsToConversation(groupId, invitee));
   }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -154,6 +154,8 @@ export class MLSService extends TypedEventEmitter<Events> {
 
   public addUsersToExistingConversation(groupId: Uint8Array, invitee: Invitee[]) {
     if (invitee.length < 1) {
+      // providing an empty invitee list to addClientsToConversation method would make core-crypto throw an error
+      // we want to skip adding clinets in this case
       return null;
     }
     return this.processCommitAction(groupId, () => this.coreCryptoClient.addClientsToConversation(groupId, invitee));


### PR DESCRIPTION
It's possible that `mlsService.getKeyPackagesPayload` can return empty array, we usually call `mlsService.addUsersToExistingConversation`. Calling this method with empty array of keypackages will make `corecrypto` throw an error. We want to skip calling this method.