### PR TITLE
feat: refill check on welcome message [WPB-4773]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -305,7 +305,7 @@ export class Account extends TypedEventEmitter<Events> {
       await this.service.mls.checkExistingPendingProposals();
 
       // initialize scheduler for syncing key packages with backend
-      this.service.mls.checkForKeyPackagesBackendSync();
+      this.service.mls.schedulePeriodicKeyPackagesBackendSync(validClient.id);
 
       // leave stale conference subconversations (e.g after a crash)
       await this.service.mls.leaveStaleConferenceSubconversations();

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -586,7 +586,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   }
 
   private async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent) {
-    return this.mlsService.handleMLSWelcomeMessageEvent(event);
+    return this.mlsService.handleMLSWelcomeMessageEvent(event, this.apiClient.validatedClientId);
   }
 
   private async handleOtrMessageAddEvent(event: ConversationOtrMessageAddEvent) {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -224,6 +224,8 @@ describe('MLSService', () => {
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
       jest.spyOn(mockCoreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
 
+      jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation(jest.fn());
+
       const mockedMLSWelcomeEvent: ConversationMLSWelcomeEvent = {
         type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
         conversation: '',
@@ -255,6 +257,8 @@ describe('MLSService', () => {
 
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
       jest.spyOn(mockCoreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+
+      jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation(jest.fn());
 
       const mockedMLSWelcomeEvent: ConversationMLSWelcomeEvent = {
         type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
@@ -289,6 +293,8 @@ describe('MLSService', () => {
 
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
       jest.spyOn(mockCoreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+
+      jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation(jest.fn());
 
       const mockedMLSWelcomeEvent: ConversationMLSWelcomeEvent = {
         type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {ClientType, RegisteredClient} from '@wireapp/api-client/lib/client';
+import {CONVERSATION_EVENT, ConversationMLSWelcomeEvent} from '@wireapp/api-client/lib/event';
 
 import {randomUUID} from 'crypto';
 
@@ -42,6 +43,7 @@ describe('MLSService', () => {
     clientKeypackages: jest.fn(),
     mlsInit: jest.fn(),
     clientPublicKey: jest.fn(),
+    processWelcomeMessage: jest.fn(),
   } as unknown as CoreCrypto;
 
   describe('registerConversation', () => {
@@ -200,6 +202,106 @@ describe('MLSService', () => {
       expect(mockCoreCrypto.mlsInit).toHaveBeenCalled();
       expect(apiClient.api.client.uploadMLSKeyPackages).not.toHaveBeenCalled();
       expect(apiClient.api.client.putClient).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleMLSWelcomeMessageEvent', () => {
+    it("before processing welcome it verifies that there's enough key packages locally", async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {ed25519: 'key'}, id: mockClientId} as unknown as RegisteredClient;
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientKeyPackages = [new Uint8Array()];
+      jest.spyOn(mockCoreCrypto, 'clientKeypackages').mockResolvedValueOnce(mockedClientKeyPackages);
+
+      const numberOfKeysBelowThreshold = mlsService.config.minRequiredNumberOfAvailableKeyPackages - 1;
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(numberOfKeysBelowThreshold);
+      jest.spyOn(mockCoreCrypto, 'clientValidKeypackagesCount').mockResolvedValueOnce(numberOfKeysBelowThreshold);
+
+      jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
+      jest.spyOn(mockCoreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+
+      const mockedMLSWelcomeEvent: ConversationMLSWelcomeEvent = {
+        type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
+        conversation: '',
+        data: '',
+        from: '',
+        time: '',
+      };
+
+      await mlsService.handleMLSWelcomeMessageEvent(mockedMLSWelcomeEvent, mockClient.id);
+
+      expect(mockCoreCrypto.processWelcomeMessage).toHaveBeenCalled();
+      expect(apiClient.api.client.uploadMLSKeyPackages).toHaveBeenCalledWith(mockClientId, expect.anything());
+    });
+
+    it('before processing welcome it does not generate new keys if there is enough key packages locally', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {ed25519: 'key'}, id: mockClientId} as unknown as RegisteredClient;
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientKeyPackages = [new Uint8Array()];
+      jest.spyOn(mockCoreCrypto, 'clientKeypackages').mockResolvedValueOnce(mockedClientKeyPackages);
+
+      const numberOfKeysAboveThreshold = mlsService.config.minRequiredNumberOfAvailableKeyPackages + 1;
+      jest.spyOn(mockCoreCrypto, 'clientValidKeypackagesCount').mockResolvedValueOnce(numberOfKeysAboveThreshold);
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(numberOfKeysAboveThreshold);
+
+      jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
+      jest.spyOn(mockCoreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+
+      const mockedMLSWelcomeEvent: ConversationMLSWelcomeEvent = {
+        type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
+        conversation: '',
+        data: '',
+        from: '',
+        time: '',
+      };
+
+      await mlsService.handleMLSWelcomeMessageEvent(mockedMLSWelcomeEvent, mockClient.id);
+
+      expect(mockCoreCrypto.processWelcomeMessage).toHaveBeenCalled();
+      expect(apiClient.api.client.uploadMLSKeyPackages).not.toHaveBeenCalled();
+    });
+
+    it('before processing welcome it does not generate new keys if there is enough key packages uploaded to backend', async () => {
+      const mlsService = new MLSService(apiClient, mockCoreCrypto, {});
+
+      const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {ed25519: 'key'}, id: mockClientId} as unknown as RegisteredClient;
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientKeyPackages = [new Uint8Array()];
+      jest.spyOn(mockCoreCrypto, 'clientKeypackages').mockResolvedValueOnce(mockedClientKeyPackages);
+
+      const numberOfKeysBelowThreshold = mlsService.config.minRequiredNumberOfAvailableKeyPackages - 1;
+      const numberOfKeysAboveThreshold = mlsService.config.minRequiredNumberOfAvailableKeyPackages + 1;
+
+      jest.spyOn(mockCoreCrypto, 'clientValidKeypackagesCount').mockResolvedValueOnce(numberOfKeysBelowThreshold);
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(numberOfKeysAboveThreshold);
+
+      jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
+      jest.spyOn(mockCoreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+
+      const mockedMLSWelcomeEvent: ConversationMLSWelcomeEvent = {
+        type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
+        conversation: '',
+        data: '',
+        from: '',
+        time: '',
+      };
+
+      await mlsService.handleMLSWelcomeMessageEvent(mockedMLSWelcomeEvent, mockClient.id);
+
+      expect(mockCoreCrypto.processWelcomeMessage).toHaveBeenCalled();
+      expect(apiClient.api.client.uploadMLSKeyPackages).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -652,10 +652,10 @@ export class MLSService extends TypedEventEmitter<Events> {
     });
   }
 
-  private async uploadMLSKeyPackages(clientId: string, keypackages: Uint8Array[]) {
+  private async uploadMLSKeyPackages(clientId: string, keyPackages: Uint8Array[]) {
     return this.apiClient.api.client.uploadMLSKeyPackages(
       clientId,
-      keypackages.map(keypackage => btoa(Converter.arrayBufferViewToBaselineString(keypackage))),
+      keyPackages.map(keyPackage => btoa(Converter.arrayBufferViewToBaselineString(keyPackage))),
     );
   }
 
@@ -781,6 +781,8 @@ export class MLSService extends TypedEventEmitter<Events> {
   public async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent, clientId: string) {
     // Every time we've received a welcome message, it means that our key package was consumed,
     // we need to verify if we need to upload new ones.
+    // Note that this has to be done before we even process the welcome message (even if it fails),
+    // receiving a welcome message means that one of our key packages on backend was claimed.
     await this.verifyLocalMLSKeyPackagesAmount(clientId);
 
     return handleMLSWelcomeMessage({event, mlsService: this});

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -593,24 +593,16 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   /**
-   * Get date of last key packages count query and schedule a task to sync it with backend
+   * Schedules a task to periodically (every 24h) check if new key packages should be generated and uploaded to backend.
    * Function must only be called once, after application start
+   * @param clientId id of the client
    */
-  public checkForKeyPackagesBackendSync() {
+  public schedulePeriodicKeyPackagesBackendSync(clientId: string) {
     registerRecurringTask({
       every: TimeUtil.TimeInMillis.DAY,
       key: 'try-key-packages-backend-sync',
-      task: () => this.syncKeyPackages(),
+      task: () => this.uploadMLSKeyPackages(clientId),
     });
-  }
-
-  private async syncKeyPackages() {
-    const validKeyPackagesCount = await this.clientValidKeypackagesCount();
-
-    if (validKeyPackagesCount <= this.config.minRequiredNumberOfAvailableKeyPackages) {
-      const clientId = this.apiClient.validatedClientId;
-      await this.uploadMLSKeyPackages(clientId);
-    }
   }
 
   private async getRemoteMLSKeyPackageCount(clientId: string) {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -783,7 +783,11 @@ export class MLSService extends TypedEventEmitter<Events> {
     // we need to verify if we need to upload new ones.
     // Note that this has to be done before we even process the welcome message (even if it fails),
     // receiving a welcome message means that one of our key packages on backend was claimed.
-    await this.verifyLocalMLSKeyPackagesAmount(clientId);
+    try {
+      await this.verifyLocalMLSKeyPackagesAmount(clientId);
+    } catch {
+      this.logger.error('Failed to verify the amount of MLS key packages');
+    }
 
     return handleMLSWelcomeMessage({event, mlsService: this});
   }


### PR DESCRIPTION
We (and other platforms) were missing a check for amount of local key packages after receiving a welcome message. We were performing a check only once every 24h. This PR adds this functionality.

Explanation:
When somebody tries to add you to a MLS group, they need to first claim one of your key packages you've uploaded to backend when registering MLS device. After successfully claiming your key package, you're being sent a welcome message. After welcome message is processed, corecrypto "consumes" your key package. Minimal number of key packages client should have uploaded to backend is half of the default amount of keys which is 100 by default (so minimal required number is 50 by default).

We need to keep track of the local amount of keypackages, to know when we should generate new keys and upload them to backend.

Example:
- we have 50 keys locally, they are all uploaded to backend
- somebody adds us to mls group, using our key package
- number of keys on backend reduces to 49
- we receive a welcome message, corecrypto processes it and reduces number of local keys to 49
- we detect that we are below minimal required number of keys (50)
- we generate new keys to top up to 100
- we upload all the newly generated keys to backend
- we have 100 keys both locally and on backend