### PR TITLE
feat: Handle backend non federating errors

### DIFF
--- a/packages/api-client/src/conversation/FederatedBackendsError.ts
+++ b/packages/api-client/src/conversation/FederatedBackendsError.ts
@@ -21,11 +21,12 @@ import {AxiosError} from 'axios';
 
 export enum FederatedBackendsErrorLabel {
   UNREACHABLE_BACKENDS = 'UnreachableBackendsError',
-  NOT_CONNECTED_BACKENDS = 'NotConnectedBackendsError',
+  NON_FEDERATING_BACKENDS = 'NotConnectedBackendsError',
 }
 
 enum FederatedBackendsErrorCode {
-  UNREACHABLE = 533,
+  UNREACHABLE = 533, // When a backend is not reachable for the current user
+  NON_FEDERATING = 409, // When 2 users' backend are not connected to each others
 }
 
 export class FederatedBackendsError extends Error {
@@ -48,6 +49,13 @@ export function handleFederationErrors(error: AxiosError<any>) {
       throw new FederatedBackendsError(
         FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS,
         error.response.data.unreachable_backends,
+      );
+    }
+
+    case FederatedBackendsErrorCode.NON_FEDERATING: {
+      throw new FederatedBackendsError(
+        FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS,
+        error.response.data.non_federating_backends,
       );
     }
   }

--- a/packages/api-client/src/conversation/FederatedBackendsError.ts
+++ b/packages/api-client/src/conversation/FederatedBackendsError.ts
@@ -25,8 +25,8 @@ export enum FederatedBackendsErrorLabel {
 }
 
 enum FederatedBackendsErrorCode {
-  UNREACHABLE = 533, // When a backend is not reachable for the current user
   NON_FEDERATING = 409, // When 2 users' backend are not connected to each others
+  UNREACHABLE = 533, // When a backend is not reachable for the current user
 }
 
 export class FederatedBackendsError extends Error {

--- a/packages/api-client/src/conversation/FederatedBackendsError.ts
+++ b/packages/api-client/src/conversation/FederatedBackendsError.ts
@@ -21,7 +21,7 @@ import {AxiosError} from 'axios';
 
 export enum FederatedBackendsErrorLabel {
   UNREACHABLE_BACKENDS = 'UnreachableBackendsError',
-  NON_FEDERATING_BACKENDS = 'NotConnectedBackendsError',
+  NON_FEDERATING_BACKENDS = 'NonFederatingBackendsError',
 }
 
 enum FederatedBackendsErrorCode {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -99,18 +99,16 @@ export class ConversationService {
   /**
    * Create a group conversation.
    *
+   * This method might fail with a `BackendsNotConnectedError` if there are users from not connected backends that are part of the payload
+   *
    * @note Do not include yourself as the requestor
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/createGroupConversation
    *
    * @param conversationData Payload object for group creation
    * @returns Resolves when the conversation was created
    */
-  public async createProteusConversation(conversationData: NewConversation): Promise<Conversation>;
-  public async createProteusConversation(
-    conversationData: NewConversation | string,
-    otherUserIds?: string | string[],
-  ): Promise<Conversation> {
-    return this.proteusService.createConversation({conversationData, otherUserIds});
+  public async createProteusConversation(conversationData: NewConversation): Promise<Conversation> {
+    return this.proteusService.createConversation(conversationData);
   }
 
   public async getConversation(conversationId: QualifiedId): Promise<Conversation> {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -53,6 +53,11 @@ import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/ful
 import {RemoteData} from '../content';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
 
+export enum AddUsersFailureReasons {
+  NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
+  UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
+}
+
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
   private readonly logger = logdown('@wireapp/core/ConversationService');

--- a/packages/core/src/errors/FederatedBackendsError.ts
+++ b/packages/core/src/errors/FederatedBackendsError.ts
@@ -18,7 +18,7 @@
  */
 
 /**
- * This error means we are trying to add users that are parts of 2 backends that are not connected to a new conversation.
+ * This error means we are trying to add users that are parts of 2 backends that are not federating with each other to a new conversation.
  */
 export class NonFederatingBackendsError extends Error {
   constructor(public readonly backends: string[]) {

--- a/packages/core/src/errors/FederatedBackendsError.ts
+++ b/packages/core/src/errors/FederatedBackendsError.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,11 +17,12 @@
  *
  */
 
-export {Account, ConnectionState, ProcessedEventPayload} from './Account';
-export * as auth from './auth/';
-export * as conversation from './conversation/';
-export {CoreError} from './CoreError';
-export * as cryptography from './cryptography/';
-export * as util from './util';
-export * as MessageBuilder from './conversation/message/MessageBuilder';
-export * as errors from './errors';
+/**
+ * This error means we are trying to add users that are parts of 2 backends that are not connected to a new conversation.
+ */
+export class BackendsNotConnectedError extends Error {
+  constructor(public readonly backends: string[]) {
+    super('2 backends are not connected');
+    this.name = 'BackendsNotConnectedError';
+  }
+}

--- a/packages/core/src/errors/FederatedBackendsError.ts
+++ b/packages/core/src/errors/FederatedBackendsError.ts
@@ -20,7 +20,7 @@
 /**
  * This error means we are trying to add users that are parts of 2 backends that are not connected to a new conversation.
  */
-export class BackendsNotConnectedError extends Error {
+export class NonFederatingBackendError extends Error {
   constructor(public readonly backends: string[]) {
     super('2 backends are not connected');
     this.name = 'BackendsNotConnectedError';

--- a/packages/core/src/errors/FederatedBackendsError.ts
+++ b/packages/core/src/errors/FederatedBackendsError.ts
@@ -20,9 +20,13 @@
 /**
  * This error means we are trying to add users that are parts of 2 backends that are not connected to a new conversation.
  */
-export class NonFederatingBackendError extends Error {
+export class NonFederatingBackendsError extends Error {
   constructor(public readonly backends: string[]) {
     super('2 backends are not connected');
-    this.name = 'BackendsNotConnectedError';
+    this.name = 'NonFederatingBackendError';
   }
+}
+
+export function isNonFederatingBackendsError(error: unknown): error is NonFederatingBackendsError {
+  return !!error && typeof error === 'object' && 'name' in error && error.name === 'NonFederatingBackendError';
 }

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2018 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,11 +17,5 @@
  *
  */
 
-export {Account, ConnectionState, ProcessedEventPayload} from './Account';
-export * as auth from './auth/';
-export * as conversation from './conversation/';
-export {CoreError} from './CoreError';
-export * as cryptography from './cryptography/';
-export * as util from './util';
-export * as MessageBuilder from './conversation/message/MessageBuilder';
-export * as errors from './errors';
+export * from './DecryptionError';
+export * from './FederatedBackendsError';

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -39,7 +39,7 @@ import {NotificationSource} from '../../../notification';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 import {ProteusService} from './ProteusService';
-import {BackendsNotConnectedError} from '../../../errors';
+import {NonFederatingBackendError} from '../../../errors';
 
 jest.mock('./CryptoClient/CoreCryptoWrapper/PrekeysTracker', () => {
   return {
@@ -636,7 +636,7 @@ describe('ProteusService', () => {
       const postMembersSpy = jest
         .spyOn(apiClient.api.conversation, 'postMembers')
         .mockRejectedValueOnce(
-          new FederatedBackendsError(FederatedBackendsErrorLabel.NOT_CONNECTED_BACKENDS, [
+          new FederatedBackendsError(FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS, [
             userDomain2.domain,
             userDomain3.domain,
           ]),
@@ -759,7 +759,7 @@ describe('ProteusService', () => {
       jest
         .spyOn(apiClient.api.conversation, 'postConversation')
         .mockRejectedValueOnce(
-          new FederatedBackendsError(FederatedBackendsErrorLabel.NOT_CONNECTED_BACKENDS, [
+          new FederatedBackendsError(FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS, [
             userDomain1.domain,
             userDomain2.domain,
           ]),
@@ -770,7 +770,7 @@ describe('ProteusService', () => {
           receipt_mode: null,
           qualified_users: [userDomain1, user2Domain1, userDomain2],
         }),
-      ).rejects.toThrow(BackendsNotConnectedError);
+      ).rejects.toThrow(NonFederatingBackendError);
     });
   });
 });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -30,7 +30,7 @@ import {
   QualifiedUserClients,
 } from '@wireapp/api-client/lib/conversation';
 
-import {MessageSendingState, MessageTargetMode} from '../../../conversation';
+import {AddUsersFailureReasons, MessageSendingState, MessageTargetMode} from '../../../conversation';
 import {buildTextMessage} from '../../../conversation/message/MessageBuilder';
 import {SendProteusMessageParams} from './ProteusService.types';
 import {buildProteusService} from './ProteusService.mocks';
@@ -627,7 +627,8 @@ describe('ProteusService', () => {
       );
       expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining([userDomain2]));
 
-      expect(result.failedToAdd).toEqual([userDomain1, user2Domain1]);
+      expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.UNREACHABLE_BACKENDS);
+      expect(result.failedToAdd?.users).toEqual([userDomain1, user2Domain1]);
     });
 
     it('partially add users if some users are part of not-connected backends', async () => {
@@ -655,7 +656,8 @@ describe('ProteusService', () => {
       );
       expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining([userDomain1, user2Domain1]));
 
-      expect(result.failedToAdd).toEqual([userDomain2, userDomain3]);
+      expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.NON_FEDERATING_BACKENDS);
+      expect(result.failedToAdd?.users).toEqual([userDomain2, userDomain3]);
     });
   });
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -39,7 +39,7 @@ import {NotificationSource} from '../../../notification';
 import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 import {ProteusService} from './ProteusService';
-import {NonFederatingBackendError} from '../../../errors';
+import {NonFederatingBackendsError} from '../../../errors';
 
 jest.mock('./CryptoClient/CoreCryptoWrapper/PrekeysTracker', () => {
   return {
@@ -770,7 +770,7 @@ describe('ProteusService', () => {
           receipt_mode: null,
           qualified_users: [userDomain1, user2Domain1, userDomain2],
         }),
-      ).rejects.toThrow(NonFederatingBackendError);
+      ).rejects.toThrow(NonFederatingBackendsError);
     });
   });
 });

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -48,7 +48,7 @@ import {filterUsersFromDomains} from './userDomainFilters';
 
 import {GenericMessageType, MessageSendingState, SendResult} from '../../../conversation';
 import {MessageService} from '../../../conversation/message/MessageService';
-import {BackendsNotConnectedError} from '../../../errors';
+import {NonFederatingBackendError} from '../../../errors';
 import type {EventHandlerResult} from '../../common.types';
 import {EventHandlerParams, handleBackendEvent} from '../EventHandler';
 import {getGenericMessageParams} from '../Utility/getGenericMessageParams';
@@ -162,9 +162,9 @@ export class ProteusService {
     } catch (error: unknown) {
       if (isFederatedBackendsError(error)) {
         switch (error.label) {
-          case FederatedBackendsErrorLabel.NOT_CONNECTED_BACKENDS: {
+          case FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS: {
             // In case we are trying to create a conversation with users from 2 backends that are not connected, we should stop the procedure and throw an error
-            throw new BackendsNotConnectedError(error.backends);
+            throw new NonFederatingBackendError(error.backends);
           }
           case FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS: {
             const {backends} = error;
@@ -202,7 +202,7 @@ export class ProteusService {
     } catch (error) {
       if (isFederatedBackendsError(error)) {
         switch (error.label) {
-          case FederatedBackendsErrorLabel.NOT_CONNECTED_BACKENDS:
+          case FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS:
           case FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS: {
             const {backends} = error;
             const {excludedUsers: unreachableUsers, includedUsers: availableUsers} = filterUsersFromDomains(

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -48,7 +48,7 @@ import {filterUsersFromDomains} from './userDomainFilters';
 
 import {GenericMessageType, MessageSendingState, SendResult} from '../../../conversation';
 import {MessageService} from '../../../conversation/message/MessageService';
-import {NonFederatingBackendError} from '../../../errors';
+import {NonFederatingBackendsError} from '../../../errors';
 import type {EventHandlerResult} from '../../common.types';
 import {EventHandlerParams, handleBackendEvent} from '../EventHandler';
 import {getGenericMessageParams} from '../Utility/getGenericMessageParams';
@@ -164,7 +164,7 @@ export class ProteusService {
         switch (error.label) {
           case FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS: {
             // In case we are trying to create a conversation with users from 2 backends that are not connected, we should stop the procedure and throw an error
-            throw new NonFederatingBackendError(error.backends);
+            throw new NonFederatingBackendsError(error.backends);
           }
           case FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS: {
             const {backends} = error;

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -40,7 +40,6 @@ import {generateDecryptionError} from './DecryptionErrorGenerator';
 import {deleteIdentity} from './identityClearer';
 import type {
   AddUsersToProteusConversationParams,
-  CreateProteusConversationParams,
   ProteusServiceConfig,
   SendProteusMessageParams,
 } from './ProteusService.types';
@@ -49,6 +48,7 @@ import {filterUsersFromDomains} from './userDomainFilters';
 
 import {GenericMessageType, MessageSendingState, SendResult} from '../../../conversation';
 import {MessageService} from '../../../conversation/message/MessageService';
+import {BackendsNotConnectedError} from '../../../errors';
 import type {EventHandlerResult} from '../../common.types';
 import {EventHandlerParams, handleBackendEvent} from '../EventHandler';
 import {getGenericMessageParams} from '../Utility/getGenericMessageParams';
@@ -156,38 +156,26 @@ export class ProteusService {
     return this.cryptoClient.getRemoteFingerprint(sessionId);
   }
 
-  public async createConversation({
-    conversationData,
-    otherUserIds,
-  }: CreateProteusConversationParams): Promise<Conversation> {
-    let payload: NewConversation;
-    if (typeof conversationData === 'string') {
-      const ids = typeof otherUserIds === 'string' ? [otherUserIds] : otherUserIds;
-
-      payload = {
-        name: conversationData,
-        receipt_mode: null,
-        users: ids ?? [],
-      };
-    } else {
-      payload = conversationData;
-    }
-
-    return this.apiClient.api.conversation.postConversation(payload).catch(async (error: unknown) => {
+  public async createConversation(conversationData: NewConversation): Promise<Conversation> {
+    try {
+      return await this.apiClient.api.conversation.postConversation(conversationData);
+    } catch (error: unknown) {
       if (isFederatedBackendsError(error)) {
         switch (error.label) {
+          case FederatedBackendsErrorLabel.NOT_CONNECTED_BACKENDS: {
+            // In case we are trying to create a conversation with users from 2 backends that are not connected, we should stop the procedure and throw an error
+            throw new BackendsNotConnectedError(error.backends);
+          }
           case FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS: {
             const {backends} = error;
             const {excludedUsers: unreachableUsers, includedUsers: availableUsers} = filterUsersFromDomains(
-              payload.qualified_users ?? [],
+              conversationData.qualified_users ?? [],
               backends,
             );
-            payload = {...payload, qualified_users: availableUsers};
+            conversationData = {...conversationData, qualified_users: availableUsers};
             // If conversation creation returns an error because a backend is offline,
             // we try creating the conversation again with users from available backends
-            const response = await this.apiClient.api.conversation.postConversation(payload).catch((error: unknown) => {
-              throw error;
-            });
+            const response = await this.apiClient.api.conversation.postConversation(conversationData);
 
             // on a succesfull conversation creation with the available users,
             // we append the users from an unreachable backend to the response
@@ -198,7 +186,7 @@ export class ProteusService {
       }
 
       throw error;
-    });
+    }
   }
 
   /**
@@ -224,7 +212,7 @@ export class ProteusService {
             if (availableUsers.length === 0) {
               return {failedToAdd: unreachableUsers};
             }
-            // In case the request to add users failed with a `UNREACHABLE_BACKENDS` error, we try again with the users from available backends
+            // In case the request to add users failed with a `UNREACHABLE_BACKENDS` or `NOT_CONNECTED_BACKENDS` errors, we try again with the users from available backends
             const response = await this.apiClient.api.conversation.postMembers(conversationId, availableUsers);
             return {
               event: response,

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -214,6 +214,7 @@ export class ProteusService {
     } catch (error) {
       if (isFederatedBackendsError(error)) {
         switch (error.label) {
+          case FederatedBackendsErrorLabel.NOT_CONNECTED_BACKENDS:
           case FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS: {
             const {backends} = error;
             const {excludedUsers: unreachableUsers, includedUsers: availableUsers} = filterUsersFromDomains(

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/WithMockedGenerics.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/WithMockedGenerics.test.ts
@@ -91,28 +91,17 @@ describe('createConversation', () => {
     it('when a new conversation object is given', async () => {
       const proteusService = await prepareProteusService();
       const conversationData = createConversationResult as unknown as NewConversation;
-      const returnData = await proteusService.createConversation({conversationData});
+      const returnData = await proteusService.createConversation(conversationData);
 
       expect(returnData).toStrictEqual(createConversationResult);
     });
 
     it('create a new conversation with no name', async () => {
       const proteusService = await prepareProteusService();
-      const otherUserIds = ['user1', 'user2'];
       const conversationData = {users: ['user1', 'user2'], receipt_mode: null};
-      const returnData = await proteusService.createConversation({conversationData, otherUserIds});
+      const returnData = await proteusService.createConversation(conversationData);
 
       expect(returnData).toStrictEqual(conversationData);
-    });
-
-    it('when a conversation string and userIds are given', async () => {
-      const proteusService = await prepareProteusService();
-
-      const otherUserIds = ['user1', 'user2'];
-      const conversationData = 'test';
-      const returnData = await proteusService.createConversation({conversationData, otherUserIds});
-
-      expect(returnData).toStrictEqual(createConversationResult);
     });
   });
 });


### PR DESCRIPTION
This will allow the core to handle the case of 2 backends not connected to each other when it comes to creating a new conversation and adding users to a conversation. 

The gist is:
- when adding users in a conversation that are from 2 non-connected backends, the `addUsersToConversation` will adds all the other users and return the users from those unconnected backends as `failedToAdd`;
- when creating a conversation with users from 2 non-connected backends, the conversation creation will fail with a `NonFederatingBackendsError` 