### PR TITLE
fix: use local settings and team settings for e2ei

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -226,9 +226,11 @@ export class Account extends TypedEventEmitter<Events> {
 
   private async getE2EIStatus() {
     const features = await this.apiClient.api.teams.feature.getAllFeatures();
+    const clientCanUseE2EI = this.coreCryptoConfig?.mls?.useE2EI;
+    const teamCanUseE2EI = features[FEATURE_KEY.MLSE2EID]?.status === FeatureStatus.ENABLED;
 
     return {
-      isFeatureEnabled: features[FEATURE_KEY.MLSE2EID]?.status === FeatureStatus.ENABLED,
+      isFeatureEnabled: clientCanUseE2EI && teamCanUseE2EI,
     };
   }
 


### PR DESCRIPTION
Previously we determined if E2EI should be active only via the team-settings. 

This PR also takes the local settings into consideration and prevents unwanted behaviour. 