### PR TITLE
fix: more flexible dexie version

### DIFF
--- a/packages/store-engine-dexie/package.json
+++ b/packages/store-engine-dexie/package.json
@@ -11,7 +11,7 @@
     "@wireapp/store-engine": "5.x.x"
   },
   "dependencies": {
-    "dexie": "3.2.4"
+    "dexie": "^3.2.0"
   },
   "devDependencies": {
     "@swc/core": "^1.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5423,7 +5423,7 @@ __metadata:
     "@types/node": ^20.1.0
     "@types/rimraf": ^3.0.2
     "@wireapp/store-engine": "workspace:^"
-    dexie: 3.2.4
+    dexie: ^3.2.0
     fake-indexeddb: ^4.0.0
     jest: ^29.2.1
     logdown: 3.3.1
@@ -8197,7 +8197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dexie@npm:3.2.4":
+"dexie@npm:^3.2.0":
   version: 3.2.4
   resolution: "dexie@npm:3.2.4"
   checksum: 4e5294a954118b6862c864b8c3970904a1733daebcd919488624520696411e2e81ed1bceeac3634c5c15a21e37ce4b8502ed41c4edfbc5ba3f5925c34d56497b


### PR DESCRIPTION
This will allow the consumer of the library to set the desired version of Dexie (as long as it's above 3.2.0). 

This will allow the webapp to actually upgrade Dexie in the future (and avoid conflicting versions)