### PR TITLE
feat(api-client): add supportedProtocols to mls feature config

### DIFF
--- a/packages/api-client/src/team/feature/Feature.ts
+++ b/packages/api-client/src/team/feature/Feature.ts
@@ -68,6 +68,7 @@ export interface FeatureMLSConfig extends FeatureConfig {
   defaultCipherSuite: number;
   defaultProtocol: ConversationProtocol;
   protocolToggleUsers: string[];
+  supportedProtocols: ConversationProtocol[];
 }
 
 export interface FeatureMLSE2EIdConfig extends FeatureConfig {


### PR DESCRIPTION
Adds `supportedProtocols` field to `mls` feature config. 