### PR TITLE
feat: replace refreshActiveCertificate with hasActiveCertificate and initialise MLSService with e2eServiceExternal

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -465,10 +465,10 @@ export class Account extends TypedEventEmitter<Events> {
         cryptoClient.getNativeClient(),
         this.db,
         this.recurringTaskScheduler,
+        e2eServiceExternal,
         {
           ...this.coreCryptoConfig?.mls,
         },
-        e2eServiceExternal,
       );
     }
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -236,13 +236,11 @@ export class Account extends TypedEventEmitter<Events> {
     displayName,
     handle,
     discoveryUrl,
-    refreshActiveCertificate = false,
     oAuthIdToken,
   }: {
     displayName: string;
     handle: string;
     discoveryUrl: string;
-    refreshActiveCertificate?: boolean;
     oAuthIdToken?: string;
   }): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
@@ -270,7 +268,6 @@ export class Account extends TypedEventEmitter<Events> {
       user,
       this.currentClient,
       this.nbPrekeys,
-      refreshActiveCertificate,
       oAuthIdToken,
     );
   }

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -449,7 +449,7 @@ export class Account extends TypedEventEmitter<Events> {
     const [clientType, cryptoClient] = await this.buildCryptoClient(context, this.storeEngine);
 
     let mlsService: MLSService | undefined;
-    let e2eIdentityService: E2EIServiceExternal | undefined;
+    let e2eServiceExternal: E2EIServiceExternal | undefined;
 
     const proteusService = new ProteusService(this.apiClient, cryptoClient, {
       onNewClient: payload => this.emit(EVENTS.NEW_SESSION, payload),
@@ -459,7 +459,7 @@ export class Account extends TypedEventEmitter<Events> {
     const clientService = new ClientService(this.apiClient, proteusService, this.storeEngine);
 
     if (clientType === CryptoClientType.CORE_CRYPTO && (await this.isMlsEnabled())) {
-      e2eIdentityService = new E2EIServiceExternal(cryptoClient.getNativeClient(), clientService);
+      e2eServiceExternal = new E2EIServiceExternal(cryptoClient.getNativeClient(), clientService);
       mlsService = new MLSService(
         this.apiClient,
         cryptoClient.getNativeClient(),
@@ -468,6 +468,7 @@ export class Account extends TypedEventEmitter<Events> {
         {
           ...this.coreCryptoConfig?.mls,
         },
+        e2eServiceExternal,
       );
     }
 
@@ -491,7 +492,7 @@ export class Account extends TypedEventEmitter<Events> {
     const userService = new UserService(this.apiClient);
 
     this.service = {
-      e2eIdentity: e2eIdentityService,
+      e2eIdentity: e2eServiceExternal,
       mls: mlsService,
       proteus: proteusService,
       account: accountService,

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -83,8 +83,8 @@ const createMLSService = async () => {
     mockCoreCrypto,
     mockedDb,
     recurringTaskScheduler,
-    {},
     e2eServiceExternal,
+    {},
   );
 
   return [mlsService, {apiClient, coreCrypto: mockCoreCrypto, recurringTaskScheduler}] as const;

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -33,9 +33,11 @@ import {CoreCrypto, DecryptedMessage} from '@wireapp/core-crypto';
 import {CoreCryptoMLSError} from './CoreCryptoMLSError';
 import {MLSService} from './MLSService';
 
+import {ClientService} from '../../../client';
 import {openDB} from '../../../storage/CoreDB';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {TaskScheduler} from '../../../util/TaskScheduler';
+import {E2EIServiceExternal} from '../E2EIdentityService';
 
 jest.createMockFromModule('@wireapp/api-client');
 
@@ -43,8 +45,14 @@ function createUserId() {
   return {id: randomUUID(), domain: ''};
 }
 
+const coreCrypto = {
+  getUserIdentities: jest.fn(),
+} as unknown as jest.Mocked<CoreCrypto>;
+
+const clientService = {} as jest.Mocked<ClientService>;
 const createMLSService = async () => {
   const apiClient = new APIClient();
+  const e2eServiceExternal = new E2EIServiceExternal(coreCrypto, clientService);
   const mockCoreCrypto = {
     createConversation: jest.fn(),
     conversationExists: jest.fn(),
@@ -70,7 +78,14 @@ const createMLSService = async () => {
     },
   });
 
-  const mlsService = new MLSService(apiClient, mockCoreCrypto, mockedDb, recurringTaskScheduler, {});
+  const mlsService = new MLSService(
+    apiClient,
+    mockCoreCrypto,
+    mockedDb,
+    recurringTaskScheduler,
+    {},
+    e2eServiceExternal,
+  );
 
   return [mlsService, {apiClient, coreCrypto: mockCoreCrypto, recurringTaskScheduler}] as const;
 };

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -92,12 +92,12 @@ export class MLSService extends TypedEventEmitter<Events> {
     private readonly coreCryptoClient: CoreCrypto,
     private readonly coreDatabase: CoreDatabase,
     private readonly recurringTaskScheduler: RecurringTaskScheduler,
-    private readonly e2eServiceExternal: E2EIServiceExternal,
     {
       keyingMaterialUpdateThreshold = defaultConfig.keyingMaterialUpdateThreshold,
       nbKeyPackages = defaultConfig.nbKeyPackages,
       cipherSuite = defaultConfig.cipherSuite,
     }: Partial<MLSServiceConfig>,
+    private readonly e2eServiceExternal: E2EIServiceExternal,
   ) {
     super();
     this.config = {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -92,6 +92,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     private readonly coreCryptoClient: CoreCrypto,
     private readonly coreDatabase: CoreDatabase,
     private readonly recurringTaskScheduler: RecurringTaskScheduler,
+    private readonly e2eServiceExternal: E2EIServiceExternal,
     {
       keyingMaterialUpdateThreshold = defaultConfig.keyingMaterialUpdateThreshold,
       nbKeyPackages = defaultConfig.nbKeyPackages,
@@ -768,7 +769,6 @@ export class MLSService extends TypedEventEmitter<Events> {
     user: User,
     client: RegisteredClient,
     nbPrekeys: number,
-    refreshActiveCertificate: boolean,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     try {
@@ -783,7 +783,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       });
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth
       if (!oAuthIdToken) {
-        const challengeData = await instance.startCertificateProcess(refreshActiveCertificate);
+        const challengeData = await instance.startCertificateProcess();
         if (challengeData) {
           return challengeData;
         }
@@ -792,7 +792,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         let rotateBundle;
 
         // If we are not refreshing the active certificate, we need to continue the certificate process with Oauth
-        if (!refreshActiveCertificate) {
+        if (!this.e2eServiceExternal.hasActiveCertificate()) {
           rotateBundle = await instance.continueCertificateProcess(oAuthIdToken);
           // If we are refreshing the active certificate, can start the refresh process
         } else {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -92,12 +92,12 @@ export class MLSService extends TypedEventEmitter<Events> {
     private readonly coreCryptoClient: CoreCrypto,
     private readonly coreDatabase: CoreDatabase,
     private readonly recurringTaskScheduler: RecurringTaskScheduler,
+    private readonly e2eServiceExternal: E2EIServiceExternal,
     {
       keyingMaterialUpdateThreshold = defaultConfig.keyingMaterialUpdateThreshold,
       nbKeyPackages = defaultConfig.nbKeyPackages,
       cipherSuite = defaultConfig.cipherSuite,
     }: Partial<MLSServiceConfig>,
-    private readonly e2eServiceExternal: E2EIServiceExternal,
   ) {
     super();
     this.config = {


### PR DESCRIPTION
remove the refreshActiveCertificate dependency instead use CC hasActiveCertificate and initialise MLSService with e2eServiceExternal

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
