### PR TITLE
feat: lock websocket when uploading a commit bundle to backend

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -408,4 +408,17 @@ export class APIClient extends EventEmitter {
     }
     throw new Error('No valid client ID.');
   }
+
+  /**
+   * Will lock the websocket before executing the callback and unlock it after
+   * @param callback The callback to execute
+   */
+  public withLockedWebSocket<T>(callback: () => T): T {
+    this.transport.ws.lock();
+    try {
+      return callback();
+    } finally {
+      this.transport.ws.unlock();
+    }
+  }
 }

--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -413,12 +413,16 @@ export class APIClient extends EventEmitter {
    * Will lock the websocket before executing the callback and unlock it after
    * @param callback The callback to execute
    */
-  public withLockedWebSocket<T>(callback: () => T): T {
-    this.transport.ws.lock();
-    try {
-      return callback();
-    } finally {
-      this.transport.ws.unlock();
-    }
+  public withLockedWebSocket<T extends (...args: any[]) => any>(
+    callback: T,
+  ): (...args: Parameters<T>) => ReturnType<T> {
+    return (...args: Parameters<T>): ReturnType<T> => {
+      this.transport.ws.lock();
+      try {
+        return callback(...args);
+      } finally {
+        this.transport.ws.unlock();
+      }
+    };
   }
 }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -133,8 +133,9 @@ export class MLSService extends TypedEventEmitter<Events> {
     const {commit, groupInfo, welcome} = commitBundle;
     const bundlePayload = new Uint8Array([...commit, ...groupInfo.payload, ...(welcome || [])]);
     try {
+      // We need to lock the websocket while commit bundle is being processed by backend,
+      // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
       return this.apiClient.withLockedWebSocket(async () => {
-        throw new Error('Not implemented');
         const response = await this.apiClient.api.conversation.postMlsCommitBundle(bundlePayload);
         if (isExternalCommit) {
           await this.coreCryptoClient.mergePendingGroupFromExternalCommit(groupId);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -125,6 +125,8 @@ export class MLSService extends TypedEventEmitter<Events> {
     await this.verifyRemoteMLSKeyPackagesAmount(client.id);
   }
 
+  // We need to lock the websocket while commit bundle is being processed by backend,
+  // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
   private readonly uploadCommitBundle = this.apiClient.withLockedWebSocket(
     async (
       groupId: Uint8Array,
@@ -133,8 +135,6 @@ export class MLSService extends TypedEventEmitter<Events> {
     ): Promise<PostMlsMessageResponse> => {
       const {commit, groupInfo, welcome} = commitBundle;
       const bundlePayload = new Uint8Array([...commit, ...groupInfo.payload, ...(welcome || [])]);
-      // We need to lock the websocket while commit bundle is being processed by backend,
-      // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
       try {
         const response = await this.apiClient.api.conversation.postMlsCommitBundle(bundlePayload);
         if (isExternalCommit) {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -125,16 +125,16 @@ export class MLSService extends TypedEventEmitter<Events> {
     await this.verifyRemoteMLSKeyPackagesAmount(client.id);
   }
 
-  private async uploadCommitBundle(
-    groupId: Uint8Array,
-    commitBundle: CommitBundle,
-    {regenerateCommitBundle, isExternalCommit}: UploadCommitOptions = {},
-  ): Promise<PostMlsMessageResponse> {
-    const {commit, groupInfo, welcome} = commitBundle;
-    const bundlePayload = new Uint8Array([...commit, ...groupInfo.payload, ...(welcome || [])]);
-    // We need to lock the websocket while commit bundle is being processed by backend,
-    // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
-    return this.apiClient.withLockedWebSocket(async () => {
+  private readonly uploadCommitBundle = this.apiClient.withLockedWebSocket(
+    async (
+      groupId: Uint8Array,
+      commitBundle: CommitBundle,
+      {regenerateCommitBundle, isExternalCommit}: UploadCommitOptions = {},
+    ): Promise<PostMlsMessageResponse> => {
+      const {commit, groupInfo, welcome} = commitBundle;
+      const bundlePayload = new Uint8Array([...commit, ...groupInfo.payload, ...(welcome || [])]);
+      // We need to lock the websocket while commit bundle is being processed by backend,
+      // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
       try {
         const response = await this.apiClient.api.conversation.postMlsCommitBundle(bundlePayload);
         if (isExternalCommit) {
@@ -165,8 +165,8 @@ export class MLSService extends TypedEventEmitter<Events> {
         }
         throw error;
       }
-    });
-  }
+    },
+  );
 
   /**
    * Will add users to an existing MLS group and send a commit bundle to backend.


### PR DESCRIPTION
### Problem

There's undesired behaviour on backend when sending a commit bundle with external commit (e.g when joining mls groups you are member of after registering completely new client). When request is being processed (we've not received a response from backend yet), it can happen that we will receive a bunch of messages on different a "channel" (websocket in this case). Those messages are usually mls messages we cannot decrypt anyway since external join (external commit) was not fully processed, and we're not yet a group member locally.

Current behaviour:
- we send a commit bundle to backend
- while request is being processed we receive some messages via websocket we cannot decrypt anyway, we're thrown a bunch of errors from core-crypto
- response from backend finally arrives, but we don't have access to messages that were received in the meantime (it's possible we're out of sync due to lost mesages)

### Solution

The solution is to simply lock websocket when we're awaiting commit bundle request. When websocket is locked, messages are buffered in the queue and waiting for websocket to be unlocked. After it's unlocked it processes them one by one in order they were received.

New behaviour:
- we lock websocket (buffer incoming messages)
- we send a commit bundle to backend (there're messages arriving but we do not process them yet, they're buffered)
- we got a response from backend
- we accept/clear the commit we've sent locally based on the response code
- we unlock websocket
- we process messages that were queued
- we're all in sync