### PR TITLE
feat: stop leaking the MLS service to the outside world

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -125,9 +125,11 @@ export class Account extends TypedEventEmitter<Events> {
   private db?: CoreDatabase;
   private readonly nbPrekeys: number;
   private readonly cryptoProtocolConfig?: CryptoProtocolConfig;
+  private protectedServices?: {
+    mls?: MLSService;
+  };
 
   public service?: {
-    mls?: MLSService;
     proteus: ProteusService;
     account: AccountService;
     asset: AssetService;
@@ -262,11 +264,11 @@ export class Account extends TypedEventEmitter<Events> {
 
     const client = await this.service.client.register(loginData, clientInfo, initialPreKeys);
 
-    if (this.service.mls) {
+    if (this.protectedServices?.mls) {
       const {userId, domain = ''} = this.apiClient.context;
-      await this.service.mls.createClient({id: userId, domain}, client.id);
+      await this.protectedServices.mls.createClient({id: userId, domain}, client.id);
     }
-    this.logger.info(`Created new client {mls: ${!!this.service.mls}, id: ${client.id}}`);
+    this.logger.info(`Created new client {mls: ${!!this.protectedServices?.mls}, id: ${client.id}}`);
 
     await this.service.notification.initializeNotificationStream();
     await this.service.client.synchronizeClients(client.id);
@@ -295,20 +297,20 @@ export class Account extends TypedEventEmitter<Events> {
     await this.apiClient.transport.http.associateClientWithSession(validClient.id);
 
     await this.service.proteus.initClient(this.storeEngine, this.apiClient.context);
-    if (this.service.mls) {
+    if (this.protectedServices?.mls) {
       const {userId, domain = ''} = this.apiClient.context;
       if (!client) {
         // If the client has been passed to the method, it means it also has been initialized
-        await this.service.mls.initClient({id: userId, domain}, validClient.id);
+        await this.protectedServices.mls.initClient({id: userId, domain}, validClient.id);
       }
       // initialize schedulers for pending mls proposals once client is initialized
-      await this.service.mls.checkExistingPendingProposals();
+      await this.protectedServices.mls.checkExistingPendingProposals();
 
       // initialize scheduler for syncing key packages with backend
-      this.service.mls.checkForKeyPackagesBackendSync();
+      this.protectedServices.mls.checkForKeyPackagesBackendSync();
 
       // leave stale conference subconversations (e.g after a crash)
-      await this.service.mls.leaveStaleConferenceSubconversations();
+      await this.protectedServices.mls.leaveStaleConferenceSubconversations();
     }
 
     return validClient;
@@ -349,7 +351,7 @@ export class Account extends TypedEventEmitter<Events> {
    * @param mlsCallbacks
    */
   configureMLSCallbacks(mlsCallbacks: MLSCallbacks) {
-    this.service?.mls?.configureMLSCallbacks(mlsCallbacks);
+    this.protectedServices?.mls?.configureMLSCallbacks(mlsCallbacks);
   }
 
   public async initServices(context: Context): Promise<void> {
@@ -388,8 +390,11 @@ export class Account extends TypedEventEmitter<Events> {
     const broadcastService = new BroadcastService(this.apiClient, proteusService);
     const userService = new UserService(this.apiClient);
 
-    this.service = {
+    this.protectedServices = {
       mls: mlsService,
+    };
+
+    this.service = {
       proteus: proteusService,
       account: accountService,
       asset: assetService,


### PR DESCRIPTION
We are leaking many internal services from Account.ts to the outside world.

Long term, we want to get rid of all of them and leak the functions that the webapp absolutely needs to run, in a more descriptive way.

MLS is a low-hanging fruit since the webapp currently does not use it.
