### PR TITLE
runfix(api-client): remove data field from team event base type

### DIFF
--- a/packages/api-client/src/event/TeamEvent.ts
+++ b/packages/api-client/src/event/TeamEvent.ts
@@ -61,6 +61,7 @@ export type TeamEvent =
   | TeamUpdateEvent;
 
 export interface BaseTeamEvent {
+  data: TeamEventData;
   team: string;
   time: string;
   type: TEAM_EVENT;
@@ -106,7 +107,7 @@ export interface TeamUpdateEvent extends BaseTeamEvent {
   type: TEAM_EVENT.UPDATE;
 }
 
-export type TeamFeatureConfigurationUpdateEvent = BaseTeamEvent &
+export type TeamFeatureConfigurationUpdateEvent = Omit<BaseTeamEvent, 'data'> &
   {
     [FeatureKey in keyof FeatureList]: {
       name: FeatureKey;

--- a/packages/api-client/src/event/TeamEvent.ts
+++ b/packages/api-client/src/event/TeamEvent.ts
@@ -61,7 +61,6 @@ export type TeamEvent =
   | TeamUpdateEvent;
 
 export interface BaseTeamEvent {
-  data: TeamEventData;
   team: string;
   time: string;
   type: TEAM_EVENT;


### PR DESCRIPTION
Omits data attribute from base team event type. It allows us to narrow down config field after providing proper name field on event object. It is not overwritten by default but extended with what comes after `&`.

Before:
`TeamEventData` was not properly overwritten (we could still access fields on different type of config update event)
![Screenshot 2023-09-25 at 15 35 06](https://github.com/wireapp/wire-web-packages/assets/45733298/dd694b89-0016-4234-b3e3-1be9aa7fe879)

After:
We ignore generic `TeamEventData` type on `data` field from base type. Type is narrowed only to the one chosen with `name` field
![Screenshot 2023-09-25 at 15 35 18](https://github.com/wireapp/wire-web-packages/assets/45733298/777e5cd7-09cc-4c83-9676-514412f6f96b)
