### PR TITLE
refactor: harmonize failedToAdd response in conversation creation and user addition

### DIFF
--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -98,15 +98,6 @@ export interface Conversation {
   epoch?: number;
   cipher_suite?: number;
 
-  /**
-   * List of users that were originaly requested to be in the conversation
-   * but could not be added due to their backend not being available
-   * @note This field comes only on conversation creation response
-   * @note Added since version 4: https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/#/default/post_conversations
-   * @note Federation only
-   */
-  failed_to_add: QualifiedId[];
-
   protocol: ConversationProtocol;
 }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -38,7 +38,13 @@ import {APIClient} from '@wireapp/api-client';
 import {Ciphersuite, CredentialType, ExternalProposalType} from '@wireapp/core-crypto';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
-import {AddUsersParams, MLSReturnType, SendMlsMessageParams, SendResult} from './ConversationService.types';
+import {
+  AddUsersFailureReasons,
+  AddUsersParams,
+  MLSReturnType,
+  SendMlsMessageParams,
+  SendResult,
+} from './ConversationService.types';
 
 import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conversation/';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
@@ -52,11 +58,6 @@ import {isMLSConversation} from '../../util';
 import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/fullyQualifiedClientIdUtils';
 import {RemoteData} from '../content';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
-
-export enum AddUsersFailureReasons {
-  NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
-  UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
-}
 
 export class ConversationService {
   public readonly messageTimer: MessageTimer;
@@ -267,7 +268,9 @@ export class ConversationService {
     return {
       events: response.events,
       conversation,
-      failedToAdd: response.failed ?? undefined,
+      failedToAdd: response.failed
+        ? {users: response.failed, reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS}
+        : undefined,
     };
   }
 
@@ -328,7 +331,10 @@ export class ConversationService {
     return {
       events: response.events,
       conversation,
-      failedToAdd: failedToFetchKeyPackages.length > 0 ? failedToFetchKeyPackages : undefined,
+      failedToAdd:
+        failedToFetchKeyPackages.length > 0
+          ? {users: failedToFetchKeyPackages, reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS}
+          : undefined,
     };
   }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -41,7 +41,7 @@ import {GenericMessage} from '@wireapp/protocol-messaging';
 import {
   AddUsersFailureReasons,
   AddUsersParams,
-  MLSReturnType,
+  MLSCreateConversationResponse,
   SendMlsMessageParams,
   SendResult,
 } from './ConversationService.types';
@@ -239,7 +239,7 @@ export class ConversationService {
     conversationData: NewConversation,
     selfUserId: QualifiedId,
     selfClientId: string,
-  ): Promise<MLSReturnType> {
+  ): Promise<MLSCreateConversationResponse> {
     const {qualified_users: qualifiedUsers = []} = conversationData;
 
     /**
@@ -269,7 +269,7 @@ export class ConversationService {
       events: response.events,
       conversation,
       failedToAdd: response.failed
-        ? {users: response.failed, reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS}
+        ? {users: response.failed, reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
         : undefined,
     };
   }
@@ -318,7 +318,7 @@ export class ConversationService {
     qualifiedUsers,
     groupId,
     conversationId,
-  }: Required<AddUsersParams>): Promise<MLSReturnType> {
+  }: Required<AddUsersParams>): Promise<MLSCreateConversationResponse> {
     const {coreCryptoKeyPackagesPayload, failedToFetchKeyPackages} = await this.mlsService.getKeyPackagesPayload(
       qualifiedUsers,
     );
@@ -333,7 +333,7 @@ export class ConversationService {
       conversation,
       failedToAdd:
         failedToFetchKeyPackages.length > 0
-          ? {users: failedToFetchKeyPackages, reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS}
+          ? {users: failedToFetchKeyPackages, reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
           : undefined,
     };
   }
@@ -342,7 +342,7 @@ export class ConversationService {
     groupId,
     conversationId,
     qualifiedUserIds,
-  }: RemoveUsersParams): Promise<MLSReturnType> {
+  }: RemoveUsersParams): Promise<MLSCreateConversationResponse> {
     const clientsToRemove = await this.apiClient.api.user.postListClients({qualified_users: qualifiedUserIds});
 
     const fullyQualifiedClientIds = mapQualifiedUserClientIdsToFullyQualifiedClientIds(

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -112,7 +112,7 @@ export class ConversationService {
    * @param conversationData Payload object for group creation
    * @returns Resolves when the conversation was created
    */
-  public async createProteusConversation(conversationData: NewConversation): Promise<Conversation> {
+  public async createProteusConversation(conversationData: NewConversation) {
     return this.proteusService.createConversation(conversationData);
   }
 
@@ -264,14 +264,10 @@ export class ConversationService {
     // We fetch the fresh version of the conversation created on backend with the newly added users
     const conversation = await this.apiClient.api.conversation.getConversation(qualifiedId);
 
-    /**
-     * @note Add users whom we could not fetch their keypackages to list of failed to add users.
-     */
-    conversation.failed_to_add = response.failed || [];
-
     return {
       events: response.events,
       conversation,
+      failedToAdd: response.failed ?? undefined,
     };
   }
 
@@ -327,13 +323,12 @@ export class ConversationService {
     const response = await this.mlsService.addUsersToExistingConversation(groupId, coreCryptoKeyPackagesPayload);
     const conversation = await this.getConversation(conversationId);
 
-    conversation.failed_to_add = failedToFetchKeyPackages;
-
     //We store the info when user was added (and key material was created), so we will know when to renew it
     this.mlsService.resetKeyMaterialRenewal(groupId);
     return {
       events: response.events,
       conversation,
+      failedToAdd: failedToFetchKeyPackages.length > 0 ? failedToFetchKeyPackages : undefined,
     };
   }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -135,14 +135,14 @@ export type AddUsersFailure = {
 /**
  * The backend response of any method that will create (or add users to) a conversation
  */
-interface BaseCreateConversationResponse {
+export interface BaseCreateConversationResponse {
   conversation: Conversation;
   failedToAdd?: AddUsersFailure;
 }
 
 export type ProteusCreateConversationResponse = BaseCreateConversationResponse;
 export type ProteusAddUsersResponse = {
-  events?: ConversationMemberJoinEvent[];
+  event?: ConversationMemberJoinEvent;
   failedToAdd?: AddUsersFailure;
 };
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -114,7 +114,28 @@ export type RemoveUsersParams = {
   groupId: string;
 };
 
-export type MLSReturnType = {events: ConversationEvent[]; conversation: Conversation; failedToAdd?: QualifiedId[]};
+/**
+ * List of users that were originaly requested to be in the conversation
+ * but could not be added due to their backend not being available
+ * @note Added since version 4: https://staging-nginz-https.z
+ ra.io/v4/api/swagger-ui/#/default/post_conversations
+ * @note Federation only
+ */
+export enum AddUsersFailureReasons {
+  NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
+  UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
+}
+
+export type AddUsersFailure = {
+  users: QualifiedId[];
+  reason: AddUsersFailureReasons;
+};
+
+export type MLSReturnType = {
+  events: ConversationEvent[];
+  conversation: Conversation;
+  failedToAdd?: AddUsersFailure;
+};
 
 export type SendResult = {
   /** The id of the message sent */

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -114,7 +114,7 @@ export type RemoveUsersParams = {
   groupId: string;
 };
 
-export type MLSReturnType = {events: ConversationEvent[]; conversation: Conversation};
+export type MLSReturnType = {events: ConversationEvent[]; conversation: Conversation; failedToAdd?: QualifiedId[]};
 
 export type SendResult = {
   /** The id of the message sent */

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -24,6 +24,7 @@ import {
   Conversation,
 } from '@wireapp/api-client/lib/conversation';
 import {ConversationEvent} from '@wireapp/api-client/lib/event';
+import {ConversationMemberJoinEvent} from '@wireapp/api-client/lib/event';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {GenericMessage} from '@wireapp/protocol-messaging';
@@ -114,6 +115,11 @@ export type RemoveUsersParams = {
   groupId: string;
 };
 
+export enum AddUsersFailureReasons {
+  NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
+  UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
+}
+
 /**
  * List of users that were originaly requested to be in the conversation
  * but could not be added due to their backend not being available
@@ -121,21 +127,28 @@ export type RemoveUsersParams = {
  ra.io/v4/api/swagger-ui/#/default/post_conversations
  * @note Federation only
  */
-export enum AddUsersFailureReasons {
-  NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
-  UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
-}
-
 export type AddUsersFailure = {
   users: QualifiedId[];
   reason: AddUsersFailureReasons;
 };
 
-export type MLSReturnType = {
-  events: ConversationEvent[];
+/**
+ * The backend response of any method that will create (or add users to) a conversation
+ */
+interface BaseCreateConversationResponse {
   conversation: Conversation;
   failedToAdd?: AddUsersFailure;
+}
+
+export type ProteusCreateConversationResponse = BaseCreateConversationResponse;
+export type ProteusAddUsersResponse = {
+  events?: ConversationMemberJoinEvent[];
+  failedToAdd?: AddUsersFailure;
 };
+
+export interface MLSCreateConversationResponse extends BaseCreateConversationResponse {
+  events: ConversationEvent[];
+}
 
 export type SendResult = {
   /** The id of the message sent */

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -40,7 +40,7 @@ import {CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 import {ProteusService} from './ProteusService';
 import {NonFederatingBackendsError} from '../../../errors';
-import {generateQualifiedIds} from '../../../testUtils';
+import {generateQualifiedId, generateQualifiedIds} from '../../../testUtils';
 
 jest.mock('./CryptoClient/CoreCryptoWrapper/PrekeysTracker', () => {
   return {
@@ -126,12 +126,19 @@ const prepareDataForEncryption = async () => {
 };
 
 describe('ProteusService', () => {
+  const domain1 = 'domain1';
+  const domain2 = 'domain2';
+  const domain3 = 'domain3';
+
+  const usersDomain1 = generateQualifiedIds(3, domain1);
+  const usersDomain2 = generateQualifiedIds(3, domain2);
+  const usersDomain3 = generateQualifiedIds(3, domain3);
   describe('getRemoteFingerprint', () => {
     it('create a session if session does not exists', async () => {
       const [proteusService, {apiClient, cryptoClient}] = await buildProteusService();
       const expectedFingerprint = 'fingerprint-client1';
 
-      const userId = {id: 'user1', domain: 'domain.com'};
+      const userId = generateQualifiedId('domain');
       const clientId = 'client1';
 
       jest.spyOn(apiClient.api.user, 'postMultiPreKeyBundles').mockResolvedValue({
@@ -166,7 +173,7 @@ describe('ProteusService', () => {
       jest.spyOn(cryptoClient, 'saveSession').mockResolvedValue(undefined);
       jest.spyOn(cryptoClient, 'sessionExists').mockResolvedValue(false);
 
-      const userId = {id: 'user1', domain: 'domain.com'};
+      const userId = generateQualifiedId('domain');
       const clientId = 'client1';
 
       const result = await proteusService.getRemoteFingerprint(userId, clientId, {
@@ -188,7 +195,7 @@ describe('ProteusService', () => {
       jest.spyOn(cryptoClient, 'getRemoteFingerprint').mockResolvedValue(expectedFingerprint);
       jest.spyOn(cryptoClient, 'sessionExists').mockResolvedValue(true);
 
-      const userId = {id: 'user1', domain: 'domain.com'};
+      const userId = generateQualifiedId('domain');
       const clientId = 'client1';
 
       const result = await proteusService.getRemoteFingerprint(userId, clientId);
@@ -203,7 +210,7 @@ describe('ProteusService', () => {
     const eventPayload = {
       event: {
         type: CONVERSATION_EVENT.OTR_MESSAGE_ADD,
-        qualified_from: {id: 'user1', domain: 'domain'},
+        qualified_from: generateQualifiedId('domain'),
         data: {sender: 'client1', text: ''},
       },
       source: NotificationSource.WEBSOCKET,
@@ -401,7 +408,7 @@ describe('ProteusService', () => {
         let errorMessage;
 
         const params: SendProteusMessageParams = {
-          conversationId: {id: 'conv1', domain: ''},
+          conversationId: generateQualifiedId('domain'),
           payload: message,
           protocol: ConversationProtocol.PROTEUS,
           targetMode: MessageTargetMode.USERS,
@@ -563,7 +570,7 @@ describe('ProteusService', () => {
 
         const result = await proteusService.sendMessage({
           protocol: ConversationProtocol.PROTEUS,
-          conversationId: {id: 'conv1', domain: 'domain1'},
+          conversationId: generateQualifiedId('domain'),
           payload: message,
           targetMode: MessageTargetMode.USERS_CLIENTS,
           userIds: recipients,
@@ -586,12 +593,7 @@ describe('ProteusService', () => {
       },
     } satisfies Awaited<ReturnType<typeof ProteusService.prototype.addUsersToConversation>>;
 
-    const conversationId = {id: 'conv1', domain: 'domain1'};
-
-    const userDomain1 = {id: 'user-1-1', domain: 'domain1'};
-    const user2Domain1 = {id: 'user-2-1', domain: 'domain1'};
-    const userDomain2 = {id: 'user-1-2', domain: 'domain2'};
-    const userDomain3 = {id: 'user-1-3', domain: 'domain3'};
+    const conversationId = generateQualifiedId('domain');
 
     it('adds all requested users to an existing conversation', async () => {
       const [proteusService, {apiClient}] = await buildProteusService();
@@ -600,7 +602,7 @@ describe('ProteusService', () => {
 
       const event = await proteusService.addUsersToConversation({
         conversationId,
-        qualifiedUsers: [userDomain1, user2Domain1, userDomain2],
+        qualifiedUsers: [...usersDomain1, ...usersDomain2],
       });
 
       expect(event).toEqual(baseResponse);
@@ -611,25 +613,23 @@ describe('ProteusService', () => {
 
       const postMembersSpy = jest
         .spyOn(apiClient.api.conversation, 'postMembers')
-        .mockRejectedValueOnce(
-          new FederatedBackendsError(FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS, [userDomain1.domain]),
-        )
+        .mockRejectedValueOnce(new FederatedBackendsError(FederatedBackendsErrorLabel.UNREACHABLE_BACKENDS, [domain1]))
         .mockResolvedValueOnce(baseResponse.event);
 
       const result = await proteusService.addUsersToConversation({
         conversationId,
-        qualifiedUsers: [userDomain1, user2Domain1, userDomain2],
+        qualifiedUsers: [...usersDomain1, ...usersDomain2],
       });
 
       expect(postMembersSpy).toHaveBeenCalledTimes(2);
       expect(postMembersSpy).toHaveBeenCalledWith(
         conversationId,
-        expect.arrayContaining([userDomain1, user2Domain1, userDomain2]),
+        expect.arrayContaining([...usersDomain1, ...usersDomain2]),
       );
-      expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining([userDomain2]));
+      expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining(usersDomain2));
 
       expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.UNREACHABLE_BACKENDS);
-      expect(result.failedToAdd?.users).toEqual([userDomain1, user2Domain1]);
+      expect(result.failedToAdd?.users).toEqual([...usersDomain1]);
     });
 
     it('partially add users if some users are part of not-connected backends', async () => {
@@ -638,27 +638,24 @@ describe('ProteusService', () => {
       const postMembersSpy = jest
         .spyOn(apiClient.api.conversation, 'postMembers')
         .mockRejectedValueOnce(
-          new FederatedBackendsError(FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS, [
-            userDomain2.domain,
-            userDomain3.domain,
-          ]),
+          new FederatedBackendsError(FederatedBackendsErrorLabel.NON_FEDERATING_BACKENDS, [domain2, domain3]),
         )
         .mockResolvedValueOnce(baseResponse.event);
 
       const result = await proteusService.addUsersToConversation({
         conversationId,
-        qualifiedUsers: [userDomain1, user2Domain1, userDomain2, userDomain3],
+        qualifiedUsers: [...usersDomain1, ...usersDomain2, ...usersDomain3],
       });
 
       expect(postMembersSpy).toHaveBeenCalledTimes(2);
       expect(postMembersSpy).toHaveBeenCalledWith(
         conversationId,
-        expect.arrayContaining([userDomain1, user2Domain1, userDomain2]),
+        expect.arrayContaining([...usersDomain1, ...usersDomain2]),
       );
-      expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining([userDomain1, user2Domain1]));
+      expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining(usersDomain1));
 
       expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.NON_FEDERATING_BACKENDS);
-      expect(result.failedToAdd?.users).toEqual([userDomain2, userDomain3]);
+      expect(result.failedToAdd?.users).toEqual([...usersDomain2, ...usersDomain3]);
     });
   });
 
@@ -686,14 +683,6 @@ describe('ProteusService', () => {
       },
       protocol: ConversationProtocol.PROTEUS,
     };
-
-    const domain1 = 'domain1';
-    const domain2 = 'domain2';
-    const domain3 = 'domain3';
-
-    const usersDomain1 = generateQualifiedIds(3, domain1);
-    const usersDomain2 = generateQualifiedIds(3, domain2);
-    const usersDomain3 = generateQualifiedIds(3, domain3);
 
     it('adds all requested users to a new conversation', async () => {
       const [proteusService, {apiClient}] = await buildProteusService();

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -172,7 +172,9 @@ export class ProteusService {
     conversationData: NewConversation,
   ): Promise<{conversation: Conversation; failedToAdd?: CreateConversationFailureToAddUsers}> {
     try {
-      return {conversation: await this.apiClient.api.conversation.postConversation(conversationData)};
+     const conversation = await this.apiClient.api.conversation.postConversation(conversationData);
+     
+      return {conversation};
     } catch (error: unknown) {
       if (isFederatedBackendsError(error)) {
         switch (error.label) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -172,8 +172,8 @@ export class ProteusService {
     conversationData: NewConversation,
   ): Promise<{conversation: Conversation; failedToAdd?: CreateConversationFailureToAddUsers}> {
     try {
-     const conversation = await this.apiClient.api.conversation.postConversation(conversationData);
-     
+      const conversation = await this.apiClient.api.conversation.postConversation(conversationData);
+
       return {conversation};
     } catch (error: unknown) {
       if (isFederatedBackendsError(error)) {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -46,7 +46,13 @@ import type {
 import {migrateToQualifiedSessionIds} from './sessionIdMigrator';
 import {filterUsersFromDomains} from './userDomainFilters';
 
-import {AddUsersFailureReasons, GenericMessageType, MessageSendingState, SendResult} from '../../../conversation';
+import {
+  AddUsersFailure,
+  AddUsersFailureReasons,
+  GenericMessageType,
+  MessageSendingState,
+  SendResult,
+} from '../../../conversation';
 import {MessageService} from '../../../conversation/message/MessageService';
 import {NonFederatingBackendsError} from '../../../errors';
 import type {EventHandlerResult} from '../../common.types';
@@ -68,18 +74,6 @@ export type EncryptionResult = {
   unknowns?: QualifiedUserClients;
   /** users for whom we could retrieve a prekey and, thus, for which we could not encrypt the message */
   failed?: QualifiedId[];
-};
-
-/**
- * List of users that were originaly requested to be in the conversation
- * but could not be added due to their backend not being available
- * @note Added since version 4: https://staging-nginz-https.z
- ra.io/v4/api/swagger-ui/#/default/post_conversations
- * @note Federation only
- */
-type CreateConversationFailureToAddUsers = {
-  reason: AddUsersFailureReasons;
-  users: QualifiedId[];
 };
 
 export class ProteusService {
@@ -170,7 +164,7 @@ export class ProteusService {
 
   public async createConversation(
     conversationData: NewConversation,
-  ): Promise<{conversation: Conversation; failedToAdd?: CreateConversationFailureToAddUsers}> {
+  ): Promise<{conversation: Conversation; failedToAdd?: AddUsersFailure}> {
     try {
       const conversation = await this.apiClient.api.conversation.postConversation(conversationData);
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/WithMockedGenerics.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/WithMockedGenerics.test.ts
@@ -93,7 +93,7 @@ describe('createConversation', () => {
       const conversationData = createConversationResult as unknown as NewConversation;
       const returnData = await proteusService.createConversation(conversationData);
 
-      expect(returnData).toStrictEqual(createConversationResult);
+      expect(returnData.conversation).toStrictEqual(createConversationResult);
     });
 
     it('create a new conversation with no name', async () => {
@@ -101,7 +101,7 @@ describe('createConversation', () => {
       const conversationData = {users: ['user1', 'user2'], receipt_mode: null};
       const returnData = await proteusService.createConversation(conversationData);
 
-      expect(returnData).toStrictEqual(conversationData);
+      expect(returnData.conversation).toStrictEqual(conversationData);
     });
   });
 });

--- a/packages/core/src/testUtils/index.ts
+++ b/packages/core/src/testUtils/index.ts
@@ -1,0 +1,30 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {randomUUID} from 'crypto';
+
+export function generateQualifiedIds(nbUsers: number, domain: string) {
+  const users: QualifiedId[] = [];
+  for (let i = 0; i < nbUsers; i++) {
+    users.push({id: randomUUID(), domain});
+  }
+  return users;
+}

--- a/packages/core/src/testUtils/index.ts
+++ b/packages/core/src/testUtils/index.ts
@@ -21,10 +21,14 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {randomUUID} from 'crypto';
 
+export function generateQualifiedId(domain: string) {
+  return {id: randomUUID(), domain};
+}
+
 export function generateQualifiedIds(nbUsers: number, domain: string) {
   const users: QualifiedId[] = [];
   for (let i = 0; i < nbUsers; i++) {
-    users.push({id: randomUUID(), domain});
+    users.push(generateQualifiedId(domain));
   }
   return users;
 }


### PR DESCRIPTION
This will make sure all the methods that add users to a conversation return the same format.

```js
{
  failedToAdd: {reason: ..., users: ...}
  // method specific data
}
```