### PR TITLE
feat: add a queue for incoming mls messages

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -410,26 +410,6 @@ export class APIClient extends EventEmitter {
   }
 
   /**
-   * Will lock the websocket before executing the callback and unlock it after
-   * @param callback The callback to execute
-   */
-  public withLockedWebSocket<T extends (...args: any[]) => any>(
-    callback: T,
-  ): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-    return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
-      this.transport.ws.lock();
-      try {
-        const result = await callback(...args);
-        this.transport.ws.unlock();
-        return result;
-      } catch (error) {
-        this.transport.ws.unlock();
-        throw error;
-      }
-    };
-  }
-
-  /**
    * Will check if MLS is supported by backend (whether the api version used supports MLS, and whether a backend removal key is present).
    */
   public async supportsMLS(): Promise<boolean> {

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingMessagesQueue/IncomingMesssagesQueue.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingMessagesQueue/IncomingMesssagesQueue.ts
@@ -1,0 +1,78 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import logdown from 'logdown';
+
+import {PromiseQueue} from '@wireapp/promise-queue';
+
+const logger = logdown('@wireapp/core/MLSService/IncomingMessagesQueue');
+
+// (groupId string -> queue) map
+const queues = new Map<string, PromiseQueue>();
+
+const getQueue = (groupId: string) => {
+  const queue = queues.get(groupId);
+
+  if (queue) {
+    return queue;
+  }
+
+  const newConversationQueue = new PromiseQueue({
+    name: `mls-messages-queue-${groupId}`,
+  });
+  queues.set(groupId, newConversationQueue);
+
+  return newConversationQueue;
+};
+
+export const queueIncomingMLSMessage = async <EventHandler extends (...args: any[]) => any>(
+  groupId: string,
+  handler: EventHandler,
+): Promise<ReturnType<EventHandler>> => {
+  const conversationQueue = getQueue(groupId);
+  return conversationQueue.push(handler);
+};
+
+export const deleteMLSMessagesQueue = (groupId: string) => {
+  queues.delete(groupId);
+};
+
+const lockMLSMessagesQueue = (groupId: string) => {
+  logger.info(`Locking incoming MLS messages queue for group ${groupId}`);
+  const conversationQueue = getQueue(groupId);
+  conversationQueue.pause(true);
+};
+
+const unlockMLSMessagesQueue = (groupId: string) => {
+  logger.info(`Unlocking incoming MLS messages queue for group ${groupId}`);
+  const conversationQueue = getQueue(groupId);
+  conversationQueue.pause(false);
+};
+
+export const withLockedMLSMessagesQueue = async <T>(groupId: string, fn: () => Promise<T>): Promise<T> => {
+  lockMLSMessagesQueue(groupId);
+  try {
+    const result = await fn();
+    unlockMLSMessagesQueue(groupId);
+    return result;
+  } catch (error) {
+    unlockMLSMessagesQueue(groupId);
+    throw error;
+  }
+};

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingMessagesQueue/index.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingMessagesQueue/index.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2022 Wire Swiss GmbH
+ * Copyright (C) 2023 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,5 +17,4 @@
  *
  */
 
-export * from './messageAdd';
-export * from './IncomingMessagesQueue';
+export * from './IncomingMesssagesQueue';

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
@@ -54,21 +54,9 @@ const createMockedMessage = () => {
 };
 
 describe('handleMLSMessageAdd', () => {
-  it('throws when received a message for a group that is not known by a client', async () => {
-    const event = createMLSMessageAddEventMock({id: 'conversationId', domain: 'staging.zinfra.io'});
-
-    const groupIdFromConversationId = () => Promise.resolve(undefined);
-
-    await expect(
-      handleMLSMessageAdd({event, mlsService: mockedMLSService, groupIdFromConversationId}),
-    ).rejects.toThrow();
-  });
-
   it('does not handle pending proposals if message does not contain proposals', async () => {
     const event = createMLSMessageAddEventMock({id: 'conversationId', domain: 'staging.zinfra.io'});
     const mockGroupId = 'AAEAAH87aajaQ011i+rNLmwpy0sAZGl5YS53aXJlLmxpbms=';
-
-    const groupIdFromConversationId = () => Promise.resolve(mockGroupId);
 
     const message = createMockedMessage();
 
@@ -80,7 +68,7 @@ describe('handleMLSMessageAdd', () => {
       isActive: true,
     });
 
-    await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupIdFromConversationId});
+    await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupId: mockGroupId});
 
     expect(mockedMLSService.handlePendingProposals).not.toHaveBeenCalled();
   });
@@ -88,8 +76,6 @@ describe('handleMLSMessageAdd', () => {
   it('handles pending proposals if message includes proposals', async () => {
     const event = createMLSMessageAddEventMock({id: 'conversationId', domain: 'staging.zinfra.io'});
     const mockGroupId = 'AAEAAH87aajaQ011i+rNLmwpy0sAZGl5YS53aXJlLmxpbms=';
-
-    const groupIdFromConversationId = () => Promise.resolve(mockGroupId);
 
     const message = createMockedMessage();
 
@@ -101,7 +87,7 @@ describe('handleMLSMessageAdd', () => {
       isActive: true,
     });
 
-    await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupIdFromConversationId});
+    await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupId: mockGroupId});
 
     expect(mockedMLSService.handlePendingProposals).toHaveBeenCalledWith({
       groupId: mockGroupId,
@@ -113,8 +99,6 @@ describe('handleMLSMessageAdd', () => {
   it('emits "newEpoch" event if incoming message has advanced epoch number', async () => {
     const event = createMLSMessageAddEventMock({id: 'conversationId', domain: 'staging.zinfra.io'});
     const mockGroupId = 'AAEAAH87aajaQ011i+rNLmwpy0sAZGl5YS53aXJlLmxpbms=';
-
-    const groupIdFromConversationId = () => Promise.resolve(mockGroupId);
 
     const message = createMockedMessage();
 
@@ -128,7 +112,7 @@ describe('handleMLSMessageAdd', () => {
     const mockedNewEpoch = 5;
     jest.spyOn(mockedMLSService, 'getEpoch').mockResolvedValueOnce(mockedNewEpoch);
 
-    await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupIdFromConversationId});
+    await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupId: mockGroupId});
 
     expect(mockedMLSService.emit).toHaveBeenCalledWith('newEpoch', {
       groupId: mockGroupId,

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
@@ -17,9 +17,7 @@
  *
  */
 
-import {SUBCONVERSATION_ID} from '@wireapp/api-client/lib/conversation';
 import {ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
-import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {Decoder} from 'bazinga64';
 
 import {GenericMessage} from '@wireapp/protocol-messaging';
@@ -29,30 +27,16 @@ import {MLSService, optionalToUint8Array} from '../../../MLSService/MLSService';
 
 interface HandleMLSMessageAddParams {
   event: ConversationMLSMessageAddEvent;
+  groupId: string;
   mlsService: MLSService;
-  groupIdFromConversationId: (
-    conversationId: QualifiedId,
-    subconversationId?: SUBCONVERSATION_ID,
-  ) => Promise<string | undefined>;
 }
 
 export const handleMLSMessageAdd = async ({
   event,
+  groupId,
   mlsService,
-  groupIdFromConversationId,
 }: HandleMLSMessageAddParams): Promise<HandledEventPayload | null> => {
   const encryptedData = Decoder.fromBase64(event.data).asBytes;
-
-  const qualifiedConversationId = event.qualified_conversation ?? {id: event.conversation, domain: ''};
-
-  const groupId = await groupIdFromConversationId(qualifiedConversationId, event.subconv);
-
-  // We should not receive a message for a group the client is not aware of
-  if (!groupId) {
-    throw new Error(
-      `Could not find a group_id for conversation ${qualifiedConversationId.id}@${qualifiedConversationId.domain}`,
-    );
-  }
 
   const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -56,6 +56,11 @@ import {TaskScheduler} from '../../../util/TaskScheduler';
 import {AcmeChallenge, E2EIServiceExternal, User} from '../E2EIdentityService';
 import {E2EIServiceInternal} from '../E2EIdentityService/E2EIServiceInternal';
 import {handleMLSMessageAdd, handleMLSWelcomeMessage} from '../EventHandler/events';
+import {
+  deleteMLSMessagesQueue,
+  queueIncomingMLSMessage,
+  withLockedMLSMessagesQueue,
+} from '../EventHandler/events/messageAdd';
 import {ClientId, CommitPendingProposalsParams, HandlePendingProposalsParams} from '../types';
 import {generateMLSDeviceId} from '../utils/MLSId';
 
@@ -136,14 +141,16 @@ export class MLSService extends TypedEventEmitter<Events> {
       : CredentialType.Basic;
   }
 
-  // We need to lock the websocket while commit bundle is being processed by backend,
-  // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
-  private readonly uploadCommitBundle = this.apiClient.withLockedWebSocket(
-    async (
-      groupId: Uint8Array,
-      commitBundle: CommitBundle,
-      {regenerateCommitBundle, isExternalCommit}: UploadCommitOptions = {},
-    ): Promise<PostMlsMessageResponse> => {
+  private readonly uploadCommitBundle = async (
+    groupId: Uint8Array,
+    commitBundle: CommitBundle,
+    {regenerateCommitBundle, isExternalCommit}: UploadCommitOptions = {},
+  ): Promise<PostMlsMessageResponse> => {
+    const groupIdStr = Encoder.toBase64(groupId).asString;
+
+    // We need to lock the incoming mls messages queue while we are uploading the commit bundle
+    // it's possible that we will be sent some mls messages before we receive the response from backend and accept a commit locally.
+    return withLockedMLSMessagesQueue(groupIdStr, async () => {
       const {commit, groupInfo, welcome} = commitBundle;
       const bundlePayload = new Uint8Array([...commit, ...groupInfo.payload, ...(welcome || [])]);
       try {
@@ -154,7 +161,6 @@ export class MLSService extends TypedEventEmitter<Events> {
           await this.coreCryptoClient.commitAccepted(groupId);
         }
         const newEpoch = await this.getEpoch(groupId);
-        const groupIdStr = Encoder.toBase64(groupId).asString;
 
         this.emit('newEpoch', {epoch: newEpoch, groupId: groupIdStr});
         return response;
@@ -176,8 +182,8 @@ export class MLSService extends TypedEventEmitter<Events> {
         }
         throw error;
       }
-    },
-  );
+    });
+  };
 
   /**
    * Will add users to an existing MLS group and send a commit bundle to backend.
@@ -612,6 +618,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   public async wipeConversation(groupId: string): Promise<void> {
+    deleteMLSMessagesQueue(groupId);
     await this.cancelKeyMaterialRenewal(groupId);
     await this.cancelPendingProposalsTask(groupId);
 
@@ -727,7 +734,18 @@ export class MLSService extends TypedEventEmitter<Events> {
       subconversationId?: SUBCONVERSATION_ID,
     ) => Promise<string | undefined>,
   ) {
-    return handleMLSMessageAdd({event, mlsService: this, groupIdFromConversationId});
+    const qualifiedConversationId = event.qualified_conversation ?? {id: event.conversation, domain: ''};
+
+    const groupId = await groupIdFromConversationId(qualifiedConversationId, event.subconv);
+
+    // We should not receive a message for a group the client is not aware of
+    if (!groupId) {
+      throw new Error(
+        `Could not find a group_id for conversation ${qualifiedConversationId.id}@${qualifiedConversationId.domain}`,
+      );
+    }
+
+    return queueIncomingMLSMessage(groupId, () => handleMLSMessageAdd({event, mlsService: this, groupId}));
   }
 
   public async handleMLSWelcomeMessageEvent(event: ConversationMLSWelcomeEvent, clientId: string) {


### PR DESCRIPTION
When uploading a commit bundle to backend, there's a chance we will receive a bunch of mls message before the response from this call is returned. Before that happens, we cannot decrypt those messages.

A previous solution for that was locking the whole websocket and unlocking it after receiving a response from backend and merging a commit locally. The downside of this approach was that while loading the app initially for the first time, when client was joining all the mls groups with external commit, we were spamming with lock/unlock websocket methods.

This PR introduces a better solution - an incoming MLS messages queue for each conversation. Instead of processing `conversation.mls-message-add` straight away, we put it in the queue which is unlocked by default (so we do not change the initial behaviour). 

Whenever we send a commit bundle to backend, we simply lock the queue of a particular mls group (allowing the app to receive all other messages) until we receive the response from backend. After queue is unlocked, all the messages that were received while backend was processing the post request, will get handled immediately in order they were received.