### PR TITLE
feat(e2ei): remove device storage for e2ei cert

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -238,13 +238,11 @@ export class Account extends TypedEventEmitter<Events> {
     displayName,
     handle,
     discoveryUrl,
-    hasActiveCertificate,
     oAuthIdToken,
   }: {
     displayName: string;
     handle: string;
     discoveryUrl: string;
-    hasActiveCertificate: boolean;
     oAuthIdToken?: string;
   }): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
@@ -272,7 +270,6 @@ export class Account extends TypedEventEmitter<Events> {
       user,
       this.currentClient,
       this.nbPrekeys,
-      hasActiveCertificate,
       oAuthIdToken,
     );
   }

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -238,11 +238,13 @@ export class Account extends TypedEventEmitter<Events> {
     displayName,
     handle,
     discoveryUrl,
+    hasActiveCertificate,
     oAuthIdToken,
   }: {
     displayName: string;
     handle: string;
     discoveryUrl: string;
+    hasActiveCertificate: boolean;
     oAuthIdToken?: string;
   }): Promise<AcmeChallenge | boolean> {
     const context = this.apiClient.context;
@@ -270,6 +272,7 @@ export class Account extends TypedEventEmitter<Events> {
       user,
       this.currentClient,
       this.nbPrekeys,
+      hasActiveCertificate,
       oAuthIdToken,
     );
   }
@@ -467,7 +470,6 @@ export class Account extends TypedEventEmitter<Events> {
         cryptoClient.getNativeClient(),
         this.db,
         this.recurringTaskScheduler,
-        e2eServiceExternal,
         {
           ...this.coreCryptoConfig?.mls,
         },

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -19,7 +19,6 @@
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {Decoder} from 'bazinga64';
-import logdown from 'logdown';
 
 import {Ciphersuite, CoreCrypto, E2eiConversationState, WireIdentity, DeviceStatus} from '@wireapp/core-crypto';
 
@@ -33,27 +32,10 @@ export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {status?: D
 
 // This export is meant to be accessible from the outside (e.g the Webapp / UI)
 export class E2EIServiceExternal {
-  private readonly logger = logdown('@wireapp/core/E2EIdentityServiceExternal');
-
   public constructor(
     private readonly coreCryptoClient: CoreCrypto,
     private readonly clientService: ClientService,
   ) {}
-
-  // Checks if there is a certificate stored in the local storage
-  public hasActiveCertificate(): boolean {
-    return E2EIStorage.has.certificateData();
-  }
-
-  // Returns the certificate data stored in the local storage
-  public getCertificateData(): string | undefined {
-    try {
-      return E2EIStorage.get.certificateData();
-    } catch (error) {
-      this.logger.error('ACME: Failed to get stored certificate', error);
-      return undefined;
-    }
-  }
 
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
   public isEnrollmentInProgress(): boolean {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
@@ -25,7 +25,6 @@ const HandleKey = 'Handle';
 const AuthDataKey = 'AuthData';
 const OderDataKey = 'OrderData';
 const InitialDataKey = 'InitialData';
-const CertificateDataKey = 'CertificateData';
 
 const storage = LocalStorageStore<string>('E2EIStorage');
 
@@ -33,11 +32,9 @@ const storeHandle = (handle: string) => storage.add(HandleKey, window.btoa(handl
 const storeOrderData = (data: OrderData) => storage.add(OderDataKey, window.btoa(JSON.stringify(data)));
 const storeAuthData = (data: AuthData) => storage.add(AuthDataKey, window.btoa(JSON.stringify(data)));
 const storeInitialData = (data: InitialData) => storage.add(InitialDataKey, window.btoa(JSON.stringify(data)));
-const storeCertificate = (data: string) => storage.add(CertificateDataKey, window.btoa(data));
 
 const hasHandle = () => storage.has(HandleKey);
 const hasInitialData = () => storage.has(InitialDataKey);
-const hasCertificateData = () => storage.has(CertificateDataKey);
 
 const getAndVerifyHandle = () => {
   const handle = storage.get(HandleKey);
@@ -75,15 +72,6 @@ const getAndVerifyOrderData = (): OrderData => {
   return JSON.parse(atob);
 };
 
-const getCertificateData = (): string => {
-  const data = storage.get(CertificateDataKey);
-  if (!data) {
-    throw new Error('ACME: CertificateData not found');
-  }
-  const atob = window.atob(data);
-  return atob;
-};
-
 const removeInitialData = () => {
   storage.remove(InitialDataKey);
 };
@@ -94,13 +82,8 @@ const removeTemporaryData = () => {
   storage.remove(OderDataKey);
 };
 
-const removeCertificateData = () => {
-  storage.remove(CertificateDataKey);
-};
-
 const removeAll = () => {
   removeTemporaryData();
-  removeCertificateData();
   removeInitialData();
 };
 
@@ -110,11 +93,9 @@ export const E2EIStorage = {
     authData: storeAuthData,
     orderData: storeOrderData,
     initialData: storeInitialData,
-    certificate: storeCertificate,
   },
   get: {
     initialData: getInitialData,
-    certificateData: getCertificateData,
     handle: getAndVerifyHandle,
     authData: getAndVerifyAuthData,
     orderData: getAndVerifyOrderData,
@@ -122,12 +103,10 @@ export const E2EIStorage = {
   has: {
     handle: hasHandle,
     initialData: hasInitialData,
-    certificateData: hasCertificateData,
   },
   remove: {
     initialData: removeInitialData,
     temporaryData: removeTemporaryData,
-    certificateData: removeCertificateData,
     all: removeAll,
   },
 };

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -33,11 +33,9 @@ import {CoreCrypto, DecryptedMessage} from '@wireapp/core-crypto';
 import {CoreCryptoMLSError} from './CoreCryptoMLSError';
 import {MLSService} from './MLSService';
 
-import {ClientService} from '../../../client';
 import {openDB} from '../../../storage/CoreDB';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {TaskScheduler} from '../../../util/TaskScheduler';
-import {E2EIServiceExternal} from '../E2EIdentityService';
 
 jest.createMockFromModule('@wireapp/api-client');
 
@@ -45,14 +43,8 @@ function createUserId() {
   return {id: randomUUID(), domain: ''};
 }
 
-const coreCrypto = {
-  getUserIdentities: jest.fn(),
-} as unknown as jest.Mocked<CoreCrypto>;
-
-const clientService = {} as jest.Mocked<ClientService>;
 const createMLSService = async () => {
   const apiClient = new APIClient();
-  const e2eServiceExternal = new E2EIServiceExternal(coreCrypto, clientService);
   const mockCoreCrypto = {
     createConversation: jest.fn(),
     conversationExists: jest.fn(),
@@ -78,14 +70,7 @@ const createMLSService = async () => {
     },
   });
 
-  const mlsService = new MLSService(
-    apiClient,
-    mockCoreCrypto,
-    mockedDb,
-    recurringTaskScheduler,
-    e2eServiceExternal,
-    {},
-  );
+  const mlsService = new MLSService(apiClient, mockCoreCrypto, mockedDb, recurringTaskScheduler, {});
 
   return [mlsService, {apiClient, coreCrypto: mockCoreCrypto, recurringTaskScheduler}] as const;
 };

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -97,7 +97,6 @@ export class MLSService extends TypedEventEmitter<Events> {
     private readonly coreCryptoClient: CoreCrypto,
     private readonly coreDatabase: CoreDatabase,
     private readonly recurringTaskScheduler: RecurringTaskScheduler,
-    private readonly e2eServiceExternal: E2EIServiceExternal,
     {
       keyingMaterialUpdateThreshold = defaultConfig.keyingMaterialUpdateThreshold,
       nbKeyPackages = defaultConfig.nbKeyPackages,
@@ -787,6 +786,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     user: User,
     client: RegisteredClient,
     nbPrekeys: number,
+    hasActiveCertificate: boolean,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     try {
@@ -801,7 +801,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       });
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth
       if (!oAuthIdToken) {
-        const challengeData = await instance.startCertificateProcess();
+        const challengeData = await instance.startCertificateProcess(hasActiveCertificate);
         if (challengeData) {
           return challengeData;
         }
@@ -810,11 +810,11 @@ export class MLSService extends TypedEventEmitter<Events> {
         let rotateBundle;
 
         // If we are not refreshing the active certificate, we need to continue the certificate process with Oauth
-        if (!this.e2eServiceExternal.hasActiveCertificate()) {
+        if (!hasActiveCertificate) {
           rotateBundle = await instance.continueCertificateProcess(oAuthIdToken);
           // If we are refreshing the active certificate, can start the refresh process
         } else {
-          rotateBundle = await instance.startRefreshCertficateFlow(oAuthIdToken);
+          rotateBundle = await instance.startRefreshCertficateFlow(oAuthIdToken, hasActiveCertificate);
         }
 
         if (rotateBundle !== undefined) {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -786,10 +786,10 @@ export class MLSService extends TypedEventEmitter<Events> {
     user: User,
     client: RegisteredClient,
     nbPrekeys: number,
-    hasActiveCertificate: boolean,
     oAuthIdToken?: string,
   ): Promise<AcmeChallenge | boolean> {
     try {
+      const hasActiveCertificate = await this.coreCryptoClient.e2eiIsEnabled(this.config.cipherSuite);
       const instance = await E2EIServiceInternal.getInstance({
         apiClient: this.apiClient,
         coreCryptClient: this.coreCryptoClient,
@@ -799,6 +799,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         discoveryUrl,
         keyPackagesAmount: nbPrekeys,
       });
+
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth
       if (!oAuthIdToken) {
         const challengeData = await instance.startCertificateProcess(hasActiveCertificate);


### PR DESCRIPTION
This cert storage was a leftover from early development. Certificates are stored by core-crypto already and should be retrieved from there.