### PR TITLE
runfix: allow keyboard navigation in group-select

### DIFF
--- a/packages/react-ui-kit/src/Form/Select.tsx
+++ b/packages/react-ui-kit/src/Form/Select.tsx
@@ -31,6 +31,7 @@ import {
   Menu,
   SelectContainer,
   ValueContainer,
+  isGroup,
 } from './SelectComponents';
 import {customStyles} from './SelectStyles';
 
@@ -78,6 +79,8 @@ export const Select = <IsMulti extends boolean = false, Group extends GroupBase<
 
   return (
     <div
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      autoFocus={isGroup(options)}
       css={(theme: Theme) => ({
         marginBottom: markInvalid ? '2px' : '20px',
         width: '100%',

--- a/packages/react-ui-kit/src/Form/SelectStyles.tsx
+++ b/packages/react-ui-kit/src/Form/SelectStyles.tsx
@@ -72,12 +72,16 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
     };
   },
   control: (_provided, {options}) => ({
-    display: isGroup(options) ? 'none' : 'flex',
+    display: 'flex',
     alignItems: 'center',
     appearance: 'none',
     padding: '0 8px 0 16px',
     height: 'auto',
     minHeight: '48px',
+    ...(isGroup(options) && {
+      position: 'absolute',
+      zIndex: -9999,
+    }),
   }),
   dropdownIndicator: (provided, selectProps) => {
     const isSelectDisabled = selectProps.isDisabled;

--- a/packages/react-ui-kit/src/Form/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Select.test.tsx.snap
@@ -203,6 +203,7 @@ exports[`"Select" renders 1`] = `
   className="emotion-0"
 >
   <div
+    autoFocus={false}
     className="emotion-1"
     data-uie-name="test"
   >
@@ -488,6 +489,7 @@ exports[`"Select" renders as disabled 1`] = `
   className="emotion-0"
 >
   <div
+    autoFocus={false}
     className="emotion-1"
     data-uie-name="test"
   >
@@ -774,6 +776,7 @@ exports[`"Select" renders as invalid 1`] = `
   className="emotion-0"
 >
   <div
+    autoFocus={false}
     className="emotion-1"
     data-uie-name="test"
   >


### PR DESCRIPTION
### Issues

- `display: none` on the control component of the Select prevent's keyboard navigation completely
- the select menu isn't in focus when clicking the button to show the Select-Group

### Solution

- replace `display: none` by `position: absolute, z-index: -9999`
- add the react `autoFocus` prop to the select component when it is of type "group"
