### PR TITLE
runfix: upload commit bundle throws error

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -262,7 +262,7 @@ export class ConversationService {
     const conversation = await this.apiClient.api.conversation.getConversation(qualifiedId);
 
     return {
-      events: response.events ?? [],
+      events: response.events,
       conversation,
     };
   }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -262,7 +262,7 @@ export class ConversationService {
     const conversation = await this.apiClient.api.conversation.getConversation(qualifiedId);
 
     return {
-      events: response?.events ?? [],
+      events: response.events ?? [],
       conversation,
     };
   }
@@ -318,7 +318,7 @@ export class ConversationService {
     //We store the info when user was added (and key material was created), so we will know when to renew it
     this.mlsService.resetKeyMaterialRenewal(groupId);
     return {
-      events: response?.events || [],
+      events: response.events,
       conversation,
     };
   }
@@ -342,7 +342,7 @@ export class ConversationService {
     const conversation = await this.getConversation(conversationId);
 
     return {
-      events: messageResponse?.events || [],
+      events: messageResponse.events,
       conversation,
     };
   }


### PR DESCRIPTION
Fail fast and let the consumer catch the error instead of silently returning `null` for `uploadCommitBundle` method. Method's response is not always read, therefore it's possible that the method will silently fail without the consumer knowing that something went wrong, when error is thrown we have to make sure this call is handled properly with try/catch.