### PR TITLE
feat: recover from mls stale message error

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -161,6 +161,7 @@ describe('ConversationService', () => {
           protocol: ConversationProtocol.MLS,
           groupId,
           payload: message,
+          conversationId: {id: '', domain: ''},
         });
 
         const result = await promise;

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -157,7 +157,7 @@ describe('ConversationService', () => {
       {type: 'image', message: MessageBuilder.buildImageMessage(generateImage())},
     ];
     messages.forEach(({type, message}) => {
-      it.skip(`calls callbacks when sending '${type}' message is starting and successful`, async () => {
+      it(`calls callbacks when sending '${type}' message is starting and successful`, async () => {
         const [conversationService] = buildConversationService();
         const promise = conversationService.send({
           protocol: ConversationProtocol.MLS,

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -37,8 +37,7 @@ import {
   ConversationMemberLeaveEvent,
   ConversationOtrMessageAddEvent,
 } from '@wireapp/api-client/lib/event';
-import {BackendError} from '@wireapp/api-client/lib/http';
-import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
+import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {XOR} from '@wireapp/commons/lib/util/TypeUtil';
 import {Decoder} from 'bazinga64';

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -37,6 +37,8 @@ import {
   ConversationMemberLeaveEvent,
   ConversationOtrMessageAddEvent,
 } from '@wireapp/api-client/lib/event';
+import {BackendError} from '@wireapp/api-client/lib/http';
+import {BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {XOR} from '@wireapp/commons/lib/util/TypeUtil';
 import {Decoder} from 'bazinga64';
@@ -290,7 +292,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
     };
   }
 
-  private async sendMLSMessage({payload, groupId}: SendMlsMessageParams): Promise<SendResult> {
+  private async sendMLSMessage(params: SendMlsMessageParams): Promise<SendResult> {
+    const {payload, groupId, conversationId} = params;
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     // immediately execute pending commits before sending the message
@@ -304,6 +307,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
       response = await this.apiClient.api.conversation.postMlsMessage(encrypted);
       sentAt = response.time?.length > 0 ? response.time : new Date().toISOString();
     } catch (error) {
+      const isMLSStaleMessageError =
+        error instanceof BackendError && error.label === BackendErrorLabel.MLS_STALE_MESSAGE;
+      if (isMLSStaleMessageError) {
+        await this.recoverMLSConversationFromEpochMismatch(conversationId);
+        return this.sendMLSMessage(params);
+      }
       throw error;
     }
 
@@ -570,19 +579,23 @@ export class ConversationService extends TypedEventEmitter<Events> {
           throw new Error('Qualified conversation id is missing in the event');
         }
 
-        const mlsConversation = await this.apiClient.api.conversation.getConversation(conversationId);
-
-        if (!isMLSConversation(mlsConversation)) {
-          throw new Error('Conversation is not an MLS conversation');
-        }
-
-        await this.handleConversationEpochMismatch(mlsConversation, () =>
-          this.emit('MLSConversationRecovered', {conversationId}),
-        );
+        await this.recoverMLSConversationFromEpochMismatch(conversationId);
         return;
       }
       throw error;
     }
+  }
+
+  private async recoverMLSConversationFromEpochMismatch(conversationId: QualifiedId) {
+    const mlsConversation = await this.apiClient.api.conversation.getConversation(conversationId);
+
+    if (!isMLSConversation(mlsConversation)) {
+      throw new Error('Conversation is not an MLS conversation');
+    }
+
+    return this.handleConversationEpochMismatch(mlsConversation, () =>
+      this.emit('MLSConversationRecovered', {conversationId: mlsConversation.qualified_id}),
+    );
   }
 
   private async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent) {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -582,7 +582,6 @@ export class ConversationService extends TypedEventEmitter<Events> {
         }
 
         await this.recoverMLSConversationFromEpochMismatch(conversationId);
-        return;
       }
       throw error;
     }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -582,6 +582,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         }
 
         await this.recoverMLSConversationFromEpochMismatch(conversationId);
+        return undefined;
       }
       throw error;
     }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -292,7 +292,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     };
   }
 
-  private async sendMLSMessage(params: SendMlsMessageParams): Promise<SendResult> {
+  private async sendMLSMessage(params: SendMlsMessageParams, shouldRetry = true): Promise<SendResult> {
     const {payload, groupId, conversationId} = params;
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
@@ -311,7 +311,11 @@ export class ConversationService extends TypedEventEmitter<Events> {
         error instanceof BackendError && error.label === BackendErrorLabel.MLS_STALE_MESSAGE;
       if (isMLSStaleMessageError) {
         await this.recoverMLSConversationFromEpochMismatch(conversationId);
+        if (shouldRetry) {
+          return this.sendMLSMessage(params, false);
+        }
       }
+
       throw error;
     }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -566,9 +566,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     }
   };
 
-  private async handleMLSMessageAddEvent(
-    event: ConversationMLSMessageAddEvent,
-  ): Promise<HandledEventPayload | undefined> {
+  private async handleMLSMessageAddEvent(event: ConversationMLSMessageAddEvent): Promise<HandledEventPayload | null> {
     try {
       return await this.mlsService.handleMLSMessageAddEvent(event);
     } catch (error) {
@@ -582,7 +580,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         }
 
         await this.recoverMLSConversationFromEpochMismatch(conversationId);
-        return undefined;
+        return null;
       }
       throw error;
     }
@@ -608,7 +606,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return this.proteusService.handleOtrMessageAddEvent(event);
   }
 
-  public async handleEvent(event: BackendEvent): Promise<HandledEventPayload | undefined> {
+  public async handleEvent(event: BackendEvent): Promise<HandledEventPayload | null> {
     switch (event.type) {
       case CONVERSATION_EVENT.MLS_MESSAGE_ADD:
         return this.handleMLSMessageAddEvent(event);
@@ -618,6 +616,6 @@ export class ConversationService extends TypedEventEmitter<Events> {
         return this.handleOtrMessageAddEvent(event);
     }
 
-    return undefined;
+    return null;
   }
 }

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -311,7 +311,6 @@ export class ConversationService extends TypedEventEmitter<Events> {
         error instanceof BackendError && error.label === BackendErrorLabel.MLS_STALE_MESSAGE;
       if (isMLSStaleMessageError) {
         await this.recoverMLSConversationFromEpochMismatch(conversationId);
-        return this.sendMLSMessage(params);
       }
       throw error;
     }

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -90,6 +90,7 @@ export type ProtocolParam = {
  */
 export type SendCommonParams = ProtocolParam & {
   payload: GenericMessage;
+  conversationId: QualifiedId;
 };
 
 export type SendMlsMessageParams = SendCommonParams & {

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
@@ -33,7 +33,7 @@ interface HandleMLSMessageAddParams {
 export const handleMLSMessageAdd = async ({
   event,
   mlsService,
-}: HandleMLSMessageAddParams): Promise<HandledEventPayload | undefined> => {
+}: HandleMLSMessageAddParams): Promise<HandledEventPayload | null> => {
   const encryptedData = Decoder.fromBase64(event.data).asBytes;
 
   const qualifiedConversationId = event.qualified_conversation ?? {id: event.conversation, domain: ''};
@@ -79,5 +79,5 @@ export const handleMLSMessageAdd = async ({
     mlsService.emit('newEpoch', {groupId, epoch: newEpoch});
   }
 
-  return message ? {event, decryptedData: GenericMessage.decode(message)} : undefined;
+  return message ? {event, decryptedData: GenericMessage.decode(message)} : null;
 };

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.types.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.types.ts
@@ -38,8 +38,6 @@ export type ProteusServiceConfig = {
 
 export type SendProteusMessageParams = SendCommonParams &
   MessageSendingOptions & {
-    conversationId: QualifiedId;
-
     /**
      * Can be either a QualifiedId[] or QualfiedUserClients. The type has some effect on the behavior of the method. (Needed only for Proteus)
      *    When given a QualifiedId[] the method will fetch the freshest list of devices for those users (since they are not given by the consumer). As a consequence no ClientMismatch error will trigger and we will ignore missing clients when sending


### PR DESCRIPTION
Adds a recovery mechanism to mls message sending when failed with `"mls-stale-message"` error. When error is catched, we should rejoin the group with external commit, retry to send a message once and notify consumer (webapp) that mls group has recovered from epoch mismatch. Consumer will then insert system message into the recovered conversation. 