### PR TITLE
feat(api-client): BE error label for mls stale message

### DIFF
--- a/packages/api-client/src/http/BackendErrorLabel.ts
+++ b/packages/api-client/src/http/BackendErrorLabel.ts
@@ -68,6 +68,7 @@ export enum BackendErrorLabel {
   NO_CONVERSATION_CODE = 'no-conversation-code',
   NOT_CONNECTED = 'not-connected',
   INVALID_CONVERSATION_PASSWORD = 'invalid-conversation-password',
+  MLS_STALE_MESSAGE = 'mls-stale-message',
 
   // Handle errors
   HANDLE_EXISTS = 'handle-exists',


### PR DESCRIPTION
Adds error label for mls stale message.