### PR TITLE
fix: Finalize backend api v4

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -246,7 +246,7 @@ export class APIClient extends EventEmitter {
       domain: responsePayload?.domain ?? '',
       federationEndpoints: backendVersion > 0,
       isFederated: responsePayload?.federation || false,
-      supportsMLS: backendVersion >= 4,
+      supportsMLS: backendVersion >= 5,
       supportsGuestLinksWithPassword: backendVersion >= 4,
     };
   }


### PR DESCRIPTION
This will make sure only to enable MLS only if backend api is v5