### PR TITLE
fix: pass tokenAsParam = false to set the access token using Authorisation header

### DIFF
--- a/packages/api-client/src/asset/AssetAPI.test.ts
+++ b/packages/api-client/src/asset/AssetAPI.test.ts
@@ -45,7 +45,7 @@ describe('"AssetAPI"', () => {
         },
         url: expect.stringMatching(new RegExp(assetId)),
       }),
-      true,
+      false,
     );
   });
 
@@ -68,7 +68,7 @@ describe('"AssetAPI"', () => {
         params: {},
         url: expect.stringMatching(new RegExp(assetId)),
       }),
-      true,
+      false,
     );
   });
 });

--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -99,7 +99,7 @@ export class AssetAPI {
 
     const handleRequest = async (): Promise<AssetResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config);
+        const response = await this.client.sendRequest<ArrayBuffer>(config, false);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],

--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -99,7 +99,7 @@ export class AssetAPI {
 
     const handleRequest = async (): Promise<AssetResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config, false);
+        const response = await this.client.sendRequest<ArrayBuffer>(config);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],

--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -99,7 +99,7 @@ export class AssetAPI {
 
     const handleRequest = async (): Promise<AssetResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config, true);
+        const response = await this.client.sendRequest<ArrayBuffer>(config, false);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- pass tokenAsParam = false to set the access token using Authorisation header
