### PR TITLE
refactor: rename failed_to_send to failed_to_confirm_clients (WPB-3393)

### DIFF
--- a/packages/api-client/src/conversation/MessageSendingStatus.ts
+++ b/packages/api-client/src/conversation/MessageSendingStatus.ts
@@ -21,6 +21,7 @@ import {QualifiedUserClients} from './QualifiedUserClients';
 
 export interface MessageSendingStatus {
   deleted: QualifiedUserClients;
+  failed_to_confirm_clients?: QualifiedUserClients;
   failed_to_send?: QualifiedUserClients;
   missing: QualifiedUserClients;
   redundant: QualifiedUserClients;

--- a/packages/core/src/conversation/message/MessageService.test.ts
+++ b/packages/core/src/conversation/message/MessageService.test.ts
@@ -37,7 +37,7 @@ import {getUUID} from '../../test/PayloadHelper';
 const baseMessageSendingStatus: MessageSendingStatus = {
   deleted: {},
   missing: {},
-  failed_to_send: {},
+  failed_to_confirm_clients: {},
   redundant: {},
   time: new Date().toISOString(),
 };
@@ -159,12 +159,12 @@ describe('MessageService', () => {
       expect(apiClient.api.broadcast.postBroadcastMessage).toHaveBeenCalledWith(clientId, expect.any(Object));
     });
 
-    describe('client mismatch', () => {
+    describe('federated client mismatch', () => {
       const baseClientMismatch: MessageSendingStatus = {
         deleted: {},
         missing: {},
         redundant: {},
-        failed_to_send: {},
+        failed_to_confirm_clients: {},
         time: new Date().toISOString(),
       };
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -545,7 +545,7 @@ describe('ProteusService', () => {
         jest.spyOn(proteusService['messageService'], 'sendMessage').mockResolvedValue({
           missing: {},
           redundant: {},
-          failed_to_send: {domain2: recipients.domain2},
+          failed_to_confirm_clients: {domain2: recipients.domain2},
           time: new Date().toISOString(),
           deleted: {},
         });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -213,9 +213,9 @@ export class ProteusService {
     const sendingState = response.canceled ? MessageSendingState.CANCELED : MessageSendingState.OUTGOING_SENT;
 
     const failedToSend =
-      response.failed || Object.keys(response.failed_to_send ?? {}).length > 0
+      response.failed || Object.keys(response.failed_to_confirm_clients ?? {}).length > 0
         ? {
-            queued: response.failed_to_send,
+            queued: response.failed_to_confirm_clients,
             failed: response.failed,
           }
         : undefined;


### PR DESCRIPTION
backend response for proteus messages that are queued after failing to reach the recipient changed for `failed_to_send` to `failed_to_confirm_clients`