### PR TITLE
runfix: always use subconversation epoch number

### DIFF
--- a/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
@@ -482,6 +482,7 @@ describe('SubconversationService', () => {
         onEpochUpdateCallback,
       );
 
+      expect(mlsService.getEpoch).toHaveBeenCalledWith(subconversationGroupId);
       expect(mlsService.on).toHaveBeenCalledWith('newEpoch', expect.any(Function));
       expect(subconversationService.getSubconversationEpochInfo).toHaveBeenCalledWith(
         parentConversationId,

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
@@ -463,6 +463,7 @@ describe('SubconversationService', () => {
       jest
         .spyOn(subconversationService, 'joinConferenceSubconversation')
         .mockResolvedValue({epoch: mockedInitialEpoch, groupId: subconversationGroupId});
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(mockedInitialEpoch);
 
       const findConversationByGroupId = (groupId: string) => {
         if (groupId === parentConversationGroupId) {

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -216,7 +216,7 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     const {epoch: initialEpoch, groupId: subconversationGroupId} =
       await this.joinConferenceSubconversation(parentConversationId);
 
-    const forwardNewEpoch = async ({groupId, epoch}: {groupId: string; epoch: number}) => {
+    const forwardNewEpoch = async ({groupId}: {groupId: string; epoch: number}) => {
       if (groupId !== subconversationGroupId) {
         // if the epoch update did not happen in the subconversation directly, check if it happened in the parent conversation
         const parentConversationId = findConversationByGroupId(groupId);
@@ -244,7 +244,12 @@ export class SubconversationService extends TypedEventEmitter<Events> {
         return;
       }
 
-      return onEpochUpdate({...subconversationEpochInfo, epoch: Number(epoch)});
+      const newSubconversationEpoch = Number(await this.mlsService.getEpoch(subconversationGroupId));
+
+      return onEpochUpdate({
+        ...subconversationEpochInfo,
+        epoch: newSubconversationEpoch,
+      });
     };
 
     this.mlsService.on('newEpoch', forwardNewEpoch);


### PR DESCRIPTION
In MLS conference calls we update avs with current epoch info every time subconversations epoch changes or every time its parent conversation's epoch changes. For the latter, we were mistakenly updating subconversation's epoch info with parent's conversation epoch instead of actual subconversation's epoch. It was causing some errors in avs making users unable to send/receive audio/video. 