### PR TITLE
runfix: send an empty response when no users can be added to an existing MLS conversation (WPB-2227)

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -378,7 +378,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const response =
       coreCryptoKeyPackagesPayload.length > 0
         ? await this.mlsService.addUsersToExistingConversation(groupId, coreCryptoKeyPackagesPayload)
-        : ({events: ''} as unknown as MLSCreateConversationResponse);
+        : {events: []};
 
     const conversation = await this.getConversation(conversationId);
 


### PR DESCRIPTION
### Description

We need to provide a conversation event response in `addUsersToMLSConversation` when no keypackages are provided in order to tell the client that users from unreachable backends could not be added to a conversation