### PR TITLE
fix: re-enable mls on api v4

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -246,7 +246,7 @@ export class APIClient extends EventEmitter {
       domain: responsePayload?.domain ?? '',
       federationEndpoints: backendVersion > 0,
       isFederated: responsePayload?.federation || false,
-      supportsMLS: backendVersion >= 5,
+      supportsMLS: backendVersion >= 4,
       supportsGuestLinksWithPassword: backendVersion >= 4,
     };
   }


### PR DESCRIPTION
#5416 was merged a little too early. Api v5 is not yet ready on backend. 
We need to revert for now in order to still be able to work on MLS before api v5 is out