### PR TITLE
refactor: method to register empty mls conversation

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -317,12 +317,11 @@ export class ConversationService {
     groupId,
     conversationId,
   }: Required<AddUsersParams>): Promise<MLSReturnType> {
-    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
     const {coreCryptoKeyPackagesPayload, failedToFetchKeyPackages} = await this.mlsService.getKeyPackagesPayload(
       qualifiedUsers,
     );
 
-    const response = await this.mlsService.addUsersToExistingConversation(groupIdBytes, coreCryptoKeyPackagesPayload);
+    const response = await this.mlsService.addUsersToExistingConversation(groupId, coreCryptoKeyPackagesPayload);
     const conversation = await this.getConversation(conversationId);
 
     conversation.failed_to_add = failedToFetchKeyPackages;

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -400,7 +400,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     });
   }
 
-  public updateKeyingMaterial(groupId: string) {
+  private updateKeyingMaterial(groupId: string) {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
     return this.processCommitAction(groupIdBytes, () => this.coreCryptoClient.updateKeyingMaterial(groupIdBytes));
   }
@@ -504,7 +504,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   /**
-   * Renew key material for a given groupId
+   * Will send an empty commit into a group (renew key material)
    *
    * @param groupId groupId of the conversation
    */

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -513,8 +513,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       const groupConversationExists = await this.conversationExists(groupId);
 
       if (!groupConversationExists) {
-        this.cancelKeyMaterialRenewal(groupId);
-        return;
+        return this.cancelKeyMaterialRenewal(groupId);
       }
 
       await this.updateKeyingMaterial(groupId);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -167,11 +167,15 @@ export class MLSService extends TypedEventEmitter<Events> {
    * @param groupId - the group id of the MLS group
    * @param invitee - the list of keys of clients to add to the MLS group
    */
-  public addUsersToExistingConversation(groupId: Uint8Array, invitee: Invitee[]) {
+  public addUsersToExistingConversation(groupId: string, invitee: Invitee[]) {
+    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
+
     if (invitee.length < 1) {
       throw new Error('Empty list of keys provided to addUsersToExistingConversation');
     }
-    return this.processCommitAction(groupId, () => this.coreCryptoClient.addClientsToConversation(groupId, invitee));
+    return this.processCommitAction(groupIdBytes, () =>
+      this.coreCryptoClient.addClientsToConversation(groupIdBytes, invitee),
+    );
   }
 
   public configureMLSCallbacks({groupIdFromConversationId, ...coreCryptoCallbacks}: MLSCallbacks): void {
@@ -396,21 +400,16 @@ export class MLSService extends TypedEventEmitter<Events> {
     });
   }
 
-  public updateKeyingMaterial(conversationId: ConversationId) {
-    return this.processCommitAction(conversationId, () => this.coreCryptoClient.updateKeyingMaterial(conversationId));
+  public updateKeyingMaterial(groupId: string) {
+    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
+    return this.processCommitAction(groupIdBytes, () => this.coreCryptoClient.updateKeyingMaterial(groupIdBytes));
   }
 
   /**
-   * Will create a conversation inside of coreCrypto.
+   * Will create an empty conversation inside of coreCrypto.
    * @param groupId the id of the group to create inside of coreCrypto
-   * @param users the list of users that will be members of the conversation (including the self user)
-   * @param creator the creator of the list. Most of the time will be the self user (or empty if the conversation was created by backend first)
    */
-  public async registerConversation(
-    groupId: string,
-    users: QualifiedId[],
-    creator?: {user: QualifiedId; client?: string},
-  ): Promise<PostMlsMessageResponse> {
+  public async registerEmptyConversation(groupId: string): Promise<void> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     const mlsKeys = (await this.apiClient.api.client.getPublicKeys()).removal;
@@ -420,7 +419,21 @@ export class MLSService extends TypedEventEmitter<Events> {
       ciphersuite: this.defaultCiphersuite,
     };
 
-    await this.coreCryptoClient.createConversation(groupIdBytes, this.defaultCredentialType, configuration);
+    return void this.coreCryptoClient.createConversation(groupIdBytes, this.defaultCredentialType, configuration);
+  }
+
+  /**
+   * Will create a conversation inside of coreCrypto, add users to it or update the keying material if empty key packages list is provided.
+   * @param groupId the id of the group to create inside of coreCrypto
+   * @param users the list of users that will be members of the conversation (including the self user)
+   * @param creator the creator of the list. Most of the time will be the self user (or empty if the conversation was created by backend first)
+   */
+  public async registerConversation(
+    groupId: string,
+    users: QualifiedId[],
+    creator?: {user: QualifiedId; client?: string},
+  ): Promise<PostMlsMessageResponse> {
+    await this.registerEmptyConversation(groupId);
 
     const {coreCryptoKeyPackagesPayload: keyPackages, failedToFetchKeyPackages} = await this.getKeyPackagesPayload(
       users.map(user => {
@@ -437,9 +450,9 @@ export class MLSService extends TypedEventEmitter<Events> {
 
     const response =
       keyPackages.length > 0
-        ? await this.addUsersToExistingConversation(groupIdBytes, keyPackages)
+        ? await this.addUsersToExistingConversation(groupId, keyPackages)
         : // If there are no clients to add, just update the keying material
-          await this.processCommitAction(groupIdBytes, () => this.coreCryptoClient.updateKeyingMaterial(groupIdBytes));
+          await this.updateKeyingMaterial(groupId);
 
     // We schedule a periodic key material renewal
     this.scheduleKeyMaterialRenewal(groupId);
@@ -504,8 +517,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         return;
       }
 
-      const groupIdDecodedFromBase64 = Decoder.fromBase64(groupId).asBytes;
-      await this.updateKeyingMaterial(groupIdDecodedFromBase64);
+      await this.updateKeyingMaterial(groupId);
     } catch (error) {
       this.logger.error(`Error while renewing key material for groupId ${groupId}`, error);
     }


### PR DESCRIPTION
Some refactoring in mls service:
- created a separate method to establish empty mls conversation (just register it with epoch 0 without adding other users or sending empty commit)
- refactored some methods to expect string group ids instead of uint8array