### PR TITLE
feat(core): establish mls 1to1

### DIFF
--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -109,3 +109,10 @@ export interface Conversation {
 
   protocol: ConversationProtocol;
 }
+
+export interface MLSConversation extends Conversation {
+  group_id: string;
+  epoch: number;
+  cipher_suite: number;
+  protocol: ConversationProtocol.MLS;
+}

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -108,7 +108,10 @@ export class ConversationAPI {
     ONE_2_ONE: 'one2one',
   };
 
-  constructor(protected readonly client: HttpClient, protected readonly backendFeatures: BackendFeatures) {}
+  constructor(
+    protected readonly client: HttpClient,
+    protected readonly backendFeatures: BackendFeatures,
+  ) {}
 
   private generateBaseConversationUrl(conversationId: QualifiedId, supportsQualifiedEndpoint: boolean = true): string {
     return supportsQualifiedEndpoint && conversationId.domain

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -32,6 +32,7 @@ import {
   JoinConversationByCodePayload,
   Member,
   MessageSendingStatus,
+  MLSConversation,
   NewConversation,
   QualifiedConversationIds,
   RemoteConversations,
@@ -107,10 +108,7 @@ export class ConversationAPI {
     ONE_2_ONE: 'one2one',
   };
 
-  constructor(
-    protected readonly client: HttpClient,
-    protected readonly backendFeatures: BackendFeatures,
-  ) {}
+  constructor(protected readonly client: HttpClient, protected readonly backendFeatures: BackendFeatures) {}
 
   private generateBaseConversationUrl(conversationId: QualifiedId, supportsQualifiedEndpoint: boolean = true): string {
     return supportsQualifiedEndpoint && conversationId.domain
@@ -484,13 +482,13 @@ export class ConversationAPI {
    * Get a MLS 1:1-conversation with a given user.
    * @param userId - qualified user id
    */
-  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<Conversation> {
+  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLSConversation> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}/${domain}/${id}`,
     };
 
-    const response = await this.client.sendJSON<Conversation>(config);
+    const response = await this.client.sendJSON<MLSConversation>(config);
     return response.data;
   }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -434,4 +434,44 @@ export class ConversationService {
       }
     }
   }
+
+  /**
+   * Will try registering mls 1:1 conversation adding the other user.
+   * If it fails and the conversation is already established, it will try joining via external commit instead.
+   *
+   * @param mlsConversation - mls 1:1 conversation
+   * @param otherUserId - id of the other user
+   * @param proteusConversation - (optional) proteus 1:1 conversation
+   */
+  public readonly establishMLS1to1Conversation = async (
+    groupId: string,
+    selfUser: {user: QualifiedId; client: string},
+    otherUserId: QualifiedId,
+  ): Promise<void> => {
+    try {
+      await this.mlsService.registerConversation(groupId, [otherUserId, selfUser.user], selfUser);
+    } catch (error) {
+      this.logger.info(`Could not register MLS group with id ${groupId}.`);
+
+      const mlsConversation = await this.apiClient.api.conversation.getMLS1to1Conversation(otherUserId);
+
+      if (mlsConversation.epoch > 0) {
+        this.logger.info(
+          `Conversation (id ${mlsConversation.qualified_id.id}) is already established, joining via external commit`,
+        );
+
+        // If its already established, we join with external commit
+        await this.joinByExternalCommit(mlsConversation.qualified_id);
+        return;
+      }
+
+      this.logger.info(
+        `Conversation (id ${mlsConversation.qualified_id.id}) is not established, retrying to establish it`,
+      );
+
+      // If conversation is not established, we can wipe it and try to establish it again
+      await this.wipeMLSConversation(groupId);
+      return this.establishMLS1to1Conversation(groupId, selfUser, otherUserId);
+    }
+  };
 }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -440,8 +440,8 @@ export class ConversationService {
    * If it fails and the conversation is already established, it will try joining via external commit instead.
    *
    * @param mlsConversation - mls 1:1 conversation
+   * @param selfUser - user and client ids of the self user
    * @param otherUserId - id of the other user
-   * @param proteusConversation - (optional) proteus 1:1 conversation
    */
   public readonly establishMLS1to1Conversation = async (
     groupId: string,


### PR DESCRIPTION
Adds a method to establish (register) MLS conversation, when registering a group fails, check the epoch number of remote conversation and:

- if it's `0` it means the group was not established yet, wipe and retry
- if it's more than `0`, it means that the group was already established by you / the other user, we should join with external commit.