### PR TITLE
feat(e2ei): update the certificate expiry time to 90 days 

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -122,7 +122,8 @@ class E2EIServiceInternal {
   private async initIdentity(hasActiveCertificate: boolean) {
     const {clientId, user} = E2EIStorage.get.initialData();
     const e2eiClientId = getE2EIClientId(clientId, user.id, user.domain).asString;
-    const expiryDays = 2;
+    // How long the issued certificate should be maximal valid
+    const expiryDays = 180;
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
     if (hasActiveCertificate) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -123,7 +123,7 @@ class E2EIServiceInternal {
     const {clientId, user} = E2EIStorage.get.initialData();
     const e2eiClientId = getE2EIClientId(clientId, user.id, user.domain).asString;
     // How long the issued certificate should be maximal valid
-    const expiryDays = 180;
+    const expiryDays = 90;
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
     if (hasActiveCertificate) {


### PR DESCRIPTION
This hardcoded value is used instead of the value from the certificate server when set lower. So we need to up it to at least 90 days to match the server settings.