### PR TITLE
runfix: do not use number of prekeys for number of mls key packages

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -366,7 +366,6 @@ export class Account extends TypedEventEmitter<Events> {
       clientType === CryptoClientType.CORE_CRYPTO && enableMLS
         ? new MLSService(this.apiClient, cryptoClient.getNativeClient(), {
             ...this.cryptoProtocolConfig?.mls,
-            nbKeyPackages: this.nbPrekeys,
           })
         : undefined;
 


### PR DESCRIPTION
We were mistakenly using `nbPrekeys` (for proteus prekeys) variable to config `nbKeyPackages` (for mls key packages).
`nbKeyPackages` is set to 100 by default and can be configured by a consumer (webapp) via `cryptoProtocolConfig.mls` object.