### PR TITLE
fix: upload of publicKeys in case of active E2EI

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -234,6 +234,7 @@ export class Account extends TypedEventEmitter<Events> {
     displayName: string,
     handle: string,
     discoveryUrl: string,
+    client: RegisteredClient,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
@@ -255,7 +256,7 @@ export class Account extends TypedEventEmitter<Events> {
       discoveryUrl,
       this.service.e2eIdentity,
       user,
-      this.clientId,
+      client,
       this.nbPrekeys,
       oAuthIdToken,
     );


### PR DESCRIPTION
Upload of prekeys was broken in case of a new client and active E2EI

This fixes it.