### PR TITLE
fix: [Web] Reactions: Keyboard navigation - Focus state of reaction pill does not show tooltip box

### DIFF
--- a/packages/react-ui-kit/src/Form/Tooltip.tsx
+++ b/packages/react-ui-kit/src/Form/Tooltip.tsx
@@ -32,7 +32,10 @@ interface ToolTipProps<T = HTMLDivElement> extends React.HTMLProps<T> {
 const tooltipStyle: (theme: Theme) => CSSObject = theme => ({
   position: 'relative',
   width: 'fit-content',
-  '&:hover .tooltip-content': {visibility: 'visible', opacity: 1},
+  '&:hover .tooltip-content, &:focus-within .tooltip-content,': {
+    visibility: 'visible',
+    opacity: 1,
+  },
   '.tooltip-content': {
     textAlign: 'center',
     visibility: 'hidden',

--- a/packages/react-ui-kit/src/Form/Tooltip.tsx
+++ b/packages/react-ui-kit/src/Form/Tooltip.tsx
@@ -27,6 +27,7 @@ import {filterProps} from '../util';
 interface ToolTipProps<T = HTMLDivElement> extends React.HTMLProps<T> {
   position?: 'top' | 'right' | 'left' | 'bottom';
   body: React.ReactNode;
+  isOpen?: boolean;
 }
 
 const tooltipStyle: (theme: Theme) => CSSObject = theme => ({
@@ -125,11 +126,11 @@ const tooltipStyle: (theme: Theme) => CSSObject = theme => ({
   },
 });
 
-const filterTooltipProps = (props: ToolTipProps) => filterProps(props, ['position', 'body']);
+const filterTooltipProps = (props: ToolTipProps) => filterProps(props, ['position', 'body', 'isOpen']);
 
 export const Tooltip = ({children, ...props}: ToolTipProps) => {
   const filteredProps = filterTooltipProps(props);
-  const {body, position = 'top'} = props;
+  const {body, position = 'top', isOpen = true} = props;
 
   return (
     <div
@@ -138,10 +139,12 @@ export const Tooltip = ({children, ...props}: ToolTipProps) => {
       {...filteredProps}
       data-testid="tooltip-wrapper"
     >
-      <div className="tooltip-content" data-testid="tooltip-content">
-        {body}
-        <div className="tooltip-arrow"></div>
-      </div>
+      {isOpen && (
+        <div className="tooltip-content" data-testid="tooltip-content">
+          {body}
+          <div className="tooltip-arrow"></div>
+        </div>
+      )}
       {children}
     </div>
   );

--- a/packages/react-ui-kit/src/Form/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Tooltip.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`<Tooltip /> renders correctly 1`] = `
   width: fit-content;
 }
 
-.emotion-1:hover .tooltip-content {
+.emotion-1:hover .tooltip-content,
+.emotion-1:focus-within .tooltip-content,
+.emotion-1 {
   visibility: visible;
   opacity: 1;
 }
@@ -184,7 +186,9 @@ exports[`<Tooltip /> renders correctly 1`] = `
   width: fit-content;
 }
 
-.emotion-1:hover .tooltip-content {
+.emotion-1:hover .tooltip-content,
+.emotion-1:focus-within .tooltip-content,
+.emotion-1 {
   visibility: visible;
   opacity: 1;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- STR: Navigate to reaction pill with keyboard

Actual: The pill is highlighted, but the tooltip box containing info about emoji name and amount of people is not displayed

Expected: The tooltip box should appear when keyboard navigation is used to get to the reaction pills
