### PR TITLE
runfix: include clientId on last notification api call

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -325,15 +325,16 @@ export class Account extends TypedEventEmitter<Events> {
     const initialPreKeys = await this.service.proteus.createClient(entropyData);
 
     const client = await this.service.client.register(loginData, clientInfo, initialPreKeys);
+    const clientId = client.id;
 
     if (this.service.mls) {
       const {userId, domain = ''} = this.apiClient.context;
       await this.initMLSClient({id: userId, domain}, client);
     }
-    this.logger.info(`Created new client {mls: ${!!this.service.mls}, id: ${client.id}}`);
+    this.logger.info(`Created new client {mls: ${!!this.service.mls}, id: ${clientId}}`);
 
-    await this.service.notification.initializeNotificationStream();
-    await this.service.client.synchronizeClients(client.id);
+    await this.service.notification.initializeNotificationStream(clientId);
+    await this.service.client.synchronizeClients(clientId);
 
     return this.initClient(client);
   }

--- a/packages/core/src/notification/NotificationService.ts
+++ b/packages/core/src/notification/NotificationService.ts
@@ -96,8 +96,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
   }
 
   /** Should only be called with a completely new client. */
-  public async initializeNotificationStream(): Promise<string> {
-    const clientId = this.apiClient.clientId;
+  public async initializeNotificationStream(clientId?: string): Promise<string> {
     await this.setLastEventDate(new Date(0));
     const latestNotification = await this.backend.getLastNotification(clientId);
     return this.setLastNotificationId(latestNotification);

--- a/packages/core/src/notification/NotificationService.ts
+++ b/packages/core/src/notification/NotificationService.ts
@@ -96,7 +96,7 @@ export class NotificationService extends TypedEventEmitter<Events> {
   }
 
   /** Should only be called with a completely new client. */
-  public async initializeNotificationStream(clientId?: string): Promise<string> {
+  public async initializeNotificationStream(clientId: string): Promise<string> {
     await this.setLastEventDate(new Date(0));
     const latestNotification = await this.backend.getLastNotification(clientId);
     return this.setLastNotificationId(latestNotification);


### PR DESCRIPTION
Client id was not properly passed to `getLastNotification` method. `this.apiClient.clientId` was `undefined` at this point. Client was trying to fetch and process all the notifications (including mls messages) directed to user, not this new client. 

It could result in `"You have missed some messages"` system message being injected into all the conversations, event though the client is completely new and it should not receive those messages since the device is new and was not listed in message's recipients when the message was sent.