### PR TITLE
runfix: decryption error generator

### DIFF
--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.test.ts
@@ -24,16 +24,16 @@ import {DecryptionError} from '../../../../errors/DecryptionError';
 const basePayload = {userId: {id: 'user1', domain: 'domain'}, clientId: 'client1'};
 
 describe('generateDecryptionError', () => {
-  it('handles coreCrypto error', () => {
-    const coreCryptoError = {proteusErrorCode: Math.floor(Math.random() * 100), message: 'decryption error'};
+  it.each([Math.floor(Math.random() * 100), 0])('handles coreCrypto error', proteusErrorCode => {
+    const coreCryptoError = {proteusErrorCode, message: 'decryption error'};
     const error = generateDecryptionError(basePayload, coreCryptoError);
     expect(error).toBeInstanceOf(DecryptionError);
     expect(error.message).toBe(`Decryption error from user1 (client1) (${coreCryptoError.message})`);
     expect(error.code).toBe(coreCryptoError.proteusErrorCode);
   });
 
-  it('handles cryptobox error', () => {
-    const coreCryptoError = {code: Math.floor(Math.random() * 100), message: 'decryption error'};
+  it.each([Math.floor(Math.random() * 100), 0])('handles cryptobox error', code => {
+    const coreCryptoError = {code, message: 'decryption error'};
     const error = generateDecryptionError(basePayload, coreCryptoError);
     expect(error).toBeInstanceOf(DecryptionError);
     expect(error.message).toBe(`Decryption error from user1 (client1) (${coreCryptoError.message})`);

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
@@ -41,27 +41,13 @@ const isCryptoboxError = (error: any): error is CryptoboxError => {
 };
 
 type SenderInfo = {clientId: string; userId: QualifiedId};
-
-const getErrorCode = (error: any): number => {
-  const coreCryptoCode = isCoreCryptoError(error) ? error.proteusErrorCode : null;
-  const cryptoboxCode = isCryptoboxError(error) ? error.code : null;
-
-  if (typeof coreCryptoCode === 'number') {
-    return coreCryptoCode;
-  }
-
-  if (typeof cryptoboxCode === 'number') {
-    return cryptoboxCode;
-  }
-
-  return ProteusErrors.Unknown;
-};
-
 export const generateDecryptionError = (senderInfo: SenderInfo, error: any): DecryptionError => {
   const {clientId, userId} = senderInfo;
   const sender = `${userId.id} (${clientId})`;
 
-  const code = getErrorCode(error);
+  const coreCryptoCode = isCoreCryptoError(error) ? error.proteusErrorCode : null;
+  const cryptoboxCode = isCryptoboxError(error) ? error.code : null;
+  const code = coreCryptoCode ?? cryptoboxCode ?? ProteusErrors.Unknown;
 
   const message = `Decryption error from ${sender} (${error.message})`;
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/DecryptionErrorGenerator/DecryptionErrorGenerator.ts
@@ -41,13 +41,27 @@ const isCryptoboxError = (error: any): error is CryptoboxError => {
 };
 
 type SenderInfo = {clientId: string; userId: QualifiedId};
+
+const getErrorCode = (error: any): number => {
+  const coreCryptoCode = isCoreCryptoError(error) ? error.proteusErrorCode : null;
+  const cryptoboxCode = isCryptoboxError(error) ? error.code : null;
+
+  if (typeof coreCryptoCode === 'number') {
+    return coreCryptoCode;
+  }
+
+  if (typeof cryptoboxCode === 'number') {
+    return cryptoboxCode;
+  }
+
+  return ProteusErrors.Unknown;
+};
+
 export const generateDecryptionError = (senderInfo: SenderInfo, error: any): DecryptionError => {
   const {clientId, userId} = senderInfo;
   const sender = `${userId.id} (${clientId})`;
 
-  const coreCryptoCode = isCoreCryptoError(error) && error.proteusErrorCode;
-  const cryptoboxCode = isCryptoboxError(error) && error.code;
-  const code = coreCryptoCode || cryptoboxCode || ProteusErrors.Unknown;
+  const code = getErrorCode(error);
 
   const message = `Decryption error from ${sender} (${error.message})`;
 


### PR DESCRIPTION
The logic would fail when we would have received 0 as `proteusErrorCode` or `code` when decryption error is handled. The reason behind it is simply 0 being a falsy value.

The fix is to simply check typeof the value to match `number`.