### PR TITLE
feat: try establishing mls group for mixed conversation

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -439,19 +439,15 @@ describe('ConversationService', () => {
     });
   });
 
-  describe('tryEstablishingMixedConversationMLSGroup', () => {
+  describe('tryEstablishingMLSGroup', () => {
     it('returns false if group did already exist locally', async () => {
       const [conversationService, {mlsService}] = buildConversationService();
 
       const mockGroupId = 'mock-group-id';
-      const mockConversationId = {id: 'mock-conversation-id', domain: 'staging.zinfra.io'};
 
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
 
-      const wasConversationEstablished = await conversationService.tryEstablishingMixedConversationMLSGroup(
-        mockConversationId,
-        mockGroupId,
-      );
+      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
 
       expect(mlsService.registerConversation).not.toHaveBeenCalled();
       expect(wasConversationEstablished).toBe(false);
@@ -460,18 +456,14 @@ describe('ConversationService', () => {
     it('returns false if corecrypto has thrown an error when trying to register group locally', async () => {
       const [conversationService, {mlsService}] = buildConversationService();
 
-      const mockGroupId = 'mock-group-id2';
-      const mockConversationId = {id: 'mock-conversation-id2', domain: 'staging.zinfra.io'};
+      const mockGroupId = 'mock-group-id';
 
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
       jest
         .spyOn(mlsService, 'registerConversation')
         .mockRejectedValueOnce(new Error(CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS));
 
-      const wasConversationEstablished = await conversationService.tryEstablishingMixedConversationMLSGroup(
-        mockConversationId,
-        mockGroupId,
-      );
+      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
 
       expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, []);
       expect(wasConversationEstablished).toBe(false);
@@ -481,17 +473,13 @@ describe('ConversationService', () => {
       const [conversationService, {mlsService}] = buildConversationService();
 
       const mockGroupId = 'mock-group-id2';
-      const mockConversationId = {id: 'mock-conversation-id2', domain: 'staging.zinfra.io'};
 
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
       jest
         .spyOn(mlsService, 'registerConversation')
         .mockRejectedValueOnce(new BackendError('', BackendErrorLabel.MLS_STALE_MESSAGE, HTTP_STATUS.CONFLICT));
 
-      const wasConversationEstablished = await conversationService.tryEstablishingMixedConversationMLSGroup(
-        mockConversationId,
-        mockGroupId,
-      );
+      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
 
       expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, []);
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
@@ -502,15 +490,11 @@ describe('ConversationService', () => {
       const [conversationService, {mlsService}] = buildConversationService();
 
       const mockGroupId = 'mock-group-id2';
-      const mockConversationId = {id: 'mock-conversation-id2', domain: 'staging.zinfra.io'};
 
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
       jest.spyOn(mlsService, 'registerConversation').mockResolvedValueOnce({events: [], time: ''});
 
-      const wasConversationEstablished = await conversationService.tryEstablishingMixedConversationMLSGroup(
-        mockConversationId,
-        mockGroupId,
-      );
+      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
 
       expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, []);
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -18,7 +18,12 @@
  */
 
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client';
-import {Conversation, ConversationProtocol, MLSConversation} from '@wireapp/api-client/lib/conversation';
+import {
+  Conversation,
+  ConversationProtocol,
+  MLSConversation,
+  PostMlsMessageResponse,
+} from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_EVENT, ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
@@ -109,6 +114,9 @@ describe('ConversationService', () => {
       conversationExists: jest.fn(),
       isConversationEstablished: jest.fn(),
       tryEstablishingMLSGroup: jest.fn(),
+      getKeyPackagesPayload: jest.fn(),
+      addUsersToExistingConversation: jest.fn(),
+      resetKeyMaterialRenewal: jest.fn(),
     } as unknown as MLSService;
 
     const conversationService = new ConversationService(client, mockedProteusService, mockedMLSService);
@@ -498,6 +506,46 @@ describe('ConversationService', () => {
 
       const fetchedMembers = await conversationService.fetchAllParticipantsClients({id: 'convid', domain: ''});
       expect(fetchedMembers).toEqual(members);
+    });
+  });
+
+  describe('addUsersToMLSConversation', () => {
+    it('should claim key packages for all the users and add them to the group', async () => {
+      const [conversationService, {apiClient, mlsService}] = buildConversationService();
+
+      const mockGroupId = 'groupId';
+      const mockConversationId = {id: PayloadHelper.getUUID(), domain: 'local.wire.com'};
+
+      const otherUsersToAdd = Array(3)
+        .fill(0)
+        .map(() => ({id: PayloadHelper.getUUID(), domain: 'local.wire.com'}));
+
+      const selfUserToAdd = {id: 'self-user-id', domain: 'local.wire.com', skipOwnClientId: apiClient.clientId};
+
+      const qualifiedUsers = [...otherUsersToAdd, selfUserToAdd];
+
+      jest
+        .spyOn(mlsService, 'getKeyPackagesPayload')
+        .mockResolvedValueOnce({coreCryptoKeyPackagesPayload: [], failedToFetchKeyPackages: []});
+
+      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: 1,
+        group_id: mockGroupId,
+      } as unknown as Conversation);
+
+      const mlsMessage: PostMlsMessageResponse = {events: [], time: ''};
+      jest.spyOn(mlsService, 'addUsersToExistingConversation').mockResolvedValueOnce(mlsMessage);
+
+      await conversationService.addUsersToMLSConversation({
+        qualifiedUsers,
+        groupId: mockGroupId,
+        conversationId: mockConversationId,
+      });
+
+      expect(mlsService.getKeyPackagesPayload).toHaveBeenCalledWith(qualifiedUsers);
+      expect(mlsService.resetKeyMaterialRenewal).toHaveBeenCalledWith(mockGroupId);
     });
   });
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -439,69 +439,6 @@ describe('ConversationService', () => {
     });
   });
 
-  describe('tryEstablishingMLSGroup', () => {
-    it('returns false if group did already exist locally', async () => {
-      const [conversationService, {mlsService}] = buildConversationService();
-
-      const mockGroupId = 'mock-group-id';
-
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-
-      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
-
-      expect(mlsService.registerConversation).not.toHaveBeenCalled();
-      expect(wasConversationEstablished).toBe(false);
-    });
-
-    it('returns false if corecrypto has thrown an error when trying to register group locally', async () => {
-      const [conversationService, {mlsService}] = buildConversationService();
-
-      const mockGroupId = 'mock-group-id';
-
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
-      jest
-        .spyOn(mlsService, 'registerConversation')
-        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS));
-
-      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
-
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, []);
-      expect(wasConversationEstablished).toBe(false);
-    });
-
-    it('returns false and wipes group locally if any backend error was thrown', async () => {
-      const [conversationService, {mlsService}] = buildConversationService();
-
-      const mockGroupId = 'mock-group-id2';
-
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
-      jest
-        .spyOn(mlsService, 'registerConversation')
-        .mockRejectedValueOnce(new BackendError('', BackendErrorLabel.MLS_STALE_MESSAGE, HTTP_STATUS.CONFLICT));
-
-      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
-
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, []);
-      expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
-      expect(wasConversationEstablished).toBe(false);
-    });
-
-    it('returns true after MLS group was etablished successfully', async () => {
-      const [conversationService, {mlsService}] = buildConversationService();
-
-      const mockGroupId = 'mock-group-id2';
-
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
-      jest.spyOn(mlsService, 'registerConversation').mockResolvedValueOnce({events: [], time: ''});
-
-      const wasConversationEstablished = await conversationService.tryEstablishingMLSGroup(mockGroupId);
-
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, []);
-      expect(mlsService.wipeConversation).not.toHaveBeenCalled();
-      expect(wasConversationEstablished).toBe(true);
-    });
-  });
-
   describe('handleEvent', () => {
     it('rejoins a MLS conversation if epoch mismatch detected when decrypting mls message', async () => {
       const [conversationService, {apiClient, mlsService}] = buildConversationService();

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -549,7 +549,7 @@ describe('ConversationService', () => {
     });
   });
 
-  describe('addMixedConversationMembersToMLSGroup', () => {
+  describe('tryEstablishingMLSGroup', () => {
     it('should add all the users to a MLS group after group was established by the self client', async () => {
       const [conversationService, {apiClient, mlsService}] = buildConversationService();
       const selfUserId = {id: 'self-user-id', domain: 'local.wire.com'};
@@ -565,7 +565,7 @@ describe('ConversationService', () => {
         .spyOn(conversationService, 'addUsersToMLSConversation')
         .mockResolvedValueOnce({conversation: {members: {others: []}}} as any);
 
-      await conversationService.tryEstablishingMLSGroupWithUsers({
+      await conversationService.tryEstablishingMLSGroup({
         conversationId: mockConversationId,
         groupId: mockGroupId,
         qualifiedUsers: otherUsersToAdd,
@@ -592,7 +592,7 @@ describe('ConversationService', () => {
       jest.spyOn(mlsService, 'tryEstablishingMLSGroup').mockResolvedValueOnce(false);
       jest.spyOn(conversationService, 'addUsersToMLSConversation');
 
-      await conversationService.tryEstablishingMLSGroupWithUsers({
+      await conversationService.tryEstablishingMLSGroup({
         conversationId: mockConversationId,
         groupId: mockGroupId,
         qualifiedUsers: otherUsersToAdd,

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -576,7 +576,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * @param selfUserId - id of the self user
    * @param qualifiedUsers - list of qualified users to add to the group (should not include the self user)
    */
-  public async tryEstablishingMLSGroupWithUsers({
+  public async tryEstablishingMLSGroup({
     groupId,
     conversationId,
     selfUserId,

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -570,24 +570,19 @@ export class ConversationService extends TypedEventEmitter<Events> {
   };
 
   /**
-   * Will try registering mls group for mixed conversation.
+   * Will try to register mls group and send an empty commit to establish it.
    *
-   * @param conversationId - id of the conversation
    * @param groupId - id of the MLS group
-   * @returns true if the group was registered, false otherwise
+   * @returns true if the client has successfully established the group, false otherwise
    */
-  public readonly tryEstablishingMixedConversationMLSGroup = async (
-    conversationId: QualifiedId,
-    groupId: string,
-  ): Promise<boolean> => {
-    this.logger.info(`Trying to establish a MLS group for mixed conversation with id ${conversationId.id}...`);
+  public readonly tryEstablishingMLSGroup = async (groupId: string): Promise<boolean> => {
+    this.logger.info(`Trying to establish a MLS group with id ${groupId}.`);
 
     // Before trying to register a group, check if the group is already established locally.
     // We could have received a welcome message in the meantime.
-
-    const doesMLSGroupExistLocally = await this.mlsGroupExistsLocally(conversationId.id);
+    const doesMLSGroupExistLocally = await this.mlsGroupExistsLocally(groupId);
     if (doesMLSGroupExistLocally) {
-      this.logger.info(`MLS Group for conversation ${conversationId.id} already exists, skipping the initialisation.`);
+      this.logger.info(`MLS Group with id ${groupId} already exists, skipping the initialisation.`);
       return false;
     }
 
@@ -597,9 +592,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     } catch (error) {
       // If conversation already existed, locally, nothing more to do, we've received a welcome message.
       if (isCoreCryptoMLSConversationAlreadyExistsError(error)) {
-        this.logger.info(
-          `MLS Group for conversation ${conversationId.id} already exists, skipping the initialisation.`,
-        );
+        this.logger.info(`MLS Group with id ${groupId} already exists, skipping the initialisation.`);
         return false;
       }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -51,6 +51,7 @@ import {GenericMessage} from '@wireapp/protocol-messaging';
 import {
   AddUsersFailureReasons,
   AddUsersParams,
+  KeyPackageClaimUser,
   MLSCreateConversationResponse,
   SendMlsMessageParams,
   SendResult,
@@ -565,6 +566,53 @@ export class ConversationService extends TypedEventEmitter<Events> {
       return this.establishMLS1to1Conversation(groupId, selfUser, otherUserId, false);
     }
   };
+
+  /**
+   * Will try to register mls group by sending an empty commit to establish it.
+   * After group was successfully established, it will try to add other users to the group.
+   *
+   * @param groupId - id of the MLS group
+   * @param conversationId - id of the conversation
+   * @param selfUserId - id of the self user
+   * @param qualifiedUsers - list of qualified users to add to the group (should not include the self user)
+   */
+  public async tryEstablishingMLSGroupWithUsers({
+    groupId,
+    conversationId,
+    selfUserId,
+    qualifiedUsers,
+  }: {
+    groupId: string;
+    conversationId: QualifiedId;
+    selfUserId: QualifiedId;
+    qualifiedUsers: QualifiedId[];
+  }): Promise<void> {
+    const wasGroupEstablishedBySelfClient = await this.mlsService.tryEstablishingMLSGroup(groupId);
+
+    if (!wasGroupEstablishedBySelfClient) {
+      this.logger.info('Group was not established by self client, skipping adding users to the group.');
+      return;
+    }
+
+    this.logger.info('Group was established by self client, adding other users to the group...');
+    const usersToAdd: KeyPackageClaimUser[] = [
+      ...qualifiedUsers,
+      {...selfUserId, skipOwnClientId: this.apiClient.validatedClientId},
+    ];
+
+    const {conversation} = await this.addUsersToMLSConversation({
+      conversationId,
+      groupId,
+      qualifiedUsers: usersToAdd,
+    });
+
+    const addedUsers = conversation.members.others;
+    if (addedUsers.length > 0) {
+      this.logger.info(`Successfully added ${addedUsers} users to the group.`);
+    } else {
+      this.logger.info('No other users were added to the group.');
+    }
+  }
 
   private async handleMLSMessageAddEvent(event: ConversationMLSMessageAddEvent): Promise<HandledEventPayload | null> {
     try {

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -25,10 +25,15 @@ export const CoreCryptoMLSError = {
       'You tried to join with an external commit but did not merge it yet. We will reapply this message for you when you merge your external commit',
     FUTURE_EPOCH: 'Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives',
   },
+  CONVERSATION_ALREADY_EXISTS: 'Conversation already exists',
 } as const;
 
 export const isCoreCryptoMLSWrongEpochError = (error: unknown): boolean => {
   return error instanceof Error && error.message === CoreCryptoMLSError.DECRYPTION.WRONG_EPOCH;
+};
+
+export const isCoreCryptoMLSConversationAlreadyExistsError = (error: unknown): boolean => {
+  return error instanceof Error && error.message === CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS;
 };
 
 const mlsDecryptionErrorsToIgnore: string[] = [

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -521,6 +521,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         return false;
       }
 
+      this.logger.info(`MLS Group with id ${groupId} was not established succesfully, wiping the group locally...`);
       // Otherwise it's a backend error. Somebody else might have created the group in the meantime.
       // We should wipe the group locally, wait for the welcome message or join later via external commit.
       await this.wipeConversation(groupId);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -46,7 +46,7 @@ import {
   RemoveProposalArgs,
 } from '@wireapp/core-crypto';
 
-import {shouldMLSDecryptionErrorBeIgnored} from './CoreCryptoMLSError';
+import {isCoreCryptoMLSConversationAlreadyExistsError, shouldMLSDecryptionErrorBeIgnored} from './CoreCryptoMLSError';
 import {MLSServiceConfig, UploadCommitOptions} from './MLSService.types';
 import {subconversationGroupIdStore} from './stores/subconversationGroupIdStore/subconversationGroupIdStore';
 
@@ -493,6 +493,40 @@ export class MLSService extends TypedEventEmitter<Events> {
     response.failed = response.failed ? [...response.failed, ...failedToFetchKeyPackages] : failedToFetchKeyPackages;
     return response;
   }
+
+  /**
+   * Will try to register mls group and send an empty commit to establish it.
+   *
+   * @param groupId - id of the MLS group
+   * @returns true if the client has successfully established the group, false otherwise
+   */
+  public readonly tryEstablishingMLSGroup = async (groupId: string): Promise<boolean> => {
+    this.logger.info(`Trying to establish a MLS group with id ${groupId}.`);
+
+    // Before trying to register a group, check if the group is already established locally.
+    // We could have received a welcome message in the meantime.
+    const doesMLSGroupExistLocally = await this.conversationExists(groupId);
+    if (doesMLSGroupExistLocally) {
+      this.logger.info(`MLS Group with id ${groupId} already exists, skipping the initialisation.`);
+      return false;
+    }
+
+    try {
+      await this.registerConversation(groupId, []);
+      return true;
+    } catch (error) {
+      // If conversation already existed, locally, nothing more to do, we've received a welcome message.
+      if (isCoreCryptoMLSConversationAlreadyExistsError(error)) {
+        this.logger.info(`MLS Group with id ${groupId} already exists, skipping the initialisation.`);
+        return false;
+      }
+
+      // Otherwise it's a backend error. Somebody else might have created the group in the meantime.
+      // We should wipe the group locally, wait for the welcome message or join later via external commit.
+      await this.wipeConversation(groupId);
+      return false;
+    }
+  };
 
   /**
    * Will send a removal commit for given clients


### PR DESCRIPTION
Adds a method for trying to establish a mls group for mixed conversation. This logic did previously live in webapp, but since it's plain core/mls logic, it can be moved to core package's `ConversationService`.