### PR TITLE
feat: specify initial nb of key packages in corecrypto

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.12",
+    "@wireapp/core-crypto": "1.0.0-rc.13",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -118,7 +118,11 @@ export class MLSService extends TypedEventEmitter<Events> {
 
   public async initClient(userId: QualifiedId, client: RegisteredClient) {
     const qualifiedClientId = constructFullyQualifiedClientId(userId.id, client.id, userId.domain);
-    await this.coreCryptoClient.mlsInit(this.textEncoder.encode(qualifiedClientId), [this.config.defaultCiphersuite]);
+    await this.coreCryptoClient.mlsInit(
+      this.textEncoder.encode(qualifiedClientId),
+      [this.config.defaultCiphersuite],
+      this.config.nbKeyPackages,
+    );
 
     // We need to make sure keypackages and public key are uploaded to the backend
     await this.uploadMLSPublicKeys(client);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4890,10 +4890,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.12"
-  checksum: 55673f2cdeceb8da5bc3648c9b60b58cbf77268de6f8dd7a82cc78f4146233048dfce0e8336208fe69b67c7bf605520732299db8611e68fbdd43efee75de1e27
+"@wireapp/core-crypto@npm:1.0.0-rc.13":
+  version: 1.0.0-rc.13
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.13"
+  checksum: 8edbf8ffbda8db2b0a2a9dd93fe5c823fb337bb6f4eef0333d3c96ea8d594739b50511eb8d463e11863205537e505fe78fe8a25fcf6e61c675ad30a335cf1b5d
   languageName: node
   linkType: hard
 
@@ -4910,7 +4910,7 @@ __metadata:
     "@types/tough-cookie": 4.0.3
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 1.0.0-rc.12
+    "@wireapp/core-crypto": 1.0.0-rc.13
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
Bumps core-crypto with version that:
- fixes one edge case with handling one edge case with rejoining a conversation with external commit after getting out of sync with epoch number
- allows consumer (core in our case) to specify initial number of key packages to be created when calling `CoreCrypto.mlsInit` method (previously it was always `100`)