### PR TITLE
refactor: move subconversations logic to separate service

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -45,6 +45,7 @@ import {ClientInfo, ClientService} from './client/';
 import {ConnectionService} from './connection/';
 import {AssetService, ConversationService} from './conversation/';
 import {getQueueLength, pauseMessageSending, resumeMessageSending} from './conversation/message/messageSender';
+import {SubconversationService} from './conversation/SubconversationService/SubconversationService';
 import {GiphyService} from './giphy/';
 import {LinkPreviewService} from './linkPreview';
 import {MLSService} from './messagingProtocols/mls';
@@ -139,6 +140,7 @@ export class Account extends TypedEventEmitter<Events> {
     client: ClientService;
     connection: ConnectionService;
     conversation: ConversationService;
+    subconversation: SubconversationService;
     giphy: GiphyService;
     linkPreview: LinkPreviewService;
     notification: NotificationService;
@@ -357,7 +359,7 @@ export class Account extends TypedEventEmitter<Events> {
       await this.service.mls.schedulePeriodicKeyPackagesBackendSync(validClient.id);
 
       // leave stale conference subconversations (e.g after a crash)
-      await this.service.mls.leaveStaleConferenceSubconversations();
+      await this.service.subconversation.leaveStaleConferenceSubconversations();
     }
 
     return validClient;
@@ -435,6 +437,7 @@ export class Account extends TypedEventEmitter<Events> {
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);
     const conversationService = new ConversationService(this.apiClient, proteusService, this.db, mlsService);
+    const subconversationService = new SubconversationService(this.apiClient, mlsService);
     const notificationService = new NotificationService(this.apiClient, this.storeEngine, conversationService);
 
     const selfService = new SelfService(this.apiClient);
@@ -453,6 +456,7 @@ export class Account extends TypedEventEmitter<Events> {
       client: clientService,
       connection: connectionService,
       conversation: conversationService,
+      subconversation: subconversationService,
       giphy: giphyService,
       linkPreview: linkPreviewService,
       notification: notificationService,

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
@@ -1,0 +1,248 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {SUBCONVERSATION_ID, Subconversation} from '@wireapp/api-client/lib/conversation';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {APIClient} from '@wireapp/api-client';
+
+import {SubconversationService} from './SubconversationService';
+
+import {MLSService} from '../../messagingProtocols/mls';
+
+interface SubconversationMember {
+  client_id: string;
+  domain: string;
+  user_id: string;
+}
+
+const getSubconversationResponse = ({
+  epoch,
+  epochTimestamp,
+  parentConversationId,
+  groupId,
+  members = [],
+  subconversationId = SUBCONVERSATION_ID.CONFERENCE,
+}: {
+  epoch: number;
+  epochTimestamp: string;
+  parentConversationId: QualifiedId;
+  groupId: string;
+  members?: SubconversationMember[];
+  subconversationId?: SUBCONVERSATION_ID;
+}): Subconversation => {
+  return {
+    cipher_suite: 1,
+    epoch,
+    parent_qualified_id: parentConversationId,
+    group_id: groupId,
+    members,
+    subconv_id: subconversationId,
+    epoch_timestamp: epochTimestamp,
+  };
+};
+
+const buildSubconversationService = () => {
+  const apiClient = new APIClient({urls: APIClient.BACKEND.STAGING});
+  const mlsService = {
+    conversationExists: jest.fn(),
+    wipeConversation: jest.fn(),
+    registerConversation: jest.fn(),
+    getEpoch: jest.fn(),
+    joinByExternalCommit: jest.fn(),
+  } as unknown as MLSService;
+
+  const subconversationService = new SubconversationService(apiClient, mlsService);
+
+  return [subconversationService, {apiClient, mlsService}] as const;
+};
+
+describe('SubconversationService', () => {
+  describe('joinConferenceSubconversation', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+      jest.clearAllMocks();
+    });
+
+    it('wipes group locally (if it exists) before registering a group if remote epoch is equal 0', async () => {
+      const [subconversationService, {apiClient, mlsService}] = buildSubconversationService();
+
+      const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const subconversationGroupId = 'subconversationGroupId';
+
+      const subconversationResponse = getSubconversationResponse({
+        epoch: 0,
+        epochTimestamp: '',
+        parentConversationId,
+        groupId: subconversationGroupId,
+        subconversationId: SUBCONVERSATION_ID.CONFERENCE,
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
+
+      await subconversationService.joinConferenceSubconversation(parentConversationId);
+
+      expect(mlsService.wipeConversation).toHaveBeenCalledWith(subconversationGroupId);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+    });
+
+    it('registers a group if remote epoch is 0 and group does not exist locally', async () => {
+      const [subconversationService, {apiClient, mlsService}] = buildSubconversationService();
+
+      const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const subconversationGroupId = 'subconversationGroupId';
+
+      const subconversationResponse = getSubconversationResponse({
+        epoch: 0,
+        epochTimestamp: '',
+        parentConversationId,
+        groupId: subconversationGroupId,
+        subconversationId: SUBCONVERSATION_ID.CONFERENCE,
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
+
+      await subconversationService.joinConferenceSubconversation(parentConversationId);
+
+      expect(mlsService.wipeConversation).not.toHaveBeenCalled();
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+    });
+
+    it('deletes conference subconversation from backend if group is already established and epoch is older than one day, then rejoins', async () => {
+      jest.useFakeTimers();
+      const [subconversationService, {apiClient, mlsService}] = buildSubconversationService();
+
+      const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const subconversationGroupId = 'subconversationGroupId';
+      const initialSubconversationEpoch = 1;
+
+      const currentTimeISO = '2023-10-24T12:00:00.000Z';
+      jest.setSystemTime(new Date(currentTimeISO));
+
+      jest.spyOn(apiClient.api.conversation, 'deleteSubconversation').mockResolvedValueOnce();
+
+      // epoch time is older than 24h
+      const epochTimestamp = '2023-10-23T11:00:00.000Z';
+
+      const subconversationResponse = getSubconversationResponse({
+        epoch: initialSubconversationEpoch,
+        epochTimestamp: epochTimestamp,
+        parentConversationId,
+        groupId: subconversationGroupId,
+        subconversationId: SUBCONVERSATION_ID.CONFERENCE,
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
+
+      // After deletion, epoch is 0
+      const subconversationEpochAfterDeletion = 0;
+      const subconversationResponse2 = getSubconversationResponse({
+        epoch: subconversationEpochAfterDeletion,
+        epochTimestamp: epochTimestamp,
+        parentConversationId,
+        groupId: subconversationGroupId,
+        subconversationId: SUBCONVERSATION_ID.CONFERENCE,
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse2);
+
+      await subconversationService.joinConferenceSubconversation(parentConversationId);
+
+      expect(apiClient.api.conversation.deleteSubconversation).toHaveBeenCalledWith(
+        parentConversationId,
+        SUBCONVERSATION_ID.CONFERENCE,
+        {
+          groupId: subconversationGroupId,
+          epoch: initialSubconversationEpoch,
+        },
+      );
+
+      expect(mlsService.registerConversation).toHaveBeenCalledTimes(1);
+      expect(mlsService.wipeConversation).toHaveBeenCalledWith(subconversationGroupId);
+    });
+
+    it('joins conference subconversation with external commit if group is already established and epoch is younger than one day', async () => {
+      jest.useFakeTimers();
+      const [subconversationService, {apiClient, mlsService}] = buildSubconversationService();
+
+      const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const subconversationGroupId = 'subconversationGroupId';
+      const subconversationEpoch = 1;
+
+      const currentTimeISO = '2023-10-24T12:00:00.000Z';
+      jest.setSystemTime(new Date(currentTimeISO));
+
+      jest.spyOn(apiClient.api.conversation, 'deleteSubconversation').mockResolvedValueOnce();
+
+      // epoch time is younger than 24h
+      const epochTimestamp = '2023-10-23T13:00:00.000Z';
+
+      const subconversationResponse = getSubconversationResponse({
+        epoch: subconversationEpoch,
+        epochTimestamp: epochTimestamp,
+        parentConversationId,
+        groupId: subconversationGroupId,
+        subconversationId: SUBCONVERSATION_ID.CONFERENCE,
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
+
+      await subconversationService.joinConferenceSubconversation(parentConversationId);
+
+      expect(apiClient.api.conversation.deleteSubconversation).not.toHaveBeenCalled();
+      expect(mlsService.registerConversation).not.toHaveBeenCalled();
+      expect(mlsService.wipeConversation).not.toHaveBeenCalled();
+      expect(mlsService.joinByExternalCommit).toHaveBeenCalled();
+    });
+
+    it('returns fresh epoch number after joining the group', async () => {
+      const [subconversationService, {apiClient, mlsService}] = buildSubconversationService();
+
+      const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const subconversationGroupId = 'subconversationGroupId';
+
+      const subconversationResponse = getSubconversationResponse({
+        epoch: 0,
+        epochTimestamp: '',
+        parentConversationId,
+        groupId: subconversationGroupId,
+        subconversationId: SUBCONVERSATION_ID.CONFERENCE,
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
+
+      const updatedEpoch = 1;
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(updatedEpoch);
+
+      const response = await subconversationService.joinConferenceSubconversation(parentConversationId);
+
+      expect(mlsService.wipeConversation).not.toHaveBeenCalled();
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+      expect(response).toEqual({epoch: updatedEpoch, groupId: subconversationGroupId});
+    });
+  });
+  describe('leaveConferenceSubconversation', () => {});
+  describe('leaveStaleConferenceSubconversations', () => {});
+  describe('getSubconversationEpochInfo', () => {});
+  describe('subscribeToEpochUpdates', () => {});
+  describe('removeClientFromConferenceSubconversation', () => {});
+});

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -1,0 +1,165 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {SUBCONVERSATION_ID, Subconversation} from '@wireapp/api-client/lib/conversation';
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
+import logdown from 'logdown';
+
+import {APIClient} from '@wireapp/api-client';
+import {TypedEventEmitter} from '@wireapp/commons';
+
+import {MLSService} from '../../messagingProtocols/mls';
+import {subconversationGroupIdStore} from '../../messagingProtocols/mls/MLSService/stores/subconversationGroupIdStore/subconversationGroupIdStore';
+
+type Events = {
+  MLSConversationRecovered: {conversationId: QualifiedId};
+};
+
+export interface SubconversationEpochInfoMember {
+  userid: `${string}@${string}`;
+  clientid: string;
+  in_subconv: boolean;
+}
+
+export class SubconversationService extends TypedEventEmitter<Events> {
+  private readonly logger = logdown('@wireapp/core/SubconversationService');
+
+  constructor(
+    private readonly apiClient: APIClient,
+    private readonly _mlsService?: MLSService,
+  ) {
+    super();
+  }
+
+  get mlsService(): MLSService {
+    if (!this._mlsService) {
+      throw new Error('MLSService was not initialised!');
+    }
+    return this._mlsService;
+  }
+
+  public async joinSubconversationByExternalCommit(conversationId: QualifiedId, subconversation: SUBCONVERSATION_ID) {
+    await this.mlsService.joinByExternalCommit(() =>
+      this.apiClient.api.conversation.getSubconversationGroupInfo(conversationId, subconversation),
+    );
+  }
+
+  public async getConferenceSubconversation(conversationId: QualifiedId): Promise<Subconversation> {
+    return this.apiClient.api.conversation.getSubconversation(conversationId, SUBCONVERSATION_ID.CONFERENCE);
+  }
+
+  private async deleteConferenceSubconversation(
+    conversationId: QualifiedId,
+    data: {groupId: string; epoch: number},
+  ): Promise<void> {
+    return this.apiClient.api.conversation.deleteSubconversation(conversationId, SUBCONVERSATION_ID.CONFERENCE, data);
+  }
+
+  /**
+   * Will join or register an mls subconversation for conference calls.
+   * Will return the secret key derived from the subconversation
+   *
+   * @param conversationId Id of the parent conversation in which the call should happen
+   */
+  public async joinConferenceSubconversation(conversationId: QualifiedId): Promise<{groupId: string; epoch: number}> {
+    const {
+      group_id: subconversationGroupId,
+      epoch: subconversationEpoch,
+      epoch_timestamp: subconversationEpochTimestamp,
+      subconv_id: subconversationId,
+    } = await this.getConferenceSubconversation(conversationId);
+
+    if (subconversationEpoch === 0) {
+      const doesConversationExistsLocally = await this.mlsService.conversationExists(subconversationGroupId);
+      if (doesConversationExistsLocally) {
+        await this.mlsService.wipeConversation(subconversationGroupId);
+      }
+
+      // If subconversation is not yet established, create it and upload the commit bundle.
+      await this.mlsService.registerConversation(subconversationGroupId, []);
+    } else {
+      const epochUpdateTime = new Date(subconversationEpochTimestamp).getTime();
+      const epochAge = new Date().getTime() - epochUpdateTime;
+
+      if (epochAge > TimeInMillis.DAY) {
+        // If subconversation does exist, but it's older than 24h, delete and re-join
+        await this.deleteConferenceSubconversation(conversationId, {
+          groupId: subconversationGroupId,
+          epoch: subconversationEpoch,
+        });
+        await this.mlsService.wipeConversation(subconversationGroupId);
+
+        return this.joinConferenceSubconversation(conversationId);
+      }
+
+      await this.joinSubconversationByExternalCommit(conversationId, SUBCONVERSATION_ID.CONFERENCE);
+    }
+
+    const epoch = Number(await this.mlsService.getEpoch(subconversationGroupId));
+
+    // We store the mapping between the subconversation and the parent conversation
+    subconversationGroupIdStore.storeGroupId(conversationId, subconversationId, subconversationGroupId);
+
+    return {groupId: subconversationGroupId, epoch};
+  }
+
+  /**
+   * Will leave conference subconversation if it's known by client and established.
+   *
+   * @param conversationId Id of the parent conversation which subconversation we want to leave
+   */
+  public async leaveConferenceSubconversation(conversationId: QualifiedId): Promise<void> {
+    const subconversationGroupId = subconversationGroupIdStore.getGroupId(
+      conversationId,
+      SUBCONVERSATION_ID.CONFERENCE,
+    );
+
+    if (!subconversationGroupId) {
+      return;
+    }
+
+    const isSubconversationEstablished = await this.mlsService.conversationExists(subconversationGroupId);
+    if (!isSubconversationEstablished) {
+      // if the subconversation was known by a client but is not established anymore, we can remove it from the store
+      return subconversationGroupIdStore.removeGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
+    }
+
+    try {
+      await this.apiClient.api.conversation.deleteSubconversationSelf(conversationId, SUBCONVERSATION_ID.CONFERENCE);
+    } catch (error) {
+      this.logger.error(`Failed to leave conference subconversation:`, error);
+    }
+
+    await this.mlsService.wipeConversation(subconversationGroupId);
+
+    // once we've left the subconversation, we can remove it from the store
+    subconversationGroupIdStore.removeGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
+  }
+
+  public async leaveStaleConferenceSubconversations(): Promise<void> {
+    const conversationIds = subconversationGroupIdStore.getAllGroupIdsBySubconversationId(
+      SUBCONVERSATION_ID.CONFERENCE,
+    );
+
+    for (const {parentConversationId} of conversationIds) {
+      await this.leaveConferenceSubconversation(parentConversationId);
+    }
+  }
+}

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -55,13 +55,13 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     return this._mlsService;
   }
 
-  public async joinSubconversationByExternalCommit(conversationId: QualifiedId, subconversation: SUBCONVERSATION_ID) {
+  private async joinSubconversationByExternalCommit(conversationId: QualifiedId, subconversation: SUBCONVERSATION_ID) {
     await this.mlsService.joinByExternalCommit(() =>
       this.apiClient.api.conversation.getSubconversationGroupInfo(conversationId, subconversation),
     );
   }
 
-  public async getConferenceSubconversation(conversationId: QualifiedId): Promise<Subconversation> {
+  private async getConferenceSubconversation(conversationId: QualifiedId): Promise<Subconversation> {
     return this.apiClient.api.conversation.getSubconversation(conversationId, SUBCONVERSATION_ID.CONFERENCE);
   }
 

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -131,9 +131,9 @@ export class SubconversationService extends TypedEventEmitter<Events> {
       return;
     }
 
-    const isSubconversationEstablished = await this.mlsService.conversationExists(subconversationGroupId);
-    if (!isSubconversationEstablished) {
-      // if the subconversation was known by a client but is not established anymore, we can remove it from the store
+    const doesGroupExistLocally = await this.mlsService.conversationExists(subconversationGroupId);
+    if (!doesGroupExistLocally) {
+      // If the subconversation was known by a client but is does not exist locally, we can remove it from the store.
       return subconversationGroupIdStore.removeGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
     }
 


### PR DESCRIPTION
Moves subconversations related logic to new `SubconversationService`. 
Also adds some logic that previously lived on webapp side.

Added a bunch of test cases.