### PR TITLE
runfix(promise-queue): correct return type for interval

### DIFF
--- a/packages/promise-queue/src/PromiseQueue.ts
+++ b/packages/promise-queue/src/PromiseQueue.ts
@@ -29,7 +29,7 @@ const defaultOptions = {
 export class PromiseQueue {
   private blocked: boolean;
   private runningTasks: number;
-  private interval?: NodeJS.Timer;
+  private interval?: NodeJS.Timeout;
   private paused: boolean;
   private readonly concurrent: number;
   private readonly logger?: {warn: (...args: any[]) => void};


### PR DESCRIPTION
Changes the type of interval to the type that is returned from `setInterval` and expected by `clearInterval` methods. Should fix failing CI.