### PR TITLE
fix: handle error when sending mls message [WBP-2300]

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -280,7 +280,9 @@ export class ConversationService {
     try {
       response = await this.apiClient.api.conversation.postMlsMessage(encrypted);
       sentAt = response.time?.length > 0 ? response.time : new Date().toISOString();
-    } catch {}
+    } catch (error) {
+      throw error;
+    }
 
     const failedToSend =
       response?.failed || (response?.failed_to_send ?? []).length > 0


### PR DESCRIPTION
### Issue 
- when sending a message to an mls conversation, the option to retry do not appear when the owning b-e is offline

### Solution
- Backend errors were not handled in the `sendMLSMessage()` method, if we simply throw the error, the webapp will handle it correctly