### PR TITLE
fix: Delete secrets store when account is wiped

### DIFF
--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -81,7 +81,7 @@ describe('Account', () => {
   const CLIENT_ID = '4e37b32f57f6da55';
 
   // Fix for node 16, crypto.subtle.decrypt has a type problem
-  jest.spyOn(global.crypto.subtle, 'decrypt').mockImplementation();
+  jest.spyOn(global.crypto.subtle, 'decrypt').mockResolvedValue(new Uint8Array(32));
   const accessTokenData = {
     access_token:
       'iJCRCjc8oROO-dkrkqCXOade997oa8Jhbz6awMUQPBQo80VenWqp_oNvfY6AnU5BxEsdDPOBfBP-uz_b0gAKBQ==.v=1.k=1.d=1498600993.t=a.l=.u=aaf9a833-ef30-4c22-86a0-9adc8a15b3b4.c=15037015562284012115',
@@ -245,7 +245,7 @@ describe('Account', () => {
         },
       });
 
-      const kill = await account.listen({
+      const kill = account.listen({
         onEvent: ({event}) => {
           expect(event.type).toBe(CONVERSATION_EVENT.OTR_MESSAGE_ADD);
           resolve();

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -427,7 +427,7 @@ export class Account extends TypedEventEmitter<Events> {
     }
 
     const {buildClient} = await import('./messagingProtocols/proteus/ProteusService/CryptoClient/CryptoboxWrapper');
-    const client = await buildClient(storeEngine, baseConfig);
+    const client = buildClient(storeEngine, baseConfig);
     return [CryptoClientType.CRYPTOBOX, client] as const;
   }
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -54,10 +54,12 @@ import {GiphyService} from './giphy/';
 import {LinkPreviewService} from './linkPreview';
 import {MLSService} from './messagingProtocols/mls';
 import {AcmeChallenge, E2EIServiceExternal, User} from './messagingProtocols/mls/E2EIdentityService';
-import {CoreCallbacks, CoreCryptoConfig} from './messagingProtocols/mls/types';
+import {CoreCallbacks, CoreCryptoConfig, SecretCrypto} from './messagingProtocols/mls/types';
 import {NewClient, ProteusService} from './messagingProtocols/proteus';
 import {CryptoClientType} from './messagingProtocols/proteus/ProteusService/CryptoClient';
 import {HandledEventPayload, NotificationService, NotificationSource} from './notification/';
+import {createCustomEncryptedStore, createEncryptedStore, EncryptedStore} from './secretStore/encryptedStore';
+import {generateSecretKey} from './secretStore/secretKeyGenerator';
 import {SelfService} from './self/';
 import {CoreDatabase, deleteDB, openDB} from './storage/CoreDB';
 import {TeamService} from './team/';
@@ -85,11 +87,12 @@ export enum ConnectionState {
   LIVE = 'live',
 }
 
-export type CreateStoreFn = (storeName: string, context: Context) => undefined | Promise<CRUDEngine | undefined>;
+export type CreateStoreFn = (storeName: string, key: Uint8Array) => undefined | Promise<CRUDEngine | undefined>;
 
 interface AccountOptions {
   /** Used to store info in the database (will create a inMemory engine if returns undefined) */
   createStore?: CreateStoreFn;
+  systemCrypto?: SecretCrypto;
 
   /** Number of prekeys to generate when creating a new device (defaults to 2)
    * Prekeys are Diffie-Hellmann public keys which allow offline initiation of a secure Proteus session between two devices.
@@ -100,7 +103,7 @@ interface AccountOptions {
    *    - make creating a new device fast
    *    - make it likely that all prekeys get consumed while the device is offline and the last resort prekey will be used to create new session
    */
-  nbPrekeys?: number;
+  nbPrekeys: number;
 
   /**
    * Config for MLS and proteus devices. Will fallback to the old cryptobox logic if not provided
@@ -126,14 +129,13 @@ type Events = {
 export class Account extends TypedEventEmitter<Events> {
   private readonly apiClient: APIClient;
   private readonly logger: logdown.Logger;
-  private readonly createStore: CreateStoreFn;
-  private readonly nbPrekeys: number;
   private readonly coreCryptoConfig?: CoreCryptoConfig;
   private readonly isMlsEnabled: () => Promise<boolean>;
   /** this is the client the consumer is currently using. Will be set as soon as `initClient` is called and will be rest upon logout */
   private currentClient?: RegisteredClient;
   private storeEngine?: CRUDEngine;
   private db?: CoreDatabase;
+  private encryptedDb?: EncryptedStore<any>;
   private coreCallbacks?: CoreCallbacks;
 
   public service?: {
@@ -163,15 +165,13 @@ export class Account extends TypedEventEmitter<Events> {
    */
   constructor(
     apiClient: APIClient = new APIClient(),
-    {createStore = () => undefined, nbPrekeys = 100, coreCryptoConfig}: AccountOptions = {},
+    private options: AccountOptions = {nbPrekeys: 100},
   ) {
     super();
     this.apiClient = apiClient;
     this.backendFeatures = this.apiClient.backendFeatures;
-    this.coreCryptoConfig = coreCryptoConfig;
-    this.nbPrekeys = nbPrekeys;
+    this.coreCryptoConfig = options.coreCryptoConfig;
     this.isMlsEnabled = async () => !!this.coreCryptoConfig?.mls && (await this.apiClient.supportsMLS());
-    this.createStore = createStore;
     this.recurringTaskScheduler = new RecurringTaskScheduler({
       get: async key => {
         const task = await this.db?.get('recurringTasks', key);
@@ -269,7 +269,7 @@ export class Account extends TypedEventEmitter<Events> {
       this.service.e2eIdentity,
       user,
       this.currentClient,
-      this.nbPrekeys,
+      this.options.nbPrekeys,
       oAuthIdToken,
     );
   }
@@ -404,9 +404,9 @@ export class Account extends TypedEventEmitter<Events> {
     return validClient;
   }
 
-  private async buildCryptoClient(context: Context, storeEngine: CRUDEngine) {
+  private async buildCryptoClient(context: Context, storeEngine: CRUDEngine, encryptedStore: EncryptedStore<any>) {
     const baseConfig = {
-      nbPrekeys: this.nbPrekeys,
+      nbPrekeys: this.options.nbPrekeys,
       onNewPrekeys: async (prekeys: PreKey[]) => {
         this.logger.debug(`Received '${prekeys.length}' new PreKeys.`);
 
@@ -421,7 +421,7 @@ export class Account extends TypedEventEmitter<Events> {
       const client = await buildClient(storeEngine, {
         ...baseConfig,
         ...coreCryptoConfig,
-        generateSecretKey: keyId => coreCryptoConfig.generateSecretKey(storeEngine.storeName, keyId, 16),
+        generateSecretKey: keyId => generateSecretKey({keyId, keySize: 16, secretsDb: encryptedStore}),
       });
       return [CryptoClientType.CORE_CRYPTO, client] as const;
     }
@@ -443,19 +443,24 @@ export class Account extends TypedEventEmitter<Events> {
   }
 
   public async initServices(context: Context): Promise<void> {
-    this.storeEngine = await this.initEngine(context);
+    const encryptedStoreName = this.generateEncryptedDbName(context);
+    this.encryptedDb = this.options.systemCrypto
+      ? await createCustomEncryptedStore(encryptedStoreName, this.options.systemCrypto)
+      : await createEncryptedStore(encryptedStoreName);
     this.db = await openDB(this.generateCoreDbName(context));
+    this.storeEngine = await this.initEngine(context, this.encryptedDb);
+
     const accountService = new AccountService(this.apiClient);
     const assetService = new AssetService(this.apiClient);
 
-    const [clientType, cryptoClient] = await this.buildCryptoClient(context, this.storeEngine);
+    const [clientType, cryptoClient] = await this.buildCryptoClient(context, this.storeEngine, this.encryptedDb);
 
     let mlsService: MLSService | undefined;
     let e2eServiceExternal: E2EIServiceExternal | undefined;
 
     const proteusService = new ProteusService(this.apiClient, cryptoClient, {
       onNewClient: payload => this.emit(EVENTS.NEW_SESSION, payload),
-      nbPrekeys: this.nbPrekeys,
+      nbPrekeys: this.options.nbPrekeys,
     });
 
     const clientService = new ClientService(this.apiClient, proteusService, this.storeEngine);
@@ -524,6 +529,7 @@ export class Account extends TypedEventEmitter<Events> {
    */
   public async logout(clearData: boolean = false): Promise<void> {
     this.db?.close();
+    this.encryptedDb?.close();
     if (clearData) {
       await this.wipe();
     }
@@ -539,6 +545,7 @@ export class Account extends TypedEventEmitter<Events> {
     if (this.db) {
       await deleteDB(this.db);
     }
+    await this.encryptedDb?.wipe();
   }
 
   /**
@@ -685,11 +692,16 @@ export class Account extends TypedEventEmitter<Events> {
     return `core-${this.generateDbName(context)}`;
   }
 
-  private async initEngine(context: Context): Promise<CRUDEngine> {
+  private generateEncryptedDbName(context: Context) {
+    return `secrets-${this.generateDbName(context)}`;
+  }
+
+  private async initEngine(context: Context, encryptedStore: EncryptedStore<any>): Promise<CRUDEngine> {
     const dbName = this.generateDbName(context);
     this.logger.log(`Initialising store with name "${dbName}"...`);
     const openDb = async () => {
-      const initializedDb = await this.createStore(dbName, context);
+      const dbKey = await generateSecretKey({keyId: 'db-key', keySize: 32, secretsDb: encryptedStore});
+      const initializedDb = await this.options.createStore?.(dbName, dbKey.key);
       if (initializedDb) {
         this.logger.info(`Initialized store with existing engine "${dbName}".`);
         return initializedDb;

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -404,7 +404,7 @@ export class Account extends TypedEventEmitter<Events> {
     return validClient;
   }
 
-  private async buildCryptoClient(context: Context, storeEngine: CRUDEngine, encryptedStore: EncryptedStore<any>) {
+  private async buildCryptoClient(context: Context, storeEngine: CRUDEngine, encryptedStore: EncryptedStore) {
     const baseConfig = {
       nbPrekeys: this.options.nbPrekeys,
       onNewPrekeys: async (prekeys: PreKey[]) => {
@@ -696,7 +696,7 @@ export class Account extends TypedEventEmitter<Events> {
     return `secrets-${this.generateDbName(context)}`;
   }
 
-  private async initEngine(context: Context, encryptedStore: EncryptedStore<any>): Promise<CRUDEngine> {
+  private async initEngine(context: Context, encryptedStore: EncryptedStore): Promise<CRUDEngine> {
     const dbName = this.generateDbName(context);
     this.logger.log(`Initialising store with name "${dbName}"...`);
     const openDb = async () => {

--- a/packages/core/src/messagingProtocols/mls/types.ts
+++ b/packages/core/src/messagingProtocols/mls/types.ts
@@ -21,21 +21,12 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 
 import {MLSServiceConfig} from './MLSService/MLSService.types';
 
-import {GeneratedKey} from '../../secretStore/secretKeyGenerator';
-
 export type ClientId = string;
 
-export type SecretCrypto =
-  | {
-      encrypt: (value: Uint8Array) => Promise<Uint8Array>;
-      decrypt: (payload: Uint8Array) => Promise<Uint8Array>;
-      version: undefined;
-    }
-  | {
-      encrypt: (value: string) => Promise<Uint8Array>;
-      decrypt: (payload: Uint8Array) => Promise<string>;
-      version: 1;
-    };
+export type SecretCrypto = {
+  encrypt: (value: Uint8Array) => Promise<Uint8Array>;
+  decrypt: (payload: Uint8Array) => Promise<Uint8Array>;
+};
 
 export interface CoreCallbacks {
   /**
@@ -61,11 +52,6 @@ export type CommitPendingProposalsParams = {
 } & CommonMLS;
 
 export interface CoreCryptoConfig {
-  /**
-   * function called to generate the secret key for CoreCrypto's database encryption
-   */
-  generateSecretKey: (storeName: string, keyId: string, keySize: number) => Promise<GeneratedKey>;
-
   /**
    * path on the public server to the core crypto wasm file.
    * This file will be downloaded lazily when corecrypto is needed.

--- a/packages/core/src/secretStore/encryptedStore.ts
+++ b/packages/core/src/secretStore/encryptedStore.ts
@@ -42,7 +42,7 @@ type EncryptedStoreConfig<EncryptedPayload> = {
   decrypt: DecryptFn<EncryptedPayload>;
 };
 
-export class EncryptedStore<EncryptedPayload> {
+export class EncryptedStore<EncryptedPayload = unknown> {
   readonly #decrypt: DecryptFn<EncryptedPayload>;
   readonly #encrypt: EncryptFn<EncryptedPayload>;
   constructor(

--- a/packages/core/src/secretStore/encryptedStore.ts
+++ b/packages/core/src/secretStore/encryptedStore.ts
@@ -96,7 +96,7 @@ async function defaultDecrypt({value, iv}: DefaultEncryptedPayload, key: CryptoK
 }
 
 async function defaultEncrypt(data: Uint8Array, key: CryptoKey): Promise<DefaultEncryptedPayload> {
-  const iv = await crypto.getRandomValues(new Uint8Array(12));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
   return {
     iv,
     value: await crypto.subtle.encrypt({name: 'AES-GCM', iv}, key, data),

--- a/packages/core/src/secretStore/secretKeyGenerator.ts
+++ b/packages/core/src/secretStore/secretKeyGenerator.ts
@@ -17,13 +17,7 @@
  *
  */
 
-import {Decoder, Encoder} from 'bazinga64';
-
-import {createCustomEncryptedStore, createEncryptedStore} from './encryptedStore';
-
-import {SecretCrypto} from '../messagingProtocols/mls/types';
-
-const isBase64 = /^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$/;
+import {EncryptedStore} from './encryptedStore';
 
 export class CorruptedKeyError extends Error {}
 
@@ -38,50 +32,15 @@ export type GeneratedKey = {
 export async function generateSecretKey({
   keyId,
   keySize = 16,
-  dbName,
-  systemCrypto: baseCrypto,
+  secretsDb,
 }: {
   /** the ID of the key to generate (if the ID already exists, then the generated key will be returned) */
   keyId: string;
   /** size of the key to generate */
   keySize?: number;
   /** name of the database that will hold the secrets */
-  dbName: string;
-  /** custom crypto primitives to use to encrypt the secret keys */
-  systemCrypto?: SecretCrypto;
+  secretsDb: EncryptedStore<unknown>;
 }): Promise<GeneratedKey> {
-  const systemCrypto = baseCrypto
-    ? {
-        encrypt: (value: Uint8Array) => {
-          if (baseCrypto.version === 1) {
-            const strValue = Encoder.toBase64(value).asString;
-            return baseCrypto.encrypt(strValue);
-          }
-          // In previous versions of the systemCrypto (prior to February 2023), encrypt took a uint8Array
-          return baseCrypto.encrypt(value);
-        },
-
-        decrypt: async (value: Uint8Array) => {
-          if (typeof baseCrypto.version === 'undefined') {
-            // In previous versions of the systemCrypto (prior to February 2023), the decrypt function returned a Uint8Array
-            return baseCrypto.decrypt(value);
-          }
-          const decrypted = await baseCrypto.decrypt(value);
-          if (isBase64.test(decrypted)) {
-            return Decoder.fromBase64(decrypted).asBytes;
-          }
-          // Between June 2022 and October 2022, the systemCrypto returned a string encoded in UTF-8
-          const encoder = new TextEncoder();
-
-          return encoder.encode(decrypted);
-        },
-      }
-    : undefined;
-
-  const secretsDb = systemCrypto
-    ? await createCustomEncryptedStore(dbName, systemCrypto)
-    : await createEncryptedStore(dbName);
-
   try {
     let key;
     try {
@@ -99,10 +58,8 @@ export async function generateSecretKey({
       key = crypto.getRandomValues(new Uint8Array(keySize));
       await secretsDb.saveSecretValue(keyId, key);
     }
-    await secretsDb?.close();
     return {key, deleteKey: () => secretsDb.deleteSecretValue(keyId)};
   } catch (error) {
-    await secretsDb?.close();
     throw error;
   }
 }

--- a/packages/core/src/secretStore/secretKeyGenerator.ts
+++ b/packages/core/src/secretStore/secretKeyGenerator.ts
@@ -39,7 +39,7 @@ export async function generateSecretKey({
   /** size of the key to generate */
   keySize?: number;
   /** name of the database that will hold the secrets */
-  secretsDb: EncryptedStore<unknown>;
+  secretsDb: EncryptedStore<any>;
 }): Promise<GeneratedKey> {
   try {
     let key;


### PR DESCRIPTION
This will make sure the `secets-db ` is wiped when the account is wiped. 

For that, we need to keep track of the secretDB instance in order to wipe it. So we need to change a bit how secret keys are generated. 

Previously generating a secret key would fire up a DB that would be closed right after (and potentially re-openned later on). 
Now we always create the secret DB and eventually use it to generate a key 
