### PR TITLE
feat: Handle adding users that are on an unreachable backend

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -915,6 +915,9 @@ export class ConversationAPI {
           throw new ConversationLegalholdMissingConsentError(backendError.message);
         }
       }
+      if (isAxiosError(error)) {
+        handleFederationErrors(error);
+      }
       throw error;
     }
   }

--- a/packages/api-client/src/conversation/FederatedBackendsError.ts
+++ b/packages/api-client/src/conversation/FederatedBackendsError.ts
@@ -38,6 +38,10 @@ export class FederatedBackendsError extends Error {
   }
 }
 
+export function isFederatedBackendsError(error: unknown): error is FederatedBackendsError {
+  return !!error && typeof error === 'object' && 'name' in error && error.name === 'FederatedBackendsError';
+}
+
 export function handleFederationErrors(error: AxiosError<any>) {
   switch (error.response?.status) {
     case FederatedBackendsErrorCode.UNREACHABLE: {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -38,6 +38,7 @@ import {constructSessionId} from '../Utility/SessionHandler';
 import {NotificationSource} from '../../../notification';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
 import {GenericMessage} from '@wireapp/protocol-messaging';
+import {ProteusService} from './ProteusService';
 
 jest.mock('./CryptoClient/CoreCryptoWrapper/PrekeysTracker', () => {
   return {
@@ -569,6 +570,59 @@ describe('ProteusService', () => {
         expect(result.state).toBe(MessageSendingState.OUTGOING_SENT);
         expect(result.failedToSend?.queued).toEqual({domain2: recipients.domain2});
       });
+    });
+  });
+
+  describe('addUsersToConversation', () => {
+    const baseResponse: Awaited<ReturnType<typeof ProteusService.prototype.addUsersToConversation>> = {
+      conversation: '',
+      from: '',
+      time: Date.now().toString(),
+      data: {users: [], user_ids: []},
+      type: CONVERSATION_EVENT.MEMBER_JOIN,
+    };
+
+    const conversationId = {id: 'conv1', domain: 'domain1'};
+    const userDomain1 = {id: 'user-1-1', domain: 'domain1'};
+    const user2Domain1 = {id: 'user-2-1', domain: 'domain1'};
+    const userDomain2 = {id: 'user-2-2', domain: 'domain2'};
+
+    it('adds all requested users to an existing conversation', async () => {
+      const [proteusService, {apiClient}] = await buildProteusService();
+
+      jest.spyOn(apiClient.api.conversation, 'postMembers').mockResolvedValueOnce({...baseResponse});
+
+      const event = await proteusService.addUsersToConversation({
+        conversationId,
+        qualifiedUsers: [userDomain1, user2Domain1, userDomain2],
+      });
+
+      expect(event).toEqual(baseResponse);
+    });
+
+    it('partially add users if some backends are unreachable', async () => {
+      const [proteusService, {apiClient}] = await buildProteusService();
+
+      const postMembersSpy = jest
+        .spyOn(apiClient.api.conversation, 'postMembers')
+        .mockRejectedValueOnce(
+          new FederatedBackendsError(FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS, [userDomain1.domain]),
+        )
+        .mockResolvedValueOnce(baseResponse);
+
+      const result = await proteusService.addUsersToConversation({
+        conversationId,
+        qualifiedUsers: [userDomain1, user2Domain1, userDomain2],
+      });
+
+      expect(postMembersSpy).toHaveBeenCalledTimes(2);
+      expect(postMembersSpy).toHaveBeenCalledWith(
+        conversationId,
+        expect.arrayContaining([userDomain1, user2Domain1, userDomain2]),
+      );
+      expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining([userDomain2]));
+
+      expect(result.failedToAdd).toEqual([userDomain1, user2Domain1]);
     });
   });
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -574,13 +574,15 @@ describe('ProteusService', () => {
   });
 
   describe('addUsersToConversation', () => {
-    const baseResponse: Awaited<ReturnType<typeof ProteusService.prototype.addUsersToConversation>> = {
-      conversation: '',
-      from: '',
-      time: Date.now().toString(),
-      data: {users: [], user_ids: []},
-      type: CONVERSATION_EVENT.MEMBER_JOIN,
-    };
+    const baseResponse = {
+      event: {
+        conversation: '',
+        from: '',
+        time: Date.now().toString(),
+        data: {users: [], user_ids: []},
+        type: CONVERSATION_EVENT.MEMBER_JOIN,
+      },
+    } satisfies Awaited<ReturnType<typeof ProteusService.prototype.addUsersToConversation>>;
 
     const conversationId = {id: 'conv1', domain: 'domain1'};
     const userDomain1 = {id: 'user-1-1', domain: 'domain1'};
@@ -590,7 +592,7 @@ describe('ProteusService', () => {
     it('adds all requested users to an existing conversation', async () => {
       const [proteusService, {apiClient}] = await buildProteusService();
 
-      jest.spyOn(apiClient.api.conversation, 'postMembers').mockResolvedValueOnce({...baseResponse});
+      jest.spyOn(apiClient.api.conversation, 'postMembers').mockResolvedValueOnce(baseResponse.event);
 
       const event = await proteusService.addUsersToConversation({
         conversationId,
@@ -608,7 +610,7 @@ describe('ProteusService', () => {
         .mockRejectedValueOnce(
           new FederatedBackendsError(FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS, [userDomain1.domain]),
         )
-        .mockResolvedValueOnce(baseResponse);
+        .mockResolvedValueOnce(baseResponse.event);
 
       const result = await proteusService.addUsersToConversation({
         conversationId,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -217,7 +217,8 @@ export class ProteusService {
               qualifiedUsers,
               backends,
             );
-            const response = this.apiClient.api.conversation.postMembers(conversationId, availableUsers);
+            // In case the request to add users failed with a `UNREACHABLE_BACKENDS` error, we try again with the users from available backends
+            const response = await this.apiClient.api.conversation.postMembers(conversationId, availableUsers);
             return {
               ...response,
               failedToAdd: unreachableUsers,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/userDomainFilters.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/userDomainFilters.ts
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+export function filterUsersFromDomains(
+  userIds: QualifiedId[],
+  domainsToExclude: string[],
+): {excludedUsers: QualifiedId[]; includedUsers: QualifiedId[]} {
+  const excludedUsers: QualifiedId[] = [];
+  const includedUsers: QualifiedId[] = [];
+  userIds.forEach(user =>
+    domainsToExclude.includes(user.domain) ? excludedUsers.push(user) : includedUsers.push(user),
+  );
+
+  return {
+    excludedUsers,
+    includedUsers,
+  };
+}


### PR DESCRIPTION
This will add the ability to handle backend errors when adding users to a conversation. 

If users from an unreachable backend are added, then those users are filtered out and marked as `failedToAdd` in the response. 