### PR TITLE
fix: Correct type for mls failed_to_send (FS-2030)

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -34,7 +34,6 @@ import {
   MessageSendingStatus,
   NewConversation,
   QualifiedConversationIds,
-  QualifiedUserClients,
   RemoteConversations,
 } from '..';
 import {BackendFeatures} from '../../APIClient';
@@ -70,7 +69,7 @@ import {
 import {Subconversation, SUBCONVERSATION_ID} from '../Subconversation';
 
 export type PostMlsMessageResponse = {
-  failed_to_send?: QualifiedUserClients;
+  failed_to_send?: QualifiedId[];
   failed?: QualifiedId[];
   events: ConversationEvent[];
   time: string;

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -274,24 +274,19 @@ export class ConversationService {
 
     const encrypted = await this.mlsService.encryptMessage(groupIdBytes, GenericMessage.encode(payload).finish());
 
-    let response: PostMlsMessageResponse = {
-      time: new Date().toISOString(),
-      events: [],
-      failed_to_send: [],
-      failed: undefined,
-    };
+    let response: PostMlsMessageResponse | null = null;
 
     try {
       response = await this.apiClient.api.conversation.postMlsMessage(encrypted);
     } catch {}
 
-    const sentAt = response.time;
+    const sentAt = response?.time || '';
 
     const failedToSend =
-      response.failed || (response.failed_to_send ?? []).length > 0
+      response?.failed || (response?.failed_to_send ?? []).length > 0
         ? {
-            queued: response.failed_to_send,
-            failed: response.failed,
+            queued: response?.failed_to_send,
+            failed: response?.failed,
           }
         : undefined;
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -278,7 +278,7 @@ export class ConversationService {
       time: new Date().toISOString(),
       events: [],
       failed_to_send: [],
-      failed: [],
+      failed: undefined,
     };
 
     try {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -275,12 +275,11 @@ export class ConversationService {
     const encrypted = await this.mlsService.encryptMessage(groupIdBytes, GenericMessage.encode(payload).finish());
 
     let response: PostMlsMessageResponse | null = null;
-
+    let sentAt: string = '';
     try {
       response = await this.apiClient.api.conversation.postMlsMessage(encrypted);
+      sentAt = response.time?.length > 0 ? response.time : new Date().toISOString();
     } catch {}
-
-    const sentAt = response?.time || '';
 
     const failedToSend =
       response?.failed || (response?.failed_to_send ?? []).length > 0

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -277,7 +277,7 @@ export class ConversationService {
     let response: PostMlsMessageResponse = {
       time: new Date().toISOString(),
       events: [],
-      failed_to_send: {},
+      failed_to_send: [],
       failed: [],
     };
 
@@ -288,7 +288,7 @@ export class ConversationService {
     const sentAt = response.time;
 
     const failedToSend =
-      response.failed || Object.keys(response.failed_to_send ?? {}).length > 0
+      response.failed || (response.failed_to_send ?? []).length > 0
         ? {
             queued: response.failed_to_send,
             failed: response.failed,

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -126,7 +126,7 @@ export type SendResult = {
   /** In case the message was sent to some federated backend, if the backend was down at the moment of sending the `failedToSend` property will contain all the users/devices that couldn't get the message */
   failedToSend?: {
     /** the message was encrypted for those recipients but will reach them later (a session existed but their backend is offline) */
-    queued?: QualifiedUserClients;
+    queued?: QualifiedUserClients | QualifiedId[];
     /** the message could not be encrypted for those recipients and thus will never reach them (a session did not exist and their backend if offline) */
     failed?: QualifiedId[];
   };


### PR DESCRIPTION
backend response type for failed_to_send on mls is actually QualifiedId[] not QualifiedUserClients