### PR TITLE
feat: add export for webapp to check if the current mlsClient is a new one

### DIFF
--- a/packages/api-client/src/client/ClientAPI.ts
+++ b/packages/api-client/src/client/ClientAPI.ts
@@ -37,10 +37,13 @@ export type ClaimedKeyPackages = {
   }[];
 };
 
-type PublicKeys = {
-  removal: {
-    [algorithm: string]: string;
-  };
+export enum MLSPublicKeyAlgorithmKeys {
+  ED25519 = 'ed25519',
+}
+export type MLSPublicKeyRecord = Partial<Record<MLSPublicKeyAlgorithmKeys, string>>;
+
+type GetMLSPublicKeysResponseData = {
+  removal: MLSPublicKeyRecord;
 };
 
 export class ClientAPI {
@@ -234,13 +237,13 @@ export class ClientAPI {
    * In the future this may be used for other purposes as well.
    * @see https://staging-nginz-https.zinfra.io/api/swagger-ui/#/default/get_mls_public_keys
    */
-  public async getPublicKeys(): Promise<PublicKeys> {
+  public async getPublicKeys(): Promise<GetMLSPublicKeysResponseData> {
     const config: AxiosRequestConfig = {
       method: 'GET',
       url: `/${ClientAPI.URL.MLS_CLIENTS}/${ClientAPI.URL.PUBLIC_KEYS}`,
     };
 
-    const response = await this.client.sendJSON<PublicKeys>(config, true);
+    const response = await this.client.sendJSON<GetMLSPublicKeysResponseData>(config, true);
     return response.data;
   }
 

--- a/packages/api-client/src/client/NewClient.ts
+++ b/packages/api-client/src/client/NewClient.ts
@@ -21,13 +21,11 @@ import {ClientCapabilityData} from './ClientCapabilityData';
 
 import {PreKey} from '../auth/';
 
-import {ClientClassification, ClientType, Location} from './';
+import {ClientClassification, ClientType, Location, MLSPublicKeyRecord} from './';
 
 type BaseUpdatePayload = ClientCapabilityData & {label?: string};
 type MLSUpdatePayload = {
-  mls_public_keys: {
-    ed25519: string;
-  };
+  mls_public_keys: MLSPublicKeyRecord;
 } & BaseUpdatePayload;
 
 type ProteusUpdatePayload = {

--- a/packages/api-client/src/client/RegisteredClient.ts
+++ b/packages/api-client/src/client/RegisteredClient.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {ClientType, Location, PublicClient} from './';
+import {ClientType, Location, MLSPublicKeyRecord, PublicClient} from './';
 
 export interface AddedClient extends PublicClient {
   /** The IP address from which the client was registered */
@@ -28,7 +28,7 @@ export interface AddedClient extends PublicClient {
   /** An ISO 8601 Date string */
   time: string;
   type: ClientType.PERMANENT | ClientType.TEMPORARY;
-  mls_public_keys: Record<string, string>;
+  mls_public_keys: MLSPublicKeyRecord;
   last_active?: string;
 }
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -445,19 +445,6 @@ export class Account extends TypedEventEmitter<Events> {
     let mlsService: MLSService | undefined;
     let e2eIdentityService: E2EIServiceExternal | undefined;
 
-    if (clientType === CryptoClientType.CORE_CRYPTO && (await this.isMlsEnabled())) {
-      e2eIdentityService = new E2EIServiceExternal(cryptoClient.getNativeClient());
-      mlsService = new MLSService(
-        this.apiClient,
-        cryptoClient.getNativeClient(),
-        this.db,
-        this.recurringTaskScheduler,
-        {
-          ...this.cryptoProtocolConfig?.mls,
-        },
-      );
-    }
-
     const proteusService = new ProteusService(this.apiClient, cryptoClient, {
       onNewClient: payload => this.emit(EVENTS.NEW_SESSION, payload),
       nbPrekeys: this.nbPrekeys,
@@ -482,6 +469,19 @@ export class Account extends TypedEventEmitter<Events> {
 
     const broadcastService = new BroadcastService(this.apiClient, proteusService);
     const userService = new UserService(this.apiClient);
+
+    if (clientType === CryptoClientType.CORE_CRYPTO && (await this.isMlsEnabled())) {
+      e2eIdentityService = new E2EIServiceExternal(cryptoClient.getNativeClient(), clientService);
+      mlsService = new MLSService(
+        this.apiClient,
+        cryptoClient.getNativeClient(),
+        this.db,
+        this.recurringTaskScheduler,
+        {
+          ...this.cryptoProtocolConfig?.mls,
+        },
+      );
+    }
 
     this.service = {
       e2eIdentity: e2eIdentityService,

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
@@ -21,12 +21,16 @@ import {CoreCrypto, WireIdentity} from '@wireapp/core-crypto';
 
 import {E2EIServiceExternal} from './E2EIServiceExternal';
 
+import {ClientService} from '../../../client';
+
 function buildE2EIService() {
   const coreCrypto = {
     getUserIdentities: jest.fn(),
   } as unknown as jest.Mocked<CoreCrypto>;
 
-  return [new E2EIServiceExternal(coreCrypto), {coreCrypto}] as const;
+  const clientService = {} as jest.Mocked<ClientService>;
+
+  return [new E2EIServiceExternal(coreCrypto, clientService), {coreCrypto}] as const;
 }
 
 function generateCoreCryptoIdentity({status = 'Valid', deviceId = 'aaaaa'}: {status?: string; deviceId?: string} = {}) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -26,6 +26,7 @@ import {Ciphersuite, CoreCrypto, E2eiConversationState, WireIdentity} from '@wir
 import {getE2EIClientId, uuidTobase64url} from './Helper';
 import {E2EIStorage} from './Storage/E2EIStorage';
 
+import {ClientService} from '../../../client';
 import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUtils';
 
 export type DeviceIdentity = Omit<WireIdentity, 'free'> & {deviceId: string};
@@ -34,7 +35,10 @@ export type DeviceIdentity = Omit<WireIdentity, 'free'> & {deviceId: string};
 export class E2EIServiceExternal {
   private readonly logger = logdown('@wireapp/core/E2EIdentityServiceExternal');
 
-  public constructor(private coreCryptoClient: CoreCrypto) {}
+  public constructor(
+    private readonly coreCryptoClient: CoreCrypto,
+    private readonly clientService: ClientService,
+  ) {}
 
   // Checks if there is a certificate stored in the local storage
   public hasActiveCertificate(): boolean {
@@ -112,5 +116,10 @@ export class E2EIServiceExternal {
       ...identity,
       deviceId: parseFullQualifiedClientId((identity as any).client_id).client,
     }));
+  }
+
+  public async isFreshMLSSelfClient(): Promise<boolean> {
+    const client = await this.clientService.loadClient();
+    return !!client && typeof client.mls_public_keys.ed25519 === 'string' && client.mls_public_keys.ed25519.length > 0;
   }
 }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -85,7 +85,7 @@ describe('MLSService', () => {
       apiClient = mockApiClient;
       jest
         .spyOn(apiClient.api.client, 'getPublicKeys')
-        .mockResolvedValue({removal: {algo: 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm3OQFc='}});
+        .mockResolvedValue({removal: {ed25519: 'mXOagqRIX/RFd7QyXJA8/Ed8X+hvQgLXIiwYHm3OQFc='}});
 
       jest.spyOn(apiClient.api.client, 'claimMLSKeyPackages').mockResolvedValue({key_packages: []});
       jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation();

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -598,7 +598,7 @@ export class MLSService extends TypedEventEmitter<Events> {
    */
   private async uploadMLSPublicKeys(client: RegisteredClient) {
     // If we've already updated a client with its public key, there's no need to do it again.
-    if (client.mls_public_keys?.ed25519) {
+    if (typeof client.mls_public_keys.ed25519 === 'string' && client.mls_public_keys.ed25519.length > 0) {
       return;
     }
 


### PR DESCRIPTION
We have a problem in the webapp, in the case of active E2EI, that we need to know if the current client is a fresh client.

This PR adds a function to E2EIServiceExternal to solve this issue for consumers.

This PR also enhances the typing of the MLSPublicKeys, which are used to determine if a client is freshly created or already in use.

