### PR TITLE
runfix(core): emit new epoch event only if the group still exists

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -367,6 +367,10 @@ export class ConversationService {
   }
 
   public async wipeMLSConversation(groupId: string): Promise<void> {
+    const isMLSConversationEstablished = await this.isMLSConversationEstablished(groupId);
+    if (!isMLSConversationEstablished) {
+      return;
+    }
     return this.mlsService.wipeConversation(groupId);
   }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -369,6 +369,7 @@ export class ConversationService {
   public async wipeMLSConversation(groupId: string): Promise<void> {
     const isMLSConversationEstablished = await this.isMLSConversationEstablished(groupId);
     if (!isMLSConversationEstablished) {
+      //if the mls group does not exist, we don't need to wipe it
       return;
     }
     return this.mlsService.wipeConversation(groupId);

--- a/packages/core/src/messagingProtocols/mls/EventHandler/EventHandler.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/EventHandler.ts
@@ -24,7 +24,7 @@ import {EventHandlerResult} from '../../common.types';
 
 const handleBackendEvent = async (
   params: EventHandlerParams,
-  onEpochChanged: (groupId: string) => void,
+  onEpochChanged: (groupId: string) => Promise<void>,
 ): EventHandlerResult => {
   const {event} = params;
   if (isWelcomeMessageEvent(event)) {

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
@@ -34,7 +34,7 @@ interface HandleMLSMessageAddParams extends EventHandlerParams {
 }
 const handleMLSMessageAdd = async (
   {mlsService, event}: HandleMLSMessageAddParams,
-  onEpochChanged: (groupId: string) => void,
+  onEpochChanged: (groupId: string) => Promise<void>,
 ): EventHandlerResult => {
   const encryptedData = Decoder.fromBase64(event.data).asBytes;
 
@@ -75,8 +75,9 @@ const handleMLSMessageAdd = async (
       eventTime: event.time,
     });
   }
+
   if (hasEpochChanged) {
-    onEpochChanged(groupId);
+    await onEpochChanged(groupId);
   }
 
   return message ? {event, decryptedData: GenericMessage.decode(message)} : undefined;

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -558,6 +558,10 @@ export class MLSService extends TypedEventEmitter<Events> {
 
   public async handleEvent(params: Omit<EventHandlerParams, 'mlsService'>): EventHandlerResult {
     return handleBackendEvent({...params, mlsService: this}, async groupId => {
+      const conversationExists = await this.conversationExists(groupId);
+      if (!conversationExists) {
+        return;
+      }
       const newEpoch = await this.getEpoch(groupId);
       this.emit('newEpoch', {groupId, epoch: newEpoch});
     });


### PR DESCRIPTION
- fixes types for onEpochChanged callback to async
- does check if group does exist, before checking epoch number and emitting an event (when `corecrypto.getEpoch` is called with `groupId` that does no longer exists, an error is thrown)