### PR TITLE
feat(E2EI): add possibility to rotate a active certificate 

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -232,13 +232,19 @@ export class Account extends TypedEventEmitter<Events> {
     };
   }
 
-  public async enrollE2EI(
-    displayName: string,
-    handle: string,
-    discoveryUrl: string,
-    refreshActiveCertificate?: boolean,
-    oAuthIdToken?: string,
-  ): Promise<AcmeChallenge | boolean> {
+  public async enrollE2EI({
+    displayName,
+    handle,
+    discoveryUrl,
+    refreshActiveCertificate = false,
+    oAuthIdToken,
+  }: {
+    displayName: string;
+    handle: string;
+    discoveryUrl: string;
+    refreshActiveCertificate?: boolean;
+    oAuthIdToken?: string;
+  }): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
     const domain = context?.domain ?? '';
 
@@ -264,7 +270,7 @@ export class Account extends TypedEventEmitter<Events> {
       user,
       this.currentClient,
       this.nbPrekeys,
-      refreshActiveCertificate ?? false,
+      refreshActiveCertificate,
       oAuthIdToken,
     );
   }

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -236,6 +236,7 @@ export class Account extends TypedEventEmitter<Events> {
     displayName: string,
     handle: string,
     discoveryUrl: string,
+    refreshActiveCertificate?: boolean,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
@@ -263,6 +264,7 @@ export class Account extends TypedEventEmitter<Events> {
       user,
       this.currentClient,
       this.nbPrekeys,
+      refreshActiveCertificate ?? false,
       oAuthIdToken,
     );
   }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -772,6 +772,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     user: User,
     client: RegisteredClient,
     nbPrekeys: number,
+    refreshActiveCertificate: boolean,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     try {
@@ -785,7 +786,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         keyPackagesAmount: nbPrekeys,
       });
       if (!oAuthIdToken) {
-        const challengeData = await instance.startCertificateProcess();
+        const challengeData = await instance.startCertificateProcess(refreshActiveCertificate);
         if (challengeData) {
           return challengeData;
         }


### PR DESCRIPTION
The current E2EI enrollment only supported fresh clients. This change adds the possibility to rotate existing certificates (for renewal).