### PR TITLE
runfix: remove creator_client field from conversation creation payload

### DIFF
--- a/packages/api-client/src/conversation/NewConversation.ts
+++ b/packages/api-client/src/conversation/NewConversation.ts
@@ -38,6 +38,4 @@ export interface NewConversation
   protocol?: ConversationProtocol;
   team?: TeamInfo;
   users?: string[]; // users must be empty for creating MLS conversations
-  creator_client?: string; // client id of self user, used for creating MLS conversations
-  selfUserId?: QualifiedId;
 }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -231,11 +231,12 @@ export class ConversationService {
    * Will create a conversation on backend and register it to CoreCrypto once created
    * @param conversationData
    */
-  public async createMLSConversation(conversationData: NewConversation): Promise<MLSReturnType> {
-    const {selfUserId, qualified_users: qualifiedUsers = []} = conversationData;
-    if (!selfUserId) {
-      throw new Error('You need to pass self user qualified id in order to create an MLS conversation');
-    }
+  public async createMLSConversation(
+    conversationData: NewConversation,
+    selfUserId: QualifiedId,
+    selfClientId: string,
+  ): Promise<MLSReturnType> {
+    const {qualified_users: qualifiedUsers = []} = conversationData;
 
     /**
      * @note For creating MLS conversations the users & qualified_users
@@ -254,7 +255,7 @@ export class ConversationService {
 
     const response = await this.mlsService.registerConversation(groupId, qualifiedUsers.concat(selfUserId), {
       user: selfUserId,
-      client: conversationData.creator_client,
+      client: selfClientId,
     });
 
     // We fetch the fresh version of the conversation created on backend with the newly added users


### PR DESCRIPTION
`creator_client` field is not needed anymore in api v4. It was being used only when creating new MLS group, and since MLS is not enabled on api versions <4, so we can simply remove it and pretend it never existed. See https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/761266263/API+changes+v3+v4

It also removes `selfUserId` from the conversationData we pass as a payload - I've made it a separate function param.