### PR TITLE
runfix: manual task cancelled when last commit was publishing a package

### DIFF
--- a/.github/workflows/release_beta_package.yml
+++ b/.github/workflows/release_beta_package.yml
@@ -51,6 +51,11 @@ jobs:
           contains(env.TITLE || env.COMMIT_MESSAGE, '[ci skip]')
         uses: andymckay/cancel-action@0.3
 
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{github.token}}
+
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release_beta_package.yml
+++ b/.github/workflows/release_beta_package.yml
@@ -45,12 +45,6 @@ jobs:
           echo -e "HOME = ${HOME}"
           echo -e "GITHUB_CONTEXT = ${GITHUB_CONTEXT}"
 
-      - name: Skip CI
-        if: |
-          contains(env.TITLE || env.COMMIT_MESSAGE, '[skip ci]') ||
-          contains(env.TITLE || env.COMMIT_MESSAGE, '[ci skip]')
-        uses: andymckay/cancel-action@0.3
-
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:


### PR DESCRIPTION
The issue of this manual action being cancelled was the fact that after it was published once, given branch contained the commit: `chore: Publish [skip ci]` and there was a rule in this script (copied from the auto release from main script), that was skipping (cancelling) the job when `skip ci` or `ci skip` was included in last commit. 

The solution is to simply remove this field. Since this action is manual it won't get re-triggered after pushing another publish commit into the branch (what would happen if this rule was not included in the auto-deploy main branch script).