### PR TITLE
runfix(api-client): remove threshold values from migration feature config

### DIFF
--- a/packages/api-client/src/team/feature/Feature.ts
+++ b/packages/api-client/src/team/feature/Feature.ts
@@ -78,8 +78,6 @@ export interface FeatureMLSE2EIdConfig extends FeatureConfig {
 export interface FeatureMLSMigrationConfig extends FeatureConfig {
   startTime?: string;
   finaliseRegardlessAfter?: string;
-  usersThreshold?: number;
-  clientsThreshold?: number;
 }
 
 export type FeatureAppLock = Feature<FeatureAppLockConfig>;


### PR DESCRIPTION
After some refinements, it was decided that `usersThreshold` and `clientsThreshold` values are not needed anymore in `mlsMigration` feature config. See https://wearezeta.atlassian.net/wiki/spaces/CORE/pages/792592579/MLS+migration+feature+config
