### PR TITLE
Revert "chore(deps-dev): bump @types/react from 18.2.7 to 18.2.8"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4152,13 +4152,13 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*, @types/react@npm:^18.0.25":
-  version: 18.2.8
-  resolution: "@types/react@npm:18.2.8"
+  version: 18.2.7
+  resolution: "@types/react@npm:18.2.7"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 351fe2450d30bff2ceb6aa84788e948317555e5ea22cb44f6778e08c977aab1878a0119bd94bc3d1bec5f5af4a75ffaa2ce111df5cd9d4ce26bfd719e4d971c2
+  checksum: caa5da4cf929766738ec789301dc6fb6624bd48dd317d851c4c9b84b1f47cd8ebe17fe01398cadaa0bc938cd4d502d67f4b9de9ff771dc132096bdc86228efba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts recent @types/react version bump as it introduced some breaking changes (don't really have time to deal with those right now, and it's breaking the CI, preventing us from publishing new versions of core)