### PR TITLE
refactor: Generic federated backend error class

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -55,7 +55,6 @@ import {
   ConversationFullError,
   ConversationCodeNotFoundError,
   ConversationLegalholdMissingConsentError,
-  ConversationCreationUnreachableBackends,
 } from '../ConversationError';
 import {
   ConversationAccessUpdateData,
@@ -67,6 +66,7 @@ import {
   ConversationReceiptModeUpdateData,
   ConversationTypingData,
 } from '../data';
+import {handleFederationErrors} from '../FederatedBackendError';
 import {Subconversation, SUBCONVERSATION_ID} from '../Subconversation';
 
 export type PostMlsMessageResponse = {
@@ -575,11 +575,7 @@ export class ConversationAPI {
         }
       }
       if (isAxiosError(error)) {
-        switch (error.response?.status) {
-          case 533: {
-            throw new ConversationCreationUnreachableBackends(error.message, error.response.data.unreachable_backends);
-          }
-        }
+        handleFederationErrors(error);
       }
       throw error;
     }

--- a/packages/api-client/src/conversation/ConversationError.ts
+++ b/packages/api-client/src/conversation/ConversationError.ts
@@ -86,16 +86,3 @@ export class ConversationFullError extends ConversationError {
     this.name = 'ConversationFullError';
   }
 }
-
-export class ConversationCreationUnreachableBackends extends ConversationError {
-  constructor(
-    message: string,
-    public readonly unreachableBackends: string[],
-    label: BackendErrorLabel = BackendErrorLabel.UNREACHABLE_BACKENDS,
-    code: StatusCode = StatusCode.SERVICE_UNAVAILABLE,
-  ) {
-    super(message, label, code);
-    Object.setPrototypeOf(this, new.target.prototype);
-    this.name = 'ConversationCreationUnreachableBackends';
-  }
-}

--- a/packages/api-client/src/conversation/FederatedBackendError.ts
+++ b/packages/api-client/src/conversation/FederatedBackendError.ts
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {AxiosError} from 'axios';
+
+export class UnreachableBackendsError extends Error {
+  constructor(public backends: string[]) {
+    super('unreachable backends');
+    this.name = 'UnreachableBackendsError';
+  }
+}
+
+export function handleFederationErrors(error: AxiosError<any>) {
+  switch (error.response?.status) {
+    case 533: {
+      throw new UnreachableBackendsError(error.response.data.unreachable_backends);
+    }
+  }
+}

--- a/packages/api-client/src/conversation/index.ts
+++ b/packages/api-client/src/conversation/index.ts
@@ -21,6 +21,7 @@ export * from './Conversation';
 export * from './ConversationAPI';
 export * from './ConversationCode';
 export * from './ConversationError';
+export * from './FederatedBackendError';
 export * from './ConversationIds';
 export * from './ConversationMembers';
 export * from './Conversations';

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -21,7 +21,7 @@ import type {APIClient} from '@wireapp/api-client/lib/APIClient';
 import type {PreKey, Context} from '@wireapp/api-client/lib/auth';
 import type {
   Conversation,
-  ConversationCreationUnreachableBackends,
+  UnreachableBackendsError,
   NewConversation,
   QualifiedOTRRecipients,
   QualifiedUserClients,
@@ -171,17 +171,17 @@ export class ProteusService {
     }
 
     return this.apiClient.api.conversation.postConversation(payload).catch(async (error: unknown) => {
-      const conversationError = error as ConversationCreationUnreachableBackends;
+      const backendError = error as UnreachableBackendsError;
       if (typeof conversationData !== 'string') {
         // switch (conversationError.label) {
         // case BackendErrorLabel.UNREACHABLE_BACKENDS: {
-        const {unreachableBackends} = conversationError;
+        const {backends} = backendError;
         const users: QualifiedId[] | undefined = conversationData.qualified_users;
         if (users !== undefined) {
           const availableUsers: QualifiedId[] = [];
           const unreachableUsers: QualifiedId[] = [];
           users.forEach(user =>
-            unreachableBackends.includes(user.domain) ? unreachableUsers.push(user) : availableUsers.push(user),
+            backends.includes(user.domain) ? unreachableUsers.push(user) : availableUsers.push(user),
           );
           conversationData.qualified_users = availableUsers;
           const refetchedConversation = await this.apiClient.api.conversation


### PR DESCRIPTION
This creates a generic error class for federated backend errors (handles unreachable backends and non connected backend later)