### PR TITLE
runfix(api-client): unlock socket after method is done executing

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -415,13 +415,16 @@ export class APIClient extends EventEmitter {
    */
   public withLockedWebSocket<T extends (...args: any[]) => any>(
     callback: T,
-  ): (...args: Parameters<T>) => ReturnType<T> {
-    return (...args: Parameters<T>): ReturnType<T> => {
+  ): (...args: Parameters<T>) => Promise<ReturnType<T>> {
+    return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
       this.transport.ws.lock();
       try {
-        return callback(...args);
-      } finally {
+        const result = await callback(...args);
         this.transport.ws.unlock();
+        return result;
+      } catch (error) {
+        this.transport.ws.unlock();
+        throw error;
       }
     };
   }


### PR DESCRIPTION
TIL: `finally` block does execute **BEFORE** `return` or `throw` statements are executed in `try`/`catch` block.
We want to make sure wrapped callback is completely done executing before unlocking the socket.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch#the_finally_block

<img width="123" alt="Screenshot 2023-11-21 at 10 20 56" src="https://github.com/wireapp/wire-web-packages/assets/45733298/71df4e73-ea4a-453e-bef7-8061f8e792f7">
