### PR TITLE
Revert "fix: pass tokenAsParam = false to set the access token using …

### DIFF
--- a/packages/api-client/src/asset/AssetAPI.test.ts
+++ b/packages/api-client/src/asset/AssetAPI.test.ts
@@ -45,7 +45,7 @@ describe('"AssetAPI"', () => {
         },
         url: expect.stringMatching(new RegExp(assetId)),
       }),
-      false,
+      true,
     );
   });
 
@@ -68,7 +68,7 @@ describe('"AssetAPI"', () => {
         params: {},
         url: expect.stringMatching(new RegExp(assetId)),
       }),
-      false,
+      true,
     );
   });
 });

--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -99,7 +99,7 @@ export class AssetAPI {
 
     const handleRequest = async (): Promise<AssetResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config, false);
+        const response = await this.client.sendRequest<ArrayBuffer>(config, true);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],


### PR DESCRIPTION
There's an issue with web client not being able to fetch assets with this suggested solution. Reverting this change for now, will need to come up with a different solution for security concerns.