### PR TITLE
fix: Add the qualified conversation ID to last read messages

### DIFF
--- a/packages/core/src/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/conversation/message/MessageBuilder.ts
@@ -200,6 +200,7 @@ export function buildLastReadMessage(conversationId: QualifiedId, lastReadTimest
   const lastRead = new LastRead({
     conversationId: conversationId.id,
     lastReadTimestamp,
+    qualifiedConversationId: conversationId,
   });
 
   return GenericMessage.create({


### PR DESCRIPTION
This will make sure that the `lastRead` event we send to sync current user's devices will contain qualified information about the conversation being updated