### PR TITLE
runfix: remove canceling tasks

### DIFF
--- a/.github/workflows/release_beta_package.yml
+++ b/.github/workflows/release_beta_package.yml
@@ -51,11 +51,6 @@ jobs:
           contains(env.TITLE || env.COMMIT_MESSAGE, '[ci skip]')
         uses: andymckay/cancel-action@0.3
 
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          access_token: ${{github.token}}
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
I feel that this might fix the issue with task being auto-cancelled, maybe this cancel-action does not play well with `workflow_dispatch` trigger.