### PR TITLE
runfix: recurring task scheduler not resumed after reload

### DIFF
--- a/packages/core/src/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.ts
+++ b/packages/core/src/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.ts
@@ -52,11 +52,11 @@ const addTask = ({key, firingDate, task, intervalDelay}: ScheduleLowPrecisionTas
     const tasks = intervals[intervalDelay]?.tasks;
     if (tasks?.length !== 0) {
       for (const taskData of tasks) {
-        if (nowTime >= firingDate) {
+        if (nowTime >= taskData.firingDate) {
           const {task, key} = taskData;
           logger.info(`Executing task with key "${key}"`);
-          task();
           cancelTask({intervalDelay, key});
+          task();
         }
       }
     }

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.test.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.test.ts
@@ -41,6 +41,26 @@ describe('RecurringTaskScheduler', () => {
     expect(task).toHaveBeenCalledTimes(2);
   });
 
+  it('resumes a task after re-registering a recurring task', () => {
+    const task = jest.fn();
+
+    // it should fire in a minute
+    registerRecurringTask({every: TimeUtil.TimeInMillis.MINUTE, task, key: 'test-task2'});
+    jest.advanceTimersByTime(TimeUtil.TimeInMillis.MINUTE / 2);
+
+    // re-register the task
+    registerRecurringTask({every: TimeUtil.TimeInMillis.MINUTE, task, key: 'test-task2'});
+
+    // only 30s have passed, so the task should not have fired yet
+    expect(task).toHaveBeenCalledTimes(0);
+
+    // advance the timer by another 30s (so we have 1 minute in total)
+    jest.advanceTimersByTime(TimeUtil.TimeInMillis.MINUTE / 2);
+
+    // the task should have fired once after a minute from the beginning even if we re-registered it
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
   it('cancel a task before it is run', () => {
     const task = jest.fn();
     const testKey = 'test-task-1';


### PR DESCRIPTION
### Problem
Recurring task scheduler was never resuming a task after app was reloaded. We were storing only last fire date, which simply didn't exist before the task was run for the first time.

### Solution
We store `firingDate` instead and make sure it's stored even before the task runs for the first time. If `firingDate` already exists, we just load it from the store.