### PR TITLE
runfix: update core-crypto

### DIFF
--- a/packages/core/__mocks__/@wireapp/core-crypto.ts
+++ b/packages/core/__mocks__/@wireapp/core-crypto.ts
@@ -18,6 +18,15 @@
  */
 
 export interface CommitBundle {}
+
+export enum Ciphersuite {
+  MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 1,
+}
+
+export enum CredentialType {
+  Basic = 1,
+}
+
 export enum PublicGroupStateEncryptionType {
   Plaintext = 1,
   JweEncrypted = 2,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "0.8.2",
+    "@wireapp/core-crypto": "0.11.0",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -35,7 +35,7 @@ import {Decoder} from 'bazinga64';
 import logdown from 'logdown';
 
 import {APIClient} from '@wireapp/api-client';
-import {ExternalProposalType} from '@wireapp/core-crypto';
+import {Ciphersuite, CredentialType, ExternalProposalType} from '@wireapp/core-crypto';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {AddUsersParams, MLSReturnType, SendMlsMessageParams, SendResult} from './ConversationService.types';
@@ -362,6 +362,8 @@ export class ConversationService {
       const externalProposal = await this.mlsService.newExternalProposal(ExternalProposalType.Add, {
         epoch,
         conversationId: groupIdBytes,
+        ciphersuite: Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+        credentialType: CredentialType.Basic,
       });
       await this.apiClient.api.conversation.postMlsMessage(
         //@todo: it's temporary - we wait for core-crypto fix to return the actual Uint8Array instead of regular array

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -17,11 +17,10 @@
  *
  */
 
-import {CoreCrypto} from '@wireapp/core-crypto/platforms/web/corecrypto';
-
 import {randomUUID} from 'crypto';
 
 import {APIClient} from '@wireapp/api-client';
+import {CoreCrypto} from '@wireapp/core-crypto';
 
 import {MLSService} from './MLSService';
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -21,7 +21,7 @@ import {PreKey} from '@wireapp/api-client/lib/auth';
 import {Encoder} from 'bazinga64';
 import {deleteDB} from 'idb';
 
-import {CoreCrypto} from '@wireapp/core-crypto';
+import {Ciphersuite, CoreCrypto} from '@wireapp/core-crypto';
 import type {CRUDEngine} from '@wireapp/store-engine';
 
 import {PrekeyTracker} from './PrekeysTracker';
@@ -70,6 +70,7 @@ export async function buildClient(
     databaseName: coreCryptoDbName,
     key: Encoder.toBase64(key.key).asString,
     wasmFilePath: coreCryptoWasmFilePath,
+    ciphersuites: [Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
   });
   return new CoreCryptoWrapper(coreCrypto, {nbPrekeys, onNewPrekeys, onWipe: key.deleteKey});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4875,10 +4875,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:0.8.2":
-  version: 0.8.2
-  resolution: "@wireapp/core-crypto@npm:0.8.2"
-  checksum: f28a44ed5c4adba56453cd6a62813d6ba433b9ee2143522a741c52f5581aca86de3296b0afe4011fc1d5d5cf76d7afda747bb2171c7c129ba73d3b15087a4e99
+"@wireapp/core-crypto@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@wireapp/core-crypto@npm:0.11.0"
+  checksum: 247272085a734b15a1fc82caaaad1c1f935609564a4fa8b5954727bcd16df23c4e85192772d853fcd15baabb6efd7e1777901aa4021e9e34fd46e89d98bab8ca
   languageName: node
   linkType: hard
 
@@ -4895,7 +4895,7 @@ __metadata:
     "@types/tough-cookie": 4.0.2
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 0.8.2
+    "@wireapp/core-crypto": 0.11.0
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
- Updates corecrypto, it fixed the issue where self key package was consumed when creating new MLS group.
- We are hardcoding ciphersuite to the only one we support currently, this is the only one that will be delivered with Zulu release (we will need to read it from team-settings in the future).