### PR TITLE
fix: Use config ciphersuite when querying e2ei

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -466,7 +466,6 @@ export class Account extends TypedEventEmitter<Events> {
     const clientService = new ClientService(this.apiClient, proteusService, this.storeEngine);
 
     if (clientType === CryptoClientType.CORE_CRYPTO && (await this.isMlsEnabled())) {
-      e2eServiceExternal = new E2EIServiceExternal(cryptoClient.getNativeClient(), clientService);
       mlsService = new MLSService(
         this.apiClient,
         cryptoClient.getNativeClient(),
@@ -475,6 +474,11 @@ export class Account extends TypedEventEmitter<Events> {
         {
           ...this.coreCryptoConfig?.mls,
         },
+      );
+      e2eServiceExternal = new E2EIServiceExternal(
+        cryptoClient.getNativeClient(),
+        clientService,
+        mlsService.config.cipherSuite,
       );
     }
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {CoreCrypto, WireIdentity} from '@wireapp/core-crypto';
+import {Ciphersuite, CoreCrypto, WireIdentity} from '@wireapp/core-crypto';
 
 import {E2EIServiceExternal} from './E2EIServiceExternal';
 
@@ -32,7 +32,10 @@ function buildE2EIService() {
 
   const clientService = {} as jest.Mocked<ClientService>;
 
-  return [new E2EIServiceExternal(coreCrypto, clientService), {coreCrypto}] as const;
+  return [
+    new E2EIServiceExternal(coreCrypto, clientService, Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256),
+    {coreCrypto},
+  ] as const;
 }
 
 function generateCoreCryptoIdentity({

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -35,6 +35,7 @@ export class E2EIServiceExternal {
   public constructor(
     private readonly coreCryptoClient: CoreCrypto,
     private readonly clientService: ClientService,
+    private readonly cipherSuite: Ciphersuite,
   ) {}
 
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
@@ -50,8 +51,8 @@ export class E2EIServiceExternal {
     return this.coreCryptoClient.e2eiConversationState(conversationId);
   }
 
-  public isE2EIEnabled(ciphersuite: Ciphersuite): Promise<boolean> {
-    return this.coreCryptoClient.e2eiIsEnabled(ciphersuite);
+  public isE2EIEnabled(): Promise<boolean> {
+    return this.coreCryptoClient.e2eiIsEnabled(this.cipherSuite);
   }
 
   public async getUsersIdentities(groupId: string, userIds: QualifiedId[]): Promise<Map<string, DeviceIdentity[]>> {


### PR DESCRIPTION
For consistency, we always use the same source of truth for the cipher suite used in the core (the one given in the general config). 