### PR TITLE
runfix(api-client): mls_public_keys field required

### DIFF
--- a/packages/api-client/src/client/RegisteredClient.ts
+++ b/packages/api-client/src/client/RegisteredClient.ts
@@ -28,7 +28,7 @@ export interface AddedClient extends PublicClient {
   /** An ISO 8601 Date string */
   time: string;
   type: ClientType.PERMANENT | ClientType.TEMPORARY;
-  mls_public_keys?: Record<string, string>;
+  mls_public_keys: Record<string, string>;
   last_active?: string;
 }
 


### PR DESCRIPTION
`mls_public_keys` field is not optional and is empty object (`"{}"`) by default.