### PR TITLE
runfix: upload kp after upgrade to mls device

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -264,7 +264,7 @@ export class Account extends TypedEventEmitter<Events> {
 
     if (this.service.mls) {
       const {userId, domain = ''} = this.apiClient.context;
-      await this.service.mls.createClient({id: userId, domain}, client.id);
+      await this.service.mls.initClient({id: userId, domain}, client.id);
     }
     this.logger.info(`Created new client {mls: ${!!this.service.mls}, id: ${client.id}}`);
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -264,7 +264,7 @@ export class Account extends TypedEventEmitter<Events> {
 
     if (this.service.mls) {
       const {userId, domain = ''} = this.apiClient.context;
-      await this.service.mls.initClient({id: userId, domain}, client.id);
+      await this.service.mls.initClient({id: userId, domain}, client);
     }
     this.logger.info(`Created new client {mls: ${!!this.service.mls}, id: ${client.id}}`);
 
@@ -299,7 +299,7 @@ export class Account extends TypedEventEmitter<Events> {
       const {userId, domain = ''} = this.apiClient.context;
       if (!client) {
         // If the client has been passed to the method, it means it also has been initialized
-        await this.service.mls.initClient({id: userId, domain}, validClient.id);
+        await this.service.mls.initClient({id: userId, domain}, validClient);
       }
       // initialize schedulers for pending mls proposals once client is initialized
       await this.service.mls.checkExistingPendingProposals();

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -144,19 +144,17 @@ describe('MLSService', () => {
 
       const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
       const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {}, id: mockClientId} as unknown as RegisteredClient;
 
       apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
 
       const mockedClientPublicKey = new Uint8Array();
 
-      jest
-        .spyOn(apiClient.api.client, 'getClient')
-        .mockResolvedValueOnce({mls_public_keys: {}} as unknown as RegisteredClient);
       jest.spyOn(mockCoreCrypto, 'clientPublicKey').mockResolvedValueOnce(mockedClientPublicKey);
       jest.spyOn(apiClient.api.client, 'putClient').mockResolvedValueOnce(undefined);
       jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
 
-      await mlsService.initClient(mockUserId, mockClientId);
+      await mlsService.initClient(mockUserId, mockClient);
 
       expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
       expect(apiClient.api.client.putClient).toHaveBeenCalledWith(mockClientId, expect.anything());
@@ -167,22 +165,18 @@ describe('MLSService', () => {
 
       const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
       const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {ed25519: 'key'}, id: mockClientId} as unknown as RegisteredClient;
 
       apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
 
       const mockedClientKeyPackages = [new Uint8Array()];
-
-      jest
-        .spyOn(apiClient.api.client, 'getClient')
-        .mockResolvedValueOnce({mls_public_keys: {ed25519: 'key'}} as unknown as RegisteredClient);
-
       jest.spyOn(mockCoreCrypto, 'clientKeypackages').mockResolvedValueOnce(mockedClientKeyPackages);
       jest
         .spyOn(apiClient.api.client, 'getMLSKeyPackageCount')
         .mockResolvedValueOnce(mlsService.config.minRequiredNumberOfAvailableKeyPackages - 1);
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
 
-      await mlsService.initClient(mockUserId, mockClientId);
+      await mlsService.initClient(mockUserId, mockClient);
 
       expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
       expect(apiClient.api.client.uploadMLSKeyPackages).toHaveBeenCalledWith(mockClientId, expect.anything());
@@ -193,16 +187,15 @@ describe('MLSService', () => {
 
       const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
       const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {ed25519: 'key'}, id: mockClientId} as unknown as RegisteredClient;
 
       apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
 
-      jest
-        .spyOn(apiClient.api.client, 'getClient')
-        .mockResolvedValueOnce({mls_public_keys: {ed25519: 'key'}} as unknown as RegisteredClient);
+      jest.spyOn(apiClient.api.client, 'getClient').mockResolvedValueOnce(mockClient);
 
       jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
 
-      await mlsService.initClient(mockUserId, mockClientId);
+      await mlsService.initClient(mockUserId, mockClient);
 
       expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
       expect(apiClient.api.client.uploadMLSKeyPackages).not.toHaveBeenCalled();

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {ClientType, RegisteredClient} from '@wireapp/api-client/lib/client';
+
 import {randomUUID} from 'crypto';
 
 import {APIClient} from '@wireapp/api-client';
@@ -36,6 +38,10 @@ describe('MLSService', () => {
     createConversation: jest.fn(),
     conversationExists: jest.fn(),
     wipeConversation: jest.fn(),
+    clientValidKeypackagesCount: jest.fn(),
+    clientKeypackages: jest.fn(),
+    mlsInit: jest.fn(),
+    clientPublicKey: jest.fn(),
   } as unknown as CoreCrypto;
 
   describe('registerConversation', () => {
@@ -129,6 +135,78 @@ describe('MLSService', () => {
       const isEstablshed = await mlsService.isConversationEstablished(groupId);
 
       expect(isEstablshed).toBe(true);
+    });
+  });
+
+  describe('initClient', () => {
+    it('uploads public key only if it was not yet defined on client entity', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
+      const mockClientId = 'client-1';
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientPublicKey = new Uint8Array();
+
+      jest
+        .spyOn(apiClient.api.client, 'getClient')
+        .mockResolvedValueOnce({mls_public_keys: {}} as unknown as RegisteredClient);
+      jest.spyOn(mockCoreCrypto, 'clientPublicKey').mockResolvedValueOnce(mockedClientPublicKey);
+      jest.spyOn(apiClient.api.client, 'putClient').mockResolvedValueOnce(undefined);
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
+
+      await mlsService.initClient(mockUserId, mockClientId);
+
+      expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
+      expect(apiClient.api.client.putClient).toHaveBeenCalledWith(mockClientId, expect.anything());
+    });
+
+    it('uploads key packages if there are not enough keys on backend', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
+      const mockClientId = 'client-1';
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientKeyPackages = [new Uint8Array()];
+
+      jest
+        .spyOn(apiClient.api.client, 'getClient')
+        .mockResolvedValueOnce({mls_public_keys: {ed25519: 'key'}} as unknown as RegisteredClient);
+
+      jest.spyOn(mockCoreCrypto, 'clientKeypackages').mockResolvedValueOnce(mockedClientKeyPackages);
+      jest
+        .spyOn(apiClient.api.client, 'getMLSKeyPackageCount')
+        .mockResolvedValueOnce(mlsService.config.minRequiredNumberOfAvailableKeyPackages - 1);
+      jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
+
+      await mlsService.initClient(mockUserId, mockClientId);
+
+      expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
+      expect(apiClient.api.client.uploadMLSKeyPackages).toHaveBeenCalledWith(mockClientId, expect.anything());
+    });
+
+    it('does not upload public key or key packages if both are already uploaded', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
+      const mockClientId = 'client-1';
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      jest
+        .spyOn(apiClient.api.client, 'getClient')
+        .mockResolvedValueOnce({mls_public_keys: {ed25519: 'key'}} as unknown as RegisteredClient);
+
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
+
+      await mlsService.initClient(mockUserId, mockClientId);
+
+      expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
+      expect(apiClient.api.client.uploadMLSKeyPackages).not.toHaveBeenCalled();
+      expect(apiClient.api.client.putClient).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -618,7 +618,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   /**
-   * Will update current client on backend with its public key.
+   * Will update the given client on backend with its public key.
    *
    * @param mlsClient Intance of the coreCrypto that represents the mls client
    * @param clientId The id of the client

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -117,11 +117,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     await this.initClient(userId, clientId);
     // If the device is new, we need to upload keypackages and public key to the backend
     const publicKey = await this.coreCryptoClient.clientPublicKey(this.config.defaultCiphersuite);
-    const keyPackages = await this.coreCryptoClient.clientKeypackages(
-      this.config.defaultCiphersuite,
-      this.config.defaultCredentialType,
-      this.config.nbKeyPackages,
-    );
+    const keyPackages = await this.clientKeypackages(this.config.nbKeyPackages);
     await this.uploadMLSPublicKeys(publicKey, clientId);
     await this.uploadMLSKeyPackages(keyPackages, clientId);
   }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -626,6 +626,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   private async uploadMLSPublicKeys(clientId: string) {
     const existingPublicKey = await this.apiClient.api.client.getClient(clientId);
 
+    // If we've already updated a client with its public key, there's no need to do it again.
     if (existingPublicKey.mls_public_keys?.ed25519) {
       return;
     }
@@ -639,6 +640,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   private async uploadMLSKeyPackages(clientId: string) {
     const backendKeyPackagesCount = await this.getRemoteMLSKeyPackageCount(clientId);
 
+    // If we have enough keys uploaded on backend, there's no need to upload more.
     if (backendKeyPackagesCount > this.config.minRequiredNumberOfAvailableKeyPackages) {
       return;
     }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -125,10 +125,6 @@ export class MLSService extends TypedEventEmitter<Events> {
     await this.uploadMLSKeyPackages(clientId);
   }
 
-  public async createClient(userId: QualifiedId, clientId: string) {
-    await this.initClient(userId, clientId);
-  }
-
   private async uploadCommitBundle(
     groupId: Uint8Array,
     commitBundle: CommitBundle,


### PR DESCRIPTION
### Problem
It can happen that the client the user is using was using only proteus initially, and later after MLS feature was enabled, it has upgraded to mls (by calling `CoreCrypto.mlsInit`). 

Previous flow of registering/initialising mls client goes as follows:
- check if corecrypto client exists (doesn't matter if it support mls already or not)
    - if it exists, call mlsService.initClient()
    - if it does not exist, call mlsService.registerClient()

Only `.registerClient()` method included uploading a public key and key packages to backend. When client did already exist previously, but mls client was not yet created, we were calling only `.mlsInit()` without uploading key packages / public key to backend. Such client ended up being mls device without any key packages uploaded to backend, therefore other clients (users) were not able to send a welcome message to this client.

---

### Solution
Now `.initClient()` method contain the logic of uploading key packages and updating a client entity with public key. Since we initialise the client every time webapp is reloaded, there's now check included before uploads, whether the client has not previously uploaded public key already and if it has enough available key packages uploaded to backend.

So every time we initialise mls client:
- public key will get uploaded, but **only if it was not uploaded previously**
- key packages will get uploaded, but only if the number of uploaded key packages is below minimum required number, which is now set to half of the `nbKeyPackages` value in mls service config.