### PR TITLE
refactor: use unknown for recurring task return type

### DIFF
--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -30,7 +30,7 @@ interface RecurringTaskSchedulerStorage {
 
 interface TaskParams {
   every: number;
-  task: () => Promise<void> | void;
+  task: () => Promise<unknown> | unknown;
   key: string;
 }
 


### PR DESCRIPTION
Use `unknown` as task's return type so we can pass a function that returns anything (not necessarily `void`).