### PR TITLE
feat: mls decrypt error recovery [WPB-523]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -527,7 +527,7 @@ export class Account extends TypedEventEmitter<Events> {
 
     const handleMissedNotifications = async (notificationId: string) => {
       if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
-        await this.service?.conversation.handleEpochMismatch();
+        await this.service?.conversation.handleEpochMismatchOfMLSConversations();
       }
       return onMissedNotifications(notificationId);
     };

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -527,7 +527,7 @@ export class Account extends TypedEventEmitter<Events> {
 
     const handleMissedNotifications = async (notificationId: string) => {
       if (this.cryptoProtocolConfig?.mls && this.backendFeatures.supportsMLS) {
-        await this.service?.conversation.handleEpochMismatchOfMLSConversations();
+        await this.service?.conversation.handleConversationsEpochMismatch();
       }
       return onMissedNotifications(notificationId);
     };

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -197,7 +197,7 @@ describe('ConversationService', () => {
       jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(false);
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(localEpoch);
 
-      await conversationService.handleEpochMismatchOfMLSConversations();
+      await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
     });
@@ -214,7 +214,7 @@ describe('ConversationService', () => {
       jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(true);
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(2);
 
-      await conversationService.handleEpochMismatchOfMLSConversations();
+      await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
     });
@@ -232,7 +232,7 @@ describe('ConversationService', () => {
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
 
-      await conversationService.handleEpochMismatchOfMLSConversations();
+      await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -19,16 +19,29 @@
 
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client';
 import {Conversation, ConversationProtocol, MLSConversation} from '@wireapp/api-client/lib/conversation';
+import {CONVERSATION_EVENT, ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {APIClient} from '@wireapp/api-client';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {ConversationService, MessageSendingState} from '..';
 import {MLSService} from '../../messagingProtocols/mls';
+import {CoreCryptoMLSErrors} from '../../messagingProtocols/mls/MLSService/CoreCryptoMLSErrors';
 import {ProteusService} from '../../messagingProtocols/proteus';
 import * as MessagingProtocols from '../../messagingProtocols/proteus';
 import * as PayloadHelper from '../../test/PayloadHelper';
 import * as MessageBuilder from '../message/MessageBuilder';
+
+const createMLSMessageAddEventMock = (conversationId: QualifiedId): ConversationMLSMessageAddEvent => ({
+  data: '',
+  conversation: conversationId.id,
+  qualified_conversation: conversationId,
+  from: '',
+  senderClientId: '',
+  type: CONVERSATION_EVENT.MLS_MESSAGE_ADD,
+  time: '2023-08-21T06:47:43.387Z',
+});
 
 jest.mock('../../messagingProtocols/proteus', () => ({
   ...jest.requireActual('../../messagingProtocols/proteus'),
@@ -42,15 +55,6 @@ jest.mock('../message/messageSender', () => ({
   ...jest.requireActual('../message/messageSender'),
   sendMessage: jest.fn().mockImplementation(fn => fn()),
 }));
-
-const mockedMLSService = {
-  encryptMessage: () => {},
-  commitPendingProposals: () => Promise.resolve(),
-  getEpoch: () => Promise.resolve(),
-  joinByExternalCommit: jest.fn(),
-  registerConversation: jest.fn(),
-  wipeConversation: jest.fn(),
-} as unknown as MLSService;
 
 const mockedProteusService = {
   encryptGenericMessage: () => Promise.resolve(),
@@ -92,9 +96,21 @@ describe('ConversationService', () => {
       clientId: PayloadHelper.getUUID(),
     };
 
+    const mockedMLSService = {
+      encryptMessage: () => {},
+      commitPendingProposals: () => Promise.resolve(),
+      getEpoch: () => Promise.resolve(),
+      joinByExternalCommit: jest.fn(),
+      registerConversation: jest.fn(),
+      wipeConversation: jest.fn(),
+      handleMLSMessageAddEvent: jest.fn(),
+      conversationExists: jest.fn(),
+    } as unknown as MLSService;
+
     const conversationService = new ConversationService(client, mockedProteusService, mockedMLSService);
 
     jest.spyOn(conversationService, 'joinByExternalCommit');
+    jest.spyOn(conversationService, 'emit');
 
     return [conversationService, {apiClient: client, mlsService: mockedMLSService}] as const;
   }
@@ -210,6 +226,7 @@ describe('ConversationService', () => {
       jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(true);
 
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
 
       await conversationService.handleEpochMismatchOfMLSConversations();
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
@@ -279,6 +296,38 @@ describe('ConversationService', () => {
       expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], selfUser);
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.registerConversation).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('handleEvent', () => {
+    it('rejoins a MLS conversation if epoch mismatch detected when decrypting mls message', async () => {
+      const [conversationService, {apiClient, mlsService}] = buildConversationService();
+      const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
+      const mockGroupId = 'mock-group-id';
+
+      const mockMLSMessageAddEvent = createMLSMessageAddEventMock(conversationId);
+
+      jest
+        .spyOn(mlsService, 'handleMLSMessageAddEvent')
+        .mockRejectedValueOnce(new Error(CoreCryptoMLSErrors.WRONG_EPOCH));
+
+      const remoteEpoch = 5;
+      const localEpoch = 4;
+
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+
+      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
+        qualified_id: conversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
+      } as unknown as Conversation);
+
+      await conversationService.handleEvent(mockMLSMessageAddEvent);
+
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(conversationId);
+      expect(conversationService.emit).toHaveBeenCalledWith('MLSConversationRecovered', {conversationId});
     });
   });
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -177,7 +177,7 @@ describe('ConversationService', () => {
 
       jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(false);
 
-      await conversationService.handleEpochMismatch();
+      await conversationService.handleEpochMismatchOfMLSConversations();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
     });
@@ -194,7 +194,7 @@ describe('ConversationService', () => {
       jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(true);
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(2);
 
-      await conversationService.handleEpochMismatch();
+      await conversationService.handleEpochMismatchOfMLSConversations();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
     });
@@ -211,7 +211,7 @@ describe('ConversationService', () => {
 
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
 
-      await conversationService.handleEpochMismatch();
+      await conversationService.handleEpochMismatchOfMLSConversations();
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -183,15 +183,19 @@ describe('ConversationService', () => {
     };
 
     it('re-joins multiple not-established conversations', async () => {
-      const [conversationService, {apiClient}] = buildConversationService();
+      const [conversationService, {apiClient, mlsService}] = buildConversationService();
 
-      const mlsConversation1 = createConversation(1, 'conversation1');
-      const mlsConversation2 = createConversation(1, 'conversation2');
+      const remoteEpoch = 1;
+      const localEpoch = 0;
+
+      const mlsConversation1 = createConversation(remoteEpoch, 'conversation1');
+      const mlsConversation2 = createConversation(remoteEpoch, 'conversation2');
 
       const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
       jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(false);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(localEpoch);
 
       await conversationService.handleEpochMismatchOfMLSConversations();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -56,7 +56,6 @@ import {
 import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conversation/';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService, optionalToUint8Array} from '../../messagingProtocols/mls';
-import {handleMLSMessageAdd, handleMLSWelcomeMessage} from '../../messagingProtocols/mls/EventHandler/events';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
 import {
   AddUsersToProteusConversationParams,
@@ -489,11 +488,11 @@ export class ConversationService {
   };
 
   private async handleMLSMessageAddEvent(event: ConversationMLSMessageAddEvent) {
-    return handleMLSMessageAdd({event, mlsService: this.mlsService});
+    return this.mlsService.handleMLSMessageAddEvent(event);
   }
 
   private async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent) {
-    return handleMLSWelcomeMessage({event, mlsService: this.mlsService});
+    return this.mlsService.handleMLSWelcomeMessageEvent(event);
   }
 
   private async handleOtrMessageAddEvent(event: ConversationOtrMessageAddEvent) {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -455,8 +455,11 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const {qualified_id: qualifiedId, group_id: groupId, epoch} = remoteMlsConversation;
 
     try {
+      const isEstablished = await this.isMLSConversationEstablished(groupId);
+      const doesEpochMatch = await this.matchesEpoch(groupId, epoch);
+
       //if conversation is not established or epoch does not match -> try to rejoin
-      if (!(await this.isMLSConversationEstablished(groupId)) || !(await this.matchesEpoch(groupId, epoch))) {
+      if (!isEstablished || !doesEpochMatch) {
         this.logger.log(
           `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
         );

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -437,9 +437,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const mlsConversations = foundConversations.filter(isMLSConversation);
 
     //check all the established conversations' epoch with the core-crypto epoch
-    await Promise.allSettled(
-      mlsConversations.map(mlsConversation => this.handleConversationEpochMismatch(mlsConversation)),
-    );
+    await Promise.all(mlsConversations.map(mlsConversation => this.handleConversationEpochMismatch(mlsConversation)));
   }
 
   /**

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -427,7 +427,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return BigInt(localEpoch) === BigInt(backendEpoch);
   }
 
-  public async handleEpochMismatchOfMLSConversations() {
+  public async handleConversationsEpochMismatch() {
     this.logger.info(`There were some missed messages, handling possible epoch mismatch in MLS conversations.`);
 
     //fetch all the mls conversations from backend
@@ -438,7 +438,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
     //check all the established conversations' epoch with the core-crypto epoch
     await Promise.allSettled(
-      mlsConversations.map(mlsConversation => this.handleEpochMismatchOfMLSConversation(mlsConversation)),
+      mlsConversations.map(mlsConversation => this.handleConversationEpochMismatch(mlsConversation)),
     );
   }
 
@@ -448,7 +448,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * If the epochs do not match, it will try to rejoin the conversation via external commit.
    * @param mlsConversation - mls conversation
    */
-  private async handleEpochMismatchOfMLSConversation(
+  private async handleConversationEpochMismatch(
     remoteMlsConversation: MLSConversation,
     onSuccessfulRejoin?: () => void,
   ) {
@@ -538,7 +538,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
           throw new Error('Conversation is not an MLS conversation');
         }
 
-        await this.handleEpochMismatchOfMLSConversation(mlsConversation, () =>
+        await this.handleConversationEpochMismatch(mlsConversation, () =>
           this.emit('MLSConversationRecovered', {conversationId}),
         );
         return;

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -453,6 +453,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     onSuccessfulRejoin?: () => void,
   ) {
     const {qualified_id: qualifiedId, group_id: groupId, epoch} = remoteMlsConversation;
+
     try {
       //if conversation is not established or epoch does not match -> try to rejoin
       if (!(await this.isMLSConversationEstablished(groupId)) || !(await this.matchesEpoch(groupId, epoch))) {

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSErrors.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSErrors.ts
@@ -17,7 +17,7 @@
  *
  */
 
-enum CoreCryptoMLSErrors {
+export enum CoreCryptoMLSErrors {
   WRONG_EPOCH = 'Incoming message is for the wrong epoch',
 }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSErrors.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSErrors.ts
@@ -1,0 +1,26 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+enum CoreCryptoMLSErrors {
+  WRONG_EPOCH = 'Incoming message is for the wrong epoch',
+}
+
+export const isCoreCryptoMLSWrongEpochError = (error: unknown): boolean => {
+  return error instanceof Error && error.message === CoreCryptoMLSErrors.WRONG_EPOCH;
+};

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -20,6 +20,7 @@
 import type {ClaimedKeyPackages} from '@wireapp/api-client/lib/client';
 import {PostMlsMessageResponse, SUBCONVERSATION_ID} from '@wireapp/api-client/lib/conversation';
 import {Subconversation} from '@wireapp/api-client/lib/conversation/Subconversation';
+import {ConversationMLSMessageAddEvent, ConversationMLSWelcomeEvent} from '@wireapp/api-client/lib/event';
 import {BackendError, StatusCode} from '@wireapp/api-client/lib/http';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
@@ -55,6 +56,7 @@ import {constructFullyQualifiedClientId, parseFullQualifiedClientId} from '../..
 import {cancelRecurringTask, registerRecurringTask} from '../../../util/RecurringTaskScheduler';
 import {TaskScheduler} from '../../../util/TaskScheduler';
 import {TypedEventEmitter} from '../../../util/TypedEventEmitter';
+import {handleMLSMessageAdd, handleMLSWelcomeMessage} from '../EventHandler/events';
 import {CommitPendingProposalsParams, HandlePendingProposalsParams, MLSCallbacks} from '../types';
 
 //@todo: this function is temporary, we wait for the update from core-crypto side
@@ -730,5 +732,13 @@ export class MLSService extends TypedEventEmitter<Events> {
       return {userId: user, clientId: client, domain};
     });
     return clientIds;
+  }
+
+  public async handleMLSMessageAddEvent(event: ConversationMLSMessageAddEvent) {
+    return handleMLSMessageAdd({event, mlsService: this});
+  }
+
+  public async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent) {
+    return handleMLSWelcomeMessage({event, mlsService: this});
   }
 }

--- a/packages/core/src/messagingProtocols/mls/types.ts
+++ b/packages/core/src/messagingProtocols/mls/types.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {Conversation, ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CoreCryptoCallbacks} from '@wireapp/core-crypto';
@@ -84,9 +83,3 @@ export interface CryptoProtocolConfig {
   /** if set to true, will use experimental proteus encryption/decryption library (core-crypto). If not set will fallback to the legacy proteus library (cryptobox) */
   proteus?: boolean;
 }
-
-export type MLSConversation = Conversation & {
-  protocol: ConversationProtocol.MLS;
-  epoch: number;
-  group_id: string;
-};

--- a/packages/core/src/util/TypePredicateUtil.ts
+++ b/packages/core/src/util/TypePredicateUtil.ts
@@ -20,12 +20,11 @@
 import {
   Conversation,
   ConversationProtocol,
+  MLSConversation,
   QualifiedUserClients,
   UserClients,
 } from '@wireapp/api-client/lib/conversation/';
 import {QualifiedId} from '@wireapp/api-client/lib/user/';
-
-import {MLSConversation} from '../messagingProtocols/mls/types';
 
 export function isStringArray(obj: any): obj is string[] {
   return Array.isArray(obj) && (obj.length === 0 || typeof obj[0] === 'string');


### PR DESCRIPTION
Adds recovery mechanism to mls message decryption failure. 

When `corecrypto.decryptMessage` fails with "WrongEpoch" error, it means that the client got out of sync - missed some handshake messages - and is receiving messages from a new epoch it is not a member of. 

At this point we should fetch conversation from backend compare local epoch number with the epoch number on the remote conversation and if there's no match - rejoin conversation with external commit.

This PR also extends `ConversationService` with event emitter. `MLSConversationRecovered` event is emitted after client has successfully rejoined a group. Consumer should subscribe to this event and react to it by inserting a system message into the chat (this will be handled by the webapp)