### PR TITLE
runfix: recurring task scheduler with indexeddb store

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -354,7 +354,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const conversation = await this.getConversation(conversationId);
 
     //We store the info when user was added (and key material was created), so we will know when to renew it
-    this.mlsService.resetKeyMaterialRenewal(groupId);
+    await this.mlsService.resetKeyMaterialRenewal(groupId);
     return {
       events: response.events,
       conversation,
@@ -379,7 +379,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const messageResponse = await this.mlsService.removeClientsFromConversation(groupId, fullyQualifiedClientIds);
 
     //key material gets updated after removing a user from the group, so we can reset last key update time value in the store
-    this.mlsService.resetKeyMaterialRenewal(groupId);
+    await this.mlsService.resetKeyMaterialRenewal(groupId);
 
     const conversation = await this.getConversation(conversationId);
 
@@ -414,7 +414,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       );
 
       //We store the info when user was added (and key material was created), so we will know when to renew it
-      this.mlsService.resetKeyMaterialRenewal(groupId);
+      await this.mlsService.resetKeyMaterialRenewal(groupId);
     });
   }
 

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
@@ -40,7 +40,7 @@ export const handleMLSWelcomeMessage = async ({
   // The groupId can then be sent back to the consumer
 
   // After we were added to the group we need to schedule a periodic key material renewal
-  mlsService.scheduleKeyMaterialRenewal(groupIdStr);
+  await mlsService.scheduleKeyMaterialRenewal(groupIdStr);
   return {
     event: {...event, data: groupIdStr},
   };

--- a/packages/core/src/storage/CoreDB.ts
+++ b/packages/core/src/storage/CoreDB.ts
@@ -18,7 +18,7 @@
  */
 
 import {DBSchema, deleteDB as idbDeleteDB, IDBPDatabase, openDB as idbOpenDb} from 'idb';
-const VERSION = 2;
+const VERSION = 3;
 
 interface CoreDBSchema extends DBSchema {
   prekeys: {
@@ -28,6 +28,10 @@ interface CoreDBSchema extends DBSchema {
   pendingProposals: {
     key: string;
     value: {groupId: string; firingDate: number};
+  };
+  recurringTasks: {
+    key: string;
+    value: {key: string; firingDate: number};
   };
 }
 
@@ -42,6 +46,8 @@ export async function openDB(dbName: string): Promise<CoreDatabase> {
         case 1:
           db.deleteObjectStore('prekeys');
           db.createObjectStore('pendingProposals');
+        case 2:
+          db.createObjectStore('recurringTasks');
       }
     },
   });

--- a/packages/core/src/testUtils/index.ts
+++ b/packages/core/src/testUtils/index.ts
@@ -33,9 +33,10 @@ export function generateQualifiedIds(nbUsers: number, domain: string) {
   return users;
 }
 
-export const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
-
+/*
+ * Jest fake timers do not play well with promises, so we need to advance the timers and wait for all the promises to resolve.
+ */
 export const advanceJestTimersWithPromise = async (time: number) => {
   jest.advanceTimersByTime(time);
-  return flushPromises();
+  return new Promise(jest.requireActual('timers').setImmediate);
 };

--- a/packages/core/src/testUtils/index.ts
+++ b/packages/core/src/testUtils/index.ts
@@ -32,3 +32,10 @@ export function generateQualifiedIds(nbUsers: number, domain: string) {
   }
   return users;
 }
+
+export const flushPromises = () => new Promise(jest.requireActual('timers').setImmediate);
+
+export const advanceJestTimersWithPromise = async (time: number) => {
+  jest.advanceTimersByTime(time);
+  return flushPromises();
+};

--- a/packages/core/src/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.ts
+++ b/packages/core/src/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.ts
@@ -19,6 +19,8 @@
 
 import {LowPrecisionTaskScheduler} from './LowPrecisionTaskScheduler';
 
+import {advanceJestTimersWithPromise} from '../../testUtils';
+
 describe('LowPrecisionTaskScheduler', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -38,11 +40,7 @@ describe('LowPrecisionTaskScheduler', () => {
       task: mockedTask,
     });
 
-    jest.advanceTimersByTime(2001);
-    await Promise.resolve();
-
-    jest.advanceTimersByTime(2001);
-    await Promise.resolve();
+    await advanceJestTimersWithPromise(5000);
 
     expect(mockedTask).toHaveBeenCalledTimes(1);
   });
@@ -57,8 +55,7 @@ describe('LowPrecisionTaskScheduler', () => {
       task: mockedTask,
     });
 
-    jest.advanceTimersByTime(1001);
-    await Promise.resolve();
+    await advanceJestTimersWithPromise(1001);
 
     expect(mockedTask).toHaveBeenCalled();
   });
@@ -74,7 +71,7 @@ describe('LowPrecisionTaskScheduler', () => {
       task: mockedTask1,
     });
 
-    jest.advanceTimersByTime(1000);
+    await advanceJestTimersWithPromise(1000);
 
     LowPrecisionTaskScheduler.addTask({
       key: 'test2-key',
@@ -83,10 +80,7 @@ describe('LowPrecisionTaskScheduler', () => {
       task: mockedTask2,
     });
 
-    jest.advanceTimersByTime(5001);
-
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceJestTimersWithPromise(5001);
 
     expect(mockedTask1).toHaveBeenCalled();
     expect(mockedTask2).toHaveBeenCalled();
@@ -103,7 +97,7 @@ describe('LowPrecisionTaskScheduler', () => {
       task: mockedTask3,
     });
 
-    jest.advanceTimersByTime(1000);
+    await advanceJestTimersWithPromise(1000);
 
     LowPrecisionTaskScheduler.addTask({
       key: 'test4-key',
@@ -117,10 +111,7 @@ describe('LowPrecisionTaskScheduler', () => {
       key: 'test3-key',
     });
 
-    jest.advanceTimersByTime(4001);
-
-    await Promise.resolve();
-    await Promise.resolve();
+    await advanceJestTimersWithPromise(4001);
 
     expect(mockedTask3).not.toHaveBeenCalled();
     expect(mockedTask4).toHaveBeenCalled();

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -46,8 +46,11 @@ export class RecurringTaskScheduler {
       key,
       task: async () => {
         await this.storage.delete(key);
-        await task();
-        await this.registerTask({every, task, key});
+        try {
+          await task();
+        } finally {
+          await this.registerTask({every, task, key});
+        }
       },
     };
 

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -19,42 +19,50 @@
 
 import {TimeUtil} from '@wireapp/commons';
 
-import {saveState, loadState, deleteState} from './RecurringTaskScheduler.store';
-
 import {LowPrecisionTaskScheduler} from '../LowPrecisionTaskScheduler';
 import {TaskScheduler} from '../TaskScheduler';
 
+interface RecurringTaskSchedulerStorage {
+  set: (key: string, timestamp: number) => Promise<void>;
+  get: (key: string) => Promise<number | undefined>;
+  delete: (key: string) => Promise<void>;
+}
+
 interface TaskParams {
   every: number;
-  task: () => void;
+  task: () => Promise<void> | void;
   key: string;
 }
 
-export function registerRecurringTask({every, task, key}: TaskParams) {
-  const firingDate = loadState(key) || Date.now() + every;
-  saveState(key, firingDate);
+export class RecurringTaskScheduler {
+  constructor(private readonly storage: RecurringTaskSchedulerStorage) {}
 
-  const taskConfig = {
-    firingDate,
-    key,
-    task: () => {
-      deleteState(key);
-      task();
-      registerRecurringTask({every, task, key});
-    },
+  public readonly registerTask = async ({every, task, key}: TaskParams): Promise<void> => {
+    const firingDate = (await this.storage.get(key)) || Date.now() + every;
+    await this.storage.set(key, firingDate);
+
+    const taskConfig = {
+      firingDate,
+      key,
+      task: async () => {
+        await this.storage.delete(key);
+        await task();
+        await this.registerTask({every, task, key});
+      },
+    };
+
+    if (every > TimeUtil.TimeInMillis.DAY * 20) {
+      // If the firing date is in more that 20 days, we could switch to a lowPrecision scheduler that will avoid hitting the limit of setTimeout
+      // (see https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value)
+      LowPrecisionTaskScheduler.addTask({...taskConfig, intervalDelay: TimeUtil.TimeInMillis.MINUTE});
+    } else {
+      TaskScheduler.addTask(taskConfig);
+    }
   };
 
-  if (every > TimeUtil.TimeInMillis.DAY * 20) {
-    // If the firing date is in more that 20 days, we could switch to a lowPrecision scheduler that will avoid hitting the limit of setTimeout
-    // (see https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value)
-    LowPrecisionTaskScheduler.addTask({...taskConfig, intervalDelay: TimeUtil.TimeInMillis.MINUTE});
-  } else {
-    TaskScheduler.addTask(taskConfig);
-  }
-}
-
-export function cancelRecurringTask(taskKey: string) {
-  deleteState(taskKey);
-  TaskScheduler.cancelTask(taskKey);
-  LowPrecisionTaskScheduler.cancelTask({intervalDelay: TimeUtil.TimeInMillis.MINUTE, key: taskKey});
+  public readonly cancelTask = async (taskKey: string): Promise<void> => {
+    await this.storage.delete(taskKey);
+    TaskScheduler.cancelTask(taskKey);
+    LowPrecisionTaskScheduler.cancelTask({intervalDelay: TimeUtil.TimeInMillis.MINUTE, key: taskKey});
+  };
 }

--- a/packages/core/src/util/TaskScheduler/TaskScheduler.ts
+++ b/packages/core/src/util/TaskScheduler/TaskScheduler.ts
@@ -27,7 +27,7 @@ const logger = logdown('@wireapp/core/TaskScheduler', {
 });
 
 type ScheduleTaskParams = {
-  task: () => void;
+  task: () => Promise<void> | void;
   firingDate: number;
   key: string;
   persist?: boolean;


### PR DESCRIPTION
Makes recurring task scheduler more generic and allows its consumer to specify storage where events will be stored.

Now `core` has its own recurring task scheduler that is using core's database (indexedDB) to store the events.