### PR TITLE
feat(api-client, core): parse client last active field [WPB-2186]

### DIFF
--- a/packages/api-client/src/client/RegisteredClient.ts
+++ b/packages/api-client/src/client/RegisteredClient.ts
@@ -29,6 +29,7 @@ export interface AddedClient extends PublicClient {
   time: string;
   type: ClientType.PERMANENT | ClientType.TEMPORARY;
   mls_public_keys?: Record<string, string>;
+  last_active?: string;
 }
 
 export interface RegisteredClient extends AddedClient {

--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -100,6 +100,7 @@ export class ClientService {
    * Will try to load the local client from the database into memory.
    * Will return undefined if the client is not found in the database or if the client does not exist on the backend.
    * If the client doesn't exist on backend it will purge the database and return undefined.
+   * If the client is found on the backend it will update the local client in the database and return it.
    *
    * @return the loaded client or undefined
    */
@@ -111,8 +112,8 @@ export class ClientService {
     }
 
     try {
-      await this.apiClient.api.client.getClient(loadedClient.id);
-      return loadedClient;
+      const remoteClient = await this.apiClient.api.client.getClient(loadedClient.id);
+      return this.database.updateLocalClient(remoteClient);
     } catch (error) {
       const notFoundOnBackend = axios.isAxiosError(error) ? error.response?.status === StatusCodes.NOT_FOUND : false;
       if (notFoundOnBackend && this.storeEngine) {


### PR DESCRIPTION
- add `last_active` field to client entity
- Since new field was added, I've noticed that the local client (under `'local_identity'` key in our local store) was never updated with the client fetched from backend. Since we are fetching the client anyway to see if it still exists on backend I think it makes sense to update the entry in the local store with the fresh one in case it was updated.