### PR TITLE
feat: Add backends that caused user adding error

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -285,7 +285,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       events: response.events,
       conversation,
       failedToAdd: response.failed
-        ? {users: response.failed, reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
+        ? {users: response.failed, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
         : undefined,
     };
   }
@@ -349,7 +349,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       conversation,
       failedToAdd:
         failedToFetchKeyPackages.length > 0
-          ? {users: failedToFetchKeyPackages, reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
+          ? {users: failedToFetchKeyPackages, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
           : undefined,
     };
   }

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -129,6 +129,8 @@ export enum AddUsersFailureReasons {
 export type AddUsersFailure = {
   users: QualifiedId[];
   reason: AddUsersFailureReasons;
+  /** the backends that caused the failure */
+  backends: string[];
 };
 
 /**

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -179,7 +179,7 @@ export class ProteusService {
                 // on a succesfull conversation creation with the available users,
                 // we append the users from an unreachable backend to the response
                 unreachableUsers.length > 0
-                  ? {reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS, users: unreachableUsers}
+                  ? {reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS, backends, users: unreachableUsers}
                   : undefined,
             };
           }
@@ -216,7 +216,7 @@ export class ProteusService {
               backends,
             );
             if (availableUsers.length === 0) {
-              return {failedToAdd: {reason: failureReasonsMap[error.label], users: unreachableUsers}};
+              return {failedToAdd: {reason: failureReasonsMap[error.label], backends, users: unreachableUsers}};
             }
             // In case the request to add users failed with a `UNREACHABLE_BACKENDS` or `NOT_CONNECTED_BACKENDS` errors, we try again with the users from available backends
             try {
@@ -225,12 +225,18 @@ export class ProteusService {
                 event: response,
                 failedToAdd:
                   unreachableUsers.length > 0
-                    ? {reason: failureReasonsMap[error.label], users: unreachableUsers}
+                    ? {reason: failureReasonsMap[error.label], backends, users: unreachableUsers}
                     : undefined,
               };
             } catch (error) {
               if (isFederatedBackendsError(error)) {
-                return {failedToAdd: {reason: failureReasonsMap[error.label], users: qualifiedUsers}};
+                return {
+                  failedToAdd: {
+                    reason: failureReasonsMap[error.label],
+                    backends: error.backends,
+                    users: qualifiedUsers,
+                  },
+                };
               }
               throw error;
             }


### PR DESCRIPTION
In order for the consuming app (the webapp) to know which backends caused a user add failure, we can return the `backends` part of the HTTP response in the return type of the `addUsersToConversation` method