### PR TITLE
runfix: cancel pending proposals task on group wipe

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -316,10 +316,10 @@ export class Account extends TypedEventEmitter<Events> {
         await this.service.mls.initClient({id: userId, domain}, validClient);
       }
       // initialize schedulers for pending mls proposals once client is initialized
-      await this.service.mls.checkExistingPendingProposals();
+      await this.service.mls.initialisePendingProposalsTasks();
 
       // initialize scheduler for syncing key packages with backend
-      this.service.mls.schedulePeriodicKeyPackagesBackendSync(validClient.id);
+      await this.service.mls.schedulePeriodicKeyPackagesBackendSync(validClient.id);
 
       // leave stale conference subconversations (e.g after a crash)
       await this.service.mls.leaveStaleConferenceSubconversations();

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -604,7 +604,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   private createKeyMaterialUpdateTaskSchedulerId(groupId: string) {
-    return `renew-key-material-update-${groupId}`;
+    return `renew-key-material-update-${groupId}` as const;
   }
 
   /**
@@ -724,6 +724,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       return;
     }
     await this.cancelKeyMaterialRenewal(groupId);
+    await this.cancelPendingProposalsTask(groupId);
 
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
     return this.coreCryptoClient.wipeConversation(groupIdBytes);
@@ -759,16 +760,29 @@ export class MLSService extends TypedEventEmitter<Events> {
       const eventDate = new Date(eventTime);
       const firingDate = eventDate.setTime(eventDate.getTime() + delayInMs);
 
-      await this.coreDatabase.put('pendingProposals', {groupId, firingDate}, groupId);
-
-      TaskScheduler.addTask({
-        task: () => this.commitPendingProposals({groupId}),
-        firingDate,
-        key: groupId,
-      });
+      await this.schedulePendingProposalsTask(groupId, firingDate);
     } else {
       await this.commitPendingProposals({groupId, skipDelete: true});
     }
+  }
+
+  private async schedulePendingProposalsTask(groupId: string, firingDate: number) {
+    await this.coreDatabase.put('pendingProposals', {groupId, firingDate}, groupId);
+
+    TaskScheduler.addTask({
+      task: () => this.commitPendingProposals({groupId}),
+      firingDate,
+      key: this.createPendingProposalsTaskKey(groupId),
+    });
+  }
+
+  private async cancelPendingProposalsTask(groupId: string) {
+    TaskScheduler.cancelTask(this.createPendingProposalsTaskKey(groupId));
+    await this.coreDatabase.delete('pendingProposals', groupId);
+  }
+
+  private createPendingProposalsTaskKey(groupId: string) {
+    return `pending-proposals-${groupId}` as const;
   }
 
   /**
@@ -782,8 +796,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       await this.commitProposals(Decoder.fromBase64(groupId).asBytes);
 
       if (!skipDelete) {
-        TaskScheduler.cancelTask(groupId);
-        await this.coreDatabase.delete('pendingProposals', groupId);
+        await this.cancelPendingProposalsTask(groupId);
       }
     } catch (error) {
       this.logger.error(`Error while committing pending proposals for groupId ${groupId}`, error);
@@ -795,7 +808,7 @@ export class MLSService extends TypedEventEmitter<Events> {
    * Function must only be called once, after application start
    *
    */
-  public async checkExistingPendingProposals() {
+  public async initialisePendingProposalsTasks() {
     try {
       const pendingProposals = await this.coreDatabase.getAll('pendingProposals');
       if (pendingProposals.length > 0) {
@@ -803,7 +816,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           TaskScheduler.addTask({
             task: () => this.commitPendingProposals({groupId}),
             firingDate,
-            key: groupId,
+            key: this.createPendingProposalsTaskKey(groupId),
           }),
         );
       }


### PR DESCRIPTION
We were never clearing pending proposals tasks after MLS group was wiped. Trying to do it after we're no longer a group member could result in CoreCrypto throwing `"Conversation does not exist"` error.

This PR also improves the task key to be `pending-proposals-${groupId}` instead of just groupId. 