### PR TITLE
refactor: mls conversation exists

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -193,7 +193,7 @@ describe('ConversationService', () => {
       const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
-      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(false);
+      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValue(false);
 
       await conversationService.handleConversationsEpochMismatch();
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
@@ -209,7 +209,7 @@ describe('ConversationService', () => {
       const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
-      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValue(true);
+      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValue(true);
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(2);
 
       await conversationService.handleConversationsEpochMismatch();
@@ -225,7 +225,7 @@ describe('ConversationService', () => {
       const mockedDBResponse: Conversation[] = [mlsConversation];
       jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
 
-      jest.spyOn(conversationService, 'isMLSConversationEstablished').mockResolvedValueOnce(true);
+      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValueOnce(true);
 
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -407,8 +407,21 @@ export class ConversationService extends TypedEventEmitter<Events> {
     });
   }
 
-  public async isMLSConversationEstablished(groupId: string) {
+  /**
+   * Will check if mls group exists locally.
+   * @param groupId groupId of the conversation
+   */
+  public async mlsGroupExistsLocally(groupId: string) {
     return this.mlsService.conversationExists(groupId);
+  }
+
+  /**
+   * Will check if mls group is established locally.
+   * Group is established after the first commit was sent in the group and epoch number is at least 1.
+   * @param groupId groupId of the conversation
+   */
+  public async isMLSGroupEstablishedLocally(groupId: string) {
+    return this.mlsService.isConversationEstablished(groupId);
   }
 
   public async wipeMLSConversation(groupId: string): Promise<void> {
@@ -453,7 +466,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const {qualified_id: qualifiedId, group_id: groupId, epoch} = remoteMlsConversation;
 
     try {
-      const isEstablished = await this.isMLSConversationEstablished(groupId);
+      const isEstablished = await this.mlsGroupExistsLocally(groupId);
       const doesEpochMatch = isEstablished && (await this.matchesEpoch(groupId, epoch));
 
       //if conversation is not established or epoch does not match -> try to rejoin

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -91,4 +91,44 @@ describe('MLSService', () => {
       expect(mlsService.cancelKeyMaterialRenewal).toHaveBeenCalledWith(groupId);
     });
   });
+
+  describe('isConversationEstablished', () => {
+    it('returns false if conversation does not exist locally', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm3OQFc=';
+
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
+
+      const isEstablshed = await mlsService.isConversationEstablished(groupId);
+
+      expect(isEstablshed).toBe(false);
+    });
+
+    it('returns false if epoch number is 0', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm3OQFc=';
+
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(0);
+
+      const isEstablshed = await mlsService.isConversationEstablished(groupId);
+
+      expect(isEstablshed).toBe(false);
+    });
+
+    it.each([1, 2, 100])('returns false if epoch number is 1 or more', async epoch => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const groupId = 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm3OQFc=';
+
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(epoch);
+
+      const isEstablshed = await mlsService.isConversationEstablished(groupId);
+
+      expect(isEstablshed).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -493,9 +493,23 @@ export class MLSService extends TypedEventEmitter<Events> {
     return commitBundle ? void (await this.uploadCommitBundle(groupId, commitBundle)) : undefined;
   }
 
+  /**
+   * Will check if mls group exists in corecrypto.
+   * @param groupId groupId of the conversation
+   */
   public async conversationExists(groupId: string): Promise<boolean> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
     return this.coreCryptoClient.conversationExists(groupIdBytes);
+  }
+
+  /**
+   * Will check if mls group is established in coreCrypto.
+   * Group is established after the first commit was sent in the group and epoch number is at least 1.
+   * @param groupId groupId of the conversation
+   */
+  public async isConversationEstablished(groupId: string): Promise<boolean> {
+    const doesConversationExist = await this.conversationExists(groupId);
+    return doesConversationExist && (await this.getEpoch(groupId)) > 0;
   }
 
   public async clientValidKeypackagesCount(): Promise<number> {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -647,8 +647,8 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   public async wipeConversation(groupId: string): Promise<void> {
-    const isMLSConversationEstablished = await this.conversationExists(groupId);
-    if (!isMLSConversationEstablished) {
+    const doesConversationExists = await this.conversationExists(groupId);
+    if (!doesConversationExists) {
       //if the mls group does not exist, we don't need to wipe it
       return;
     }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -647,8 +647,8 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   public async wipeConversation(groupId: string): Promise<void> {
-    const doesConversationExists = await this.conversationExists(groupId);
-    if (!doesConversationExists) {
+    const doesConversationExist = await this.conversationExists(groupId);
+    if (!doesConversationExist) {
       //if the mls group does not exist, we don't need to wipe it
       return;
     }


### PR DESCRIPTION
Splits the concerns of mls group just existing and being established:
- Group exists if `coreCrypto.conversationExists` returns true, the epoch number doesn't matter, could be `0` (initial number after group creation) or more (after some users were added or just key material was updated).
- We say that the group is established when it exists (see point above) and epoch number is at least 1 - it means that at least one commit was sent in the group. There's a new method that checks that on `MLSService`: `mlsService.isConversationEstablished`.

If group is established (epoch number is at least `1`) we know that backend is aware of this group since the commit bundle needed to be successfully uploaded, processed by backend and accepted by one of the members. If group only exists (with epoch `0`) it's possible that backend does not know about such a group.

A check for mls group being already established will for example help in establishing 1:1 conversation to decide whether we should register a conversation or we should join it with external commit as it was already established by somebody else.