### PR TITLE
runfix: properly await mls conversation creation

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -419,7 +419,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       ciphersuite: this.defaultCiphersuite,
     };
 
-    return void this.coreCryptoClient.createConversation(groupIdBytes, this.defaultCredentialType, configuration);
+    return this.coreCryptoClient.createConversation(groupIdBytes, this.defaultCredentialType, configuration);
   }
 
   /**


### PR DESCRIPTION
void operator evaluates the given expression and then returns undefined what prevents consumer from catching potential error thrown by corecrypto. void keyword is not needed there.