### PR TITLE
feat: specify default ciphersuite

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import type {CommitBundle} from '@wireapp/core-crypto';
+import type {Ciphersuite, CommitBundle, CredentialType} from '@wireapp/core-crypto';
 
 export interface UploadCommitOptions {
   /**
@@ -34,4 +34,6 @@ export interface UploadCommitOptions {
 export interface MLSServiceConfig {
   keyingMaterialUpdateThreshold: number;
   nbKeyPackages: number;
+  defaultCiphersuite: Ciphersuite;
+  defaultCredentialType: CredentialType;
 }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
@@ -32,8 +32,20 @@ export interface UploadCommitOptions {
 }
 
 export interface MLSServiceConfig {
+  /**
+   * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
+   */
   keyingMaterialUpdateThreshold: number;
+  /**
+   * number of key packages client should upload to the server (100 by default)
+   */
   nbKeyPackages: number;
+  /**
+   * default ciphersuite to use for MLS (MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 1 by default)
+   */
   defaultCiphersuite: Ciphersuite;
+  /**
+   * default credential type to use for MLS (Basic = 1 by default)
+   */
   defaultCredentialType: CredentialType;
 }

--- a/packages/core/src/messagingProtocols/mls/types.ts
+++ b/packages/core/src/messagingProtocols/mls/types.ts
@@ -21,6 +21,8 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {CoreCryptoCallbacks} from '@wireapp/core-crypto';
 
+import {MLSServiceConfig} from './MLSService/MLSService.types';
+
 export type SecretCrypto =
   | {
       encrypt: (value: Uint8Array) => Promise<Uint8Array>;
@@ -73,12 +75,7 @@ export interface CryptoProtocolConfig {
   coreCrypoWasmFilePath: string;
 
   /** If set will create an MLS capable device from the current device */
-  mls?: {
-    /**
-     * (milliseconds) period of time between automatic updates of the keying material (30 days by default)
-     */
-    keyingMaterialUpdateThreshold?: number;
-  };
+  mls?: Partial<MLSServiceConfig>;
 
   /** if set to true, will use experimental proteus encryption/decryption library (core-crypto). If not set will fallback to the legacy proteus library (cryptobox) */
   proteus?: boolean;


### PR DESCRIPTION
Adds ability to specify `defaultCiphersuite` and `defaultCredentialType` to be specified by a consumer via MLSService config. 