### PR TITLE
feat: add get supported protocols to user service

### DIFF
--- a/packages/core/src/self/SelfService.test.ts
+++ b/packages/core/src/self/SelfService.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
+
+import {APIClient} from '@wireapp/api-client';
+
+import {SelfService} from './SelfService';
+
+const BASE_URL = 'mock-backend.wire.com';
+const MOCK_BACKEND = {
+  name: 'mock',
+  rest: `https://${BASE_URL}`,
+  ws: `wss://${BASE_URL}`,
+};
+
+describe('SelfService', () => {
+  describe('putSupportedProtocols', () => {
+    it('updates the list of self supported protocols', async () => {
+      const apiClient = new APIClient({urls: MOCK_BACKEND});
+
+      const selfService = new SelfService(apiClient);
+
+      const supportedProtocols = [ConversationProtocol.PROTEUS, ConversationProtocol.MLS];
+
+      jest.spyOn(apiClient.api.self, 'putSupportedProtocols').mockImplementation(jest.fn());
+
+      await selfService.putSupportedProtocols(supportedProtocols);
+
+      expect(apiClient.api.self.putSupportedProtocols).toHaveBeenCalledWith(supportedProtocols);
+    });
+
+    it('throws if supported protocols list is not provided', async () => {
+      const apiClient = new APIClient({urls: MOCK_BACKEND});
+
+      const selfService = new SelfService(apiClient);
+
+      const supportedProtocols = undefined as any;
+
+      jest.spyOn(apiClient.api.self, 'putSupportedProtocols').mockImplementation(jest.fn());
+
+      await expect(() => selfService.putSupportedProtocols(supportedProtocols)).rejects.toThrow(
+        'Supported protocols must be a non-empty array',
+      );
+    });
+
+    it('throws if supported protocols list is empty', async () => {
+      const apiClient = new APIClient({urls: MOCK_BACKEND});
+
+      const selfService = new SelfService(apiClient);
+
+      const supportedProtocols: ConversationProtocol[] = [];
+
+      jest.spyOn(apiClient.api.self, 'putSupportedProtocols').mockImplementation(jest.fn());
+
+      await expect(() => selfService.putSupportedProtocols(supportedProtocols)).rejects.toThrow(
+        'Supported protocols must be a non-empty array',
+      );
+    });
+  });
+});

--- a/packages/core/src/self/SelfService.test.ts
+++ b/packages/core/src/self/SelfService.test.ts
@@ -32,9 +32,10 @@ const MOCK_BACKEND = {
 
 describe('SelfService', () => {
   describe('putSupportedProtocols', () => {
-    it('updates the list of self supported protocols', async () => {
-      const apiClient = new APIClient({urls: MOCK_BACKEND});
+    const apiClient = new APIClient({urls: MOCK_BACKEND});
+    apiClient.backendFeatures.supportsMLS = true;
 
+    it('updates the list of self supported protocols', async () => {
       const selfService = new SelfService(apiClient);
 
       const supportedProtocols = [ConversationProtocol.PROTEUS, ConversationProtocol.MLS];
@@ -47,8 +48,6 @@ describe('SelfService', () => {
     });
 
     it('throws if supported protocols list is not provided', async () => {
-      const apiClient = new APIClient({urls: MOCK_BACKEND});
-
       const selfService = new SelfService(apiClient);
 
       const supportedProtocols = undefined as any;
@@ -56,13 +55,11 @@ describe('SelfService', () => {
       jest.spyOn(apiClient.api.self, 'putSupportedProtocols').mockImplementation(jest.fn());
 
       await expect(() => selfService.putSupportedProtocols(supportedProtocols)).rejects.toThrow(
-        'Supported protocols must be a non-empty array',
+        'Supported protocols must be a non-empty protocols list',
       );
     });
 
     it('throws if supported protocols list is empty', async () => {
-      const apiClient = new APIClient({urls: MOCK_BACKEND});
-
       const selfService = new SelfService(apiClient);
 
       const supportedProtocols: ConversationProtocol[] = [];
@@ -70,7 +67,7 @@ describe('SelfService', () => {
       jest.spyOn(apiClient.api.self, 'putSupportedProtocols').mockImplementation(jest.fn());
 
       await expect(() => selfService.putSupportedProtocols(supportedProtocols)).rejects.toThrow(
-        'Supported protocols must be a non-empty array',
+        'Supported protocols must be a non-empty protocols list',
       );
     });
   });

--- a/packages/core/src/self/SelfService.ts
+++ b/packages/core/src/self/SelfService.ts
@@ -65,7 +65,7 @@ export class SelfService {
    */
   public async putSupportedProtocols(supportedProtocols: ConversationProtocol[]) {
     if (!supportedProtocols || supportedProtocols.length === 0) {
-      throw new Error('Supported protocols must be a non-empty array');
+      throw new Error('Supported protocols must be a non-empty protocols list');
     }
 
     return this.apiClient.api.self.putSupportedProtocols(supportedProtocols);

--- a/packages/core/src/self/SelfService.ts
+++ b/packages/core/src/self/SelfService.ts
@@ -19,10 +19,13 @@
 
 import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {Self} from '@wireapp/api-client/lib/self/';
+import logdown from 'logdown';
 
 import {APIClient} from '@wireapp/api-client';
 
 export class SelfService {
+  private readonly logger = logdown('@wireapp/core/SelfService');
+
   constructor(private readonly apiClient: APIClient) {}
 
   public async checkUsername(username: string): Promise<boolean> {
@@ -64,6 +67,11 @@ export class SelfService {
    * @param supportedProtocols The list of supported protocols
    */
   public async putSupportedProtocols(supportedProtocols: ConversationProtocol[]) {
+    if (!this.apiClient.backendFeatures.supportsMLS) {
+      this.logger.warn('Self supported protocols were not updated, because endpoint is not supported by backend');
+      return;
+    }
+
     if (!supportedProtocols || supportedProtocols.length === 0) {
       throw new Error('Supported protocols must be a non-empty protocols list');
     }

--- a/packages/core/src/self/SelfService.ts
+++ b/packages/core/src/self/SelfService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {Self} from '@wireapp/api-client/lib/self/';
 
 import {APIClient} from '@wireapp/api-client';
@@ -56,5 +57,17 @@ export class SelfService {
 
   public setUsername(username: string): Promise<void> {
     return this.apiClient.api.self.putHandle({handle: username});
+  }
+
+  /**
+   * Update self user's list of supported-protocols
+   * @param supportedProtocols The list of supported protocols
+   */
+  public async putSupportedProtocols(supportedProtocols: ConversationProtocol[]) {
+    if (!supportedProtocols || supportedProtocols.length === 0) {
+      throw new Error('Supported protocols must be a non-empty array');
+    }
+
+    return this.apiClient.api.self.putSupportedProtocols(supportedProtocols);
   }
 }

--- a/packages/core/src/user/UserService.ts
+++ b/packages/core/src/user/UserService.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import {ConversationProtocol} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId, User} from '@wireapp/api-client/lib/user/';
 
 import {APIClient} from '@wireapp/api-client';
@@ -37,5 +38,18 @@ export class UserService {
       return [];
     }
     return this.apiClient.api.user.postListUsers({qualified_ids: userIds});
+  }
+
+  /**
+   * Get the list of other user's supported protocols.
+   */
+  public async getUserSupportedProtocols(userId: QualifiedId): Promise<ConversationProtocol[]> {
+    // Clients that uses version below the one supporting MLS, are not aware of user's supported protocols, we default to Proteus in this case.
+    if (!this.apiClient.backendFeatures.supportsMLS) {
+      return [ConversationProtocol.PROTEUS];
+    }
+
+    const supportedProtocols = await this.apiClient.api.user.getUserSupportedProtocols(userId);
+    return supportedProtocols.length > 0 ? supportedProtocols : [ConversationProtocol.PROTEUS];
   }
 }


### PR DESCRIPTION
Adds a method for fetching other user's supported protocols to `UserService` so we don't have to maintain any logic on consumer (webapp) side and we do not call apiClient directly.