### PR TITLE
fix: Keep local instance of the registered client

### DIFF
--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -18,7 +18,7 @@
  */
 
 import {AuthAPI} from '@wireapp/api-client/lib/auth';
-import {ClientAPI, ClientType, RegisteredClient} from '@wireapp/api-client/lib/client';
+import {ClientAPI, ClientClassification, ClientType, RegisteredClient} from '@wireapp/api-client/lib/client';
 import {ConversationAPI} from '@wireapp/api-client/lib/conversation';
 import {BackendEvent, CONVERSATION_EVENT} from '@wireapp/api-client/lib/event';
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
@@ -161,6 +161,14 @@ describe('Account', () => {
     cleanAll();
   });
 
+  const currentClient: RegisteredClient = {
+    id: CLIENT_ID,
+    cookie: '',
+    time: '',
+    type: ClientType.TEMPORARY,
+    class: ClientClassification.DESKTOP,
+    mls_public_keys: {},
+  };
   describe('"init"', () => {
     it('initializes the Protocol buffers', async () => {
       const account = new Account();
@@ -227,6 +235,7 @@ describe('Account', () => {
         email: 'hello@example.com',
         password: 'my-secret',
       });
+      account['currentClient'] = currentClient;
 
       jest.spyOn(apiClient, 'connect').mockImplementation();
       jest.spyOn(account.service!.notification as any, 'handleEvent').mockReturnValue({
@@ -282,11 +291,13 @@ describe('Account', () => {
 
     beforeEach(async () => {
       dependencies = await createAccount();
-      await dependencies.account.login({
+      const {account} = dependencies;
+      await account.login({
         clientType: ClientType.TEMPORARY,
         email: 'hello@example.com',
         password: 'my-secret',
       });
+      account['currentClient'] = currentClient;
       jest
         .spyOn(dependencies.account.service!.notification, 'handleNotification')
         .mockImplementation(notif => notif.payload as any);

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -130,6 +130,7 @@ export class Account extends TypedEventEmitter<Events> {
   private readonly nbPrekeys: number;
   private readonly cryptoProtocolConfig?: CryptoProtocolConfig;
   private readonly isMlsEnabled: () => Promise<boolean>;
+  private currentClient?: RegisteredClient;
   private storeEngine?: CRUDEngine;
   private db?: CoreDatabase;
   private coreCallbacks?: CoreCallbacks;
@@ -234,11 +235,14 @@ export class Account extends TypedEventEmitter<Events> {
     displayName: string,
     handle: string,
     discoveryUrl: string,
-    client: RegisteredClient,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
     const domain = context?.domain ?? '';
+
+    if (!this.currentClient) {
+      throw new Error('Client has not been initialized - please login first');
+    }
 
     if (!this.service?.mls || !this.service?.e2eIdentity) {
       this.logger.info('MLS not initialized, unable to enroll E2EI');
@@ -256,7 +260,7 @@ export class Account extends TypedEventEmitter<Events> {
       discoveryUrl,
       this.service.e2eIdentity,
       user,
-      client,
+      this.currentClient,
       this.nbPrekeys,
       oAuthIdToken,
     );
@@ -387,6 +391,7 @@ export class Account extends TypedEventEmitter<Events> {
       await this.service.subconversation.leaveStaleConferenceSubconversations();
     }
 
+    this.currentClient = validClient;
     return validClient;
   }
 
@@ -498,6 +503,7 @@ export class Account extends TypedEventEmitter<Events> {
   }
 
   private resetContext(): void {
+    this.currentClient = undefined;
     delete this.apiClient.context;
     delete this.service;
   }
@@ -570,8 +576,8 @@ export class Account extends TypedEventEmitter<Events> {
      */
     dryRun?: boolean;
   } = {}): () => void {
-    if (!this.apiClient.context) {
-      throw new Error('Context is not set - please login first');
+    if (!this.currentClient) {
+      throw new Error('Client has not been initialized - please login first');
     }
 
     const handleEvent = async (payload: HandledEventPayload, source: NotificationSource) => {

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -130,6 +130,7 @@ export class Account extends TypedEventEmitter<Events> {
   private readonly nbPrekeys: number;
   private readonly cryptoProtocolConfig?: CryptoProtocolConfig;
   private readonly isMlsEnabled: () => Promise<boolean>;
+  /** this is the client the consumer is currently using. Will be set as soon as `initClient` is called and will be rest upon logout */
   private currentClient?: RegisteredClient;
   private storeEngine?: CRUDEngine;
   private db?: CoreDatabase;


### PR DESCRIPTION
The entire `client` is needed to enroll for E2EI. But the consumer doesn't necessarily need to store this client, so the core can hold on to it and keep it around when enrolling later on