### PR TITLE
runfix: check if 1:1 is already established before registering it

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -105,6 +105,7 @@ describe('ConversationService', () => {
       wipeConversation: jest.fn(),
       handleMLSMessageAddEvent: jest.fn(),
       conversationExists: jest.fn(),
+      isConversationEstablished: jest.fn(),
     } as unknown as MLSService;
 
     const conversationService = new ConversationService(client, mockedProteusService, mockedMLSService);
@@ -246,7 +247,6 @@ describe('ConversationService', () => {
       const otherUserId = {id: 'other-user-id', domain: 'staging.zinfra.io'};
 
       const remoteEpoch = 1;
-      const localEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
         qualified_id: mockConversationId,
@@ -254,8 +254,7 @@ describe('ConversationService', () => {
         epoch: remoteEpoch,
         group_id: mockGroupId,
       } as unknown as MLSConversation);
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(true);
 
       await conversationService.establishMLS1to1Conversation(mockGroupId, selfUser, otherUserId);
 
@@ -274,7 +273,6 @@ describe('ConversationService', () => {
       const otherUserId = {id: 'other-user-id', domain: 'staging.zinfra.io'};
 
       const remoteEpoch = 1;
-      const localEpoch = 0;
       const updatedEpoch = 2;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -292,8 +290,7 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as MLSConversation);
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+      jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(false);
       jest.spyOn(mlsService, 'joinByExternalCommit').mockResolvedValueOnce({events: [], time: ''});
 
       const establishedConversation = await conversationService.establishMLS1to1Conversation(
@@ -317,7 +314,6 @@ describe('ConversationService', () => {
       const otherUserId = {id: 'other-user-id', domain: 'staging.zinfra.io'};
 
       const remoteEpoch = 0;
-      const localEpoch = 0;
       const updatedEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -335,8 +331,6 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as MLSConversation);
 
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
       jest.spyOn(mlsService, 'wipeConversation');
 
       const establishedConversation = await conversationService.establishMLS1to1Conversation(
@@ -362,7 +356,6 @@ describe('ConversationService', () => {
       const otherUserId = {id: 'other-user-id', domain: 'staging.zinfra.io'};
 
       const remoteEpoch = 0;
-      const localEpoch = 0;
       const updatedEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -389,8 +382,6 @@ describe('ConversationService', () => {
       } as unknown as MLSConversation);
 
       jest.spyOn(mlsService, 'registerConversation').mockRejectedValueOnce(undefined);
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
       jest.spyOn(mlsService, 'wipeConversation');
 
       const establishedConversation = await conversationService.establishMLS1to1Conversation(

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -524,7 +524,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
       // If conversation is not established, we can wipe it and try to establish it again
       await this.wipeMLSConversation(groupId);
-      return this.establishMLS1to1Conversation(groupId, selfUser, otherUserId);
+      await this.mlsService.registerConversation(groupId, [otherUserId, selfUser.user], selfUser);
     }
   };
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -539,6 +539,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
     try {
       await this.mlsService.registerConversation(groupId, [otherUserId, selfUser.user], selfUser);
+      this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) established successfully.`);
+
       return this.apiClient.api.conversation.getMLS1to1Conversation(otherUserId);
     } catch (error) {
       this.logger.info(`Could not register MLS group with id ${groupId}: `, error);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -514,11 +514,10 @@ export class ConversationService extends TypedEventEmitter<Events> {
         `Conversation (id ${mlsConversation.qualified_id.id}) is already established on backend, checking the local epoch...`,
       );
 
-      const doesExistLocally = await this.isMLSConversationEstablished(groupId);
-      const localEpoch = doesExistLocally ? await this.mlsService.getEpoch(groupId) : -1;
+      const isMLSGroupEstablishedLocally = await this.isMLSGroupEstablishedLocally(groupId);
 
       // If group is already established locally, there's nothing more to do
-      if (localEpoch > 0) {
+      if (isMLSGroupEstablishedLocally) {
         this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) is already established locally.`);
         return mlsConversation;
       }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -500,44 +500,57 @@ export class ConversationService extends TypedEventEmitter<Events> {
     groupId: string,
     selfUser: {user: QualifiedId; client: string},
     otherUserId: QualifiedId,
-  ): Promise<void> => {
+    shouldRetry = true,
+  ): Promise<MLSConversation> => {
+    this.logger.info(`Trying to establish a MLS 1:1 conversation with user ${otherUserId.id}...`);
+
+    // Before trying to register a group, check if the group is already established o backend.
+    // If remote epoch is higher than 0, it means that the group was already established.
+    // It's possible that we've already received a welcome message.
+    const mlsConversation = await this.apiClient.api.conversation.getMLS1to1Conversation(otherUserId);
+
+    if (mlsConversation.epoch > 0) {
+      this.logger.info(
+        `Conversation (id ${mlsConversation.qualified_id.id}) is already established on backend, checking the local epoch...`,
+      );
+
+      const doesExistLocally = await this.isMLSConversationEstablished(groupId);
+      const localEpoch = doesExistLocally ? await this.mlsService.getEpoch(groupId) : -1;
+
+      // If group is already established locally, there's nothing more to do
+      if (localEpoch > 0) {
+        this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) is already established locally.`);
+        return mlsConversation;
+      }
+
+      // If local epoch is 0 it means that we've not received a welcome message
+      // We try joining via external commit.
+      this.logger.info(
+        `Conversation (id ${mlsConversation.qualified_id.id}) is not yet established locally, joining via external commit...`,
+      );
+
+      await this.joinByExternalCommit(mlsConversation.qualified_id);
+      return this.apiClient.api.conversation.getMLS1to1Conversation(otherUserId);
+    }
+
+    // If group is not established on backend,
+    // we wipe the it locally (in case it exsits in the local store) and try to register it.
+    await this.mlsService.wipeConversation(groupId);
+
     try {
       await this.mlsService.registerConversation(groupId, [otherUserId, selfUser.user], selfUser);
+      return this.apiClient.api.conversation.getMLS1to1Conversation(otherUserId);
     } catch (error) {
-      this.logger.info(`Could not register MLS group with id ${groupId}.`);
+      this.logger.info(`Could not register MLS group with id ${groupId}: `, error);
 
-      const mlsConversation = await this.apiClient.api.conversation.getMLS1to1Conversation(otherUserId);
-
-      if (mlsConversation.epoch > 0) {
-        this.logger.info(
-          `Conversation (id ${mlsConversation.qualified_id.id}) is already established on backend, checking the local epoch...`,
-        );
-
-        // If its already established, on backend, we check the local epoch,
-        // it's possible that we've received a welcome message in the meantime
-        const isEstablished = await this.isMLSConversationEstablished(groupId);
-        const localEpoch = isEstablished ? await this.mlsService.getEpoch(groupId) : -1;
-        if (localEpoch > 0) {
-          this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) is already established locally.`);
-          return;
-        }
-
-        // If local epoch is 0 it means that we've not received a welcome message
-        // We try joining via external commit.
-        this.logger.info(
-          `Conversation (id ${mlsConversation.qualified_id.id}) is not yet established, joining via external commit...`,
-        );
-        await this.joinByExternalCommit(mlsConversation.qualified_id);
-        return;
+      if (!shouldRetry) {
+        throw error;
       }
 
       this.logger.info(
         `Conversation (id ${mlsConversation.qualified_id.id}) is not established, retrying to establish it`,
       );
-
-      // If conversation is not established, we can wipe it and try to establish it again
-      await this.wipeMLSConversation(groupId);
-      await this.mlsService.registerConversation(groupId, [otherUserId, selfUser.user], selfUser);
+      return this.establishMLS1to1Conversation(groupId, selfUser, otherUserId, false);
     }
   };
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -514,8 +514,9 @@ export class ConversationService extends TypedEventEmitter<Events> {
         );
 
         // If its already established, on backend, we check the local epoch,
-        // it's possible that we've received a welcome message already
-        const localEpoch = await this.mlsService.getEpoch(groupId);
+        // it's possible that we've received a welcome message in the meantime
+        const isEstablished = await this.isMLSConversationEstablished(groupId);
+        const localEpoch = isEstablished ? await this.mlsService.getEpoch(groupId) : -1;
         if (localEpoch > 0) {
           this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) is already established locally.`);
           return;


### PR DESCRIPTION
This will make a method for establishing mls 1:1 conversation check if the group is already established first before trying to register it. Since both users are very likely to do this operation at the same time, only one of them will register the group successfully, other user will either receive a welcome message or join with an external commit.

Example: 
- User A sends a connection request to user B.
- B accepts a connection
- Users `A` and `B` are being sent an event about connection being accepted
- They both try to establish MLS group at at this point, a "race" begins
- Only one of them will successfully establish MLS group, the other one will receive an error from backend when trying to upload a commit bundle to backend (`"group was already established!"`)
- User that has won the "race" will do nothing as it has created the conversation
- User that has lost, will fetch the conversation from backend and check the epoch number
   - if epoch === 0 it will wipe local mls group and retry registering a group
   - if epoch is more than 0 (probably 1) it means that the group was already established -> we check local epoch number and either:
        a)do nothing as we have received a welcome message already, or
        b)need to join with external commit