### PR TITLE
fix: Add MLS basic devices to the return value of user identities

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -96,7 +96,9 @@ export class E2EIServiceExternal {
 
       const basicMLSDevices = allUsersMLSDevices
         .filter(({user}) => user === userId.id)
+        // filtering devices that have a valid identity
         .filter(({client}) => !identities.map(identity => identity.deviceId).includes(client))
+        // map basic MLS devices to "fake" identity object
         .map<DeviceIdentity>(id => ({
           ...id,
           deviceId: id.client,

--- a/packages/core/src/util/fullyQualifiedClientIdUtils.ts
+++ b/packages/core/src/util/fullyQualifiedClientIdUtils.ts
@@ -23,6 +23,7 @@ type UserId = string;
 type ClientId = string;
 type Domain = string;
 export type ClientIdStringType = `${UserId}:${ClientId}@${Domain}`;
+export type ParsedFullyQualifiedId = {user: UserId; client: ClientId; domain: Domain};
 
 export const constructFullyQualifiedClientId = (
   userId: UserId,
@@ -30,7 +31,7 @@ export const constructFullyQualifiedClientId = (
   domain: Domain,
 ): ClientIdStringType => `${userId}:${clientId}@${domain}`;
 
-export const parseFullQualifiedClientId = (qualifiedId: string): {user: UserId; client: ClientId; domain: Domain} => {
+export const parseFullQualifiedClientId = (qualifiedId: string): ParsedFullyQualifiedId => {
   const regexp = /([a-zA-Z0-9\-]+):([a-zA-Z0-9\-]+)@([a-zA-Z0-9\-.]+)/;
   const [, user, client, domain] = qualifiedId.match(regexp) ?? [];
   if (!user || !client || !domain) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Description

the method `getUserIdentities` from CoreCrypto doesn't list the MLS basic devices in the return value. But we need to indicate those devices as `not downloaded` so we need to be aware of those. 

To circumvent this issue, we:
- ask CoreCrypto to give us all the devices known in the conversation (both with identities and basics)
- ask CoreCrypto the devices that have identities
- merge both values in order to add basic devices to the return value

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
