### PR TITLE
feat: fetch local certificate root [WPB-3338]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -48,6 +48,7 @@ import {
   OidcChallengeResponseSchema,
   GetCertificateResponseData,
   GetCertificateResponseSchema,
+  LocalCertificateRootResponseSchema,
 } from './schema';
 
 import {AcmeChallenge, AcmeDirectory} from '../../E2EIService.types';
@@ -57,9 +58,15 @@ export class AcmeService {
   private readonly axiosInstance: AxiosInstance = axios.create();
   private readonly url = {
     DIRECTORY: '/directory',
+    ROOTS: '/roots.pem',
   };
 
   constructor(private discoveryUrl: string) {}
+
+  private get acmeBaseUrl() {
+    const hostname = new URL(this.discoveryUrl ?? '').hostname;
+    return `https://${hostname}`;
+  }
 
   // ############ Internal Functions ############
 
@@ -112,6 +119,12 @@ export class AcmeService {
       this.logger.error('Error while receiving Directory', e);
       return undefined;
     }
+  }
+
+  public async getLocalCertificateRoot(): Promise<string> {
+    const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.ROOTS}`);
+    const localCertificateRoot = LocalCertificateRootResponseSchema.parse(data);
+    return localCertificateRoot;
   }
 
   public async getInitialNonce(url: AcmeDirectory['newNonce']): GetInitialNonceReturnValue {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -64,8 +64,8 @@ export class AcmeService {
   constructor(private discoveryUrl: string) {}
 
   private get acmeBaseUrl() {
-    const hostname = new URL(this.discoveryUrl).hostname;
-    return `https://${hostname}`;
+    const {origin} = new URL(this.discoveryUrl);
+    return origin;
   }
 
   // ############ Internal Functions ############

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -64,7 +64,7 @@ export class AcmeService {
   constructor(private discoveryUrl: string) {}
 
   private get acmeBaseUrl() {
-    const hostname = new URL(this.discoveryUrl ?? '').hostname;
+    const hostname = new URL(this.discoveryUrl).hostname;
     return `https://${hostname}`;
   }
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/schema.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/schema.ts
@@ -41,6 +41,9 @@ export const DirectoryResponseSchema = z.object({
 });
 export type DirectoryResponseData = z.infer<typeof DirectoryResponseSchema>;
 
+export const LocalCertificateRootResponseSchema = nonOptionalString;
+export type LocalCertificateRootResonseData = z.infer<typeof LocalCertificateRootResponseSchema>;
+
 export const NewAccountResponseSchema = z.object({
   status: nonOptionalString,
   orders: nonOptionalUrl,

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -151,7 +151,7 @@ export class E2EIServiceExternal {
    * @param discoveryUrl
    */
   public async registerServerCertificates(discoveryUrl: string): Promise<void> {
-    const ROOT_CA_KEY = 'e2ei_root-received';
+    const ROOT_CA_KEY = 'e2ei_root-registered';
     const store = LocalStorageStore(ROOT_CA_KEY);
     const acmeService = new AcmeService(discoveryUrl);
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -22,11 +22,13 @@ import {Decoder} from 'bazinga64';
 
 import {Ciphersuite, CoreCrypto, E2eiConversationState, WireIdentity, DeviceStatus} from '@wireapp/core-crypto';
 
+import {AcmeService} from './Connection';
 import {getE2EIClientId} from './Helper';
 import {E2EIStorage} from './Storage/E2EIStorage';
 
 import {ClientService} from '../../../client';
 import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUtils';
+import {LocalStorageStore} from '../../../util/LocalStorageStore';
 
 export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {status?: DeviceStatus; deviceId: string};
 
@@ -124,5 +126,45 @@ export class E2EIServiceExternal {
       return true;
     }
     return typeof client.mls_public_keys.ed25519 !== 'string' || client.mls_public_keys.ed25519.length === 0;
+  }
+
+  private async registerLocalCertificateRoot(connection: AcmeService): Promise<string> {
+    const localCertificateRoot = await connection.getLocalCertificateRoot();
+    await this.coreCryptoClient.e2eiRegisterAcmeCA(localCertificateRoot);
+
+    return localCertificateRoot;
+  }
+
+  /**
+   * This function is used to register different server certificates in CoreCrypto.
+   *
+   * 1. Root Certificate: This is the root certificate of the server.
+   * - It must only be registered once.
+   * - It must be the first certificate to be registered. Nothing else will work
+   *
+   * 2. Intermediate Certificate: This is the intermediate certificate of the server. It must be updated every 24 hours.
+   * - It must be registered after the root certificate.
+   * - It must be updated every 24 hours.
+   *
+   * Both must be registered before the first enrollment.
+   *
+   * @param discoveryUrl
+   */
+  public async registerServerCertificates(discoveryUrl: string): Promise<void> {
+    const ROOT_CA_KEY = 'e2ei_root-received';
+    const store = LocalStorageStore(ROOT_CA_KEY);
+    const acmeService = new AcmeService(discoveryUrl);
+
+    // Register root certificate if not already registered
+    if (!store.has(ROOT_CA_KEY)) {
+      try {
+        await this.registerLocalCertificateRoot(acmeService);
+        store.add(ROOT_CA_KEY, 'true');
+      } catch (error) {
+        console.error('Failed to register root certificate', error);
+      }
+    }
+
+    // Register intermediate certificate and update it every 24 hours
   }
 }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -104,9 +104,6 @@ class E2EIServiceInternal {
         );
       }
 
-      // Before we initialise the identity we need to register the local certificate root.
-      await this.registerLocalCertificateRoot(this.acmeService);
-
       await this.initIdentity(hasActiveCertificate);
       return this.startNewOAuthFlow();
     } catch (error) {
@@ -191,20 +188,6 @@ class E2EIServiceInternal {
       throw error;
     }
     return undefined;
-  }
-
-  private async registerLocalCertificateRoot(connection: AcmeService): Promise<string> {
-    try {
-      const localCertificateRoot = await connection.getLocalCertificateRoot();
-      await this.coreCryptoClient.e2eiRegisterAcmeCA(localCertificateRoot);
-
-      return localCertificateRoot;
-    } catch (error) {
-      //TODO: handle errors from corecrypto
-      //open question: how do we recover from these errors
-      this.logger.error('Error while trying to set a local certificate root', error);
-      throw error;
-    }
   }
 
   private async getInitialNonce(directory: AcmeDirectory, connection: AcmeService): Promise<string> {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -104,8 +104,8 @@ class E2EIServiceInternal {
         );
       }
 
-      // Before we initialise the identity we need to validate the local certificate root.
-      await this.validateLocalCertificateRoot(this.acmeService);
+      // Before we initialise the identity we need to register the local certificate root.
+      await this.registerLocalCertificateRoot(this.acmeService);
 
       await this.initIdentity(hasActiveCertificate);
       return this.startNewOAuthFlow();
@@ -193,10 +193,11 @@ class E2EIServiceInternal {
     return undefined;
   }
 
-  private async validateLocalCertificateRoot(connection: AcmeService): Promise<string> {
+  private async registerLocalCertificateRoot(connection: AcmeService): Promise<string> {
     try {
       const localCertificateRoot = await connection.getLocalCertificateRoot();
-      //TODO: pass the cert to core-crypto
+      await this.coreCryptoClient.e2eiRegisterAcmeCA(localCertificateRoot);
+
       return localCertificateRoot;
     } catch (error) {
       //TODO: handle errors from corecrypto

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -97,13 +97,6 @@ class E2EIServiceInternal {
     // If we don't have a handle, we need to start a new OAuth flow
     try {
       // Initialize the identity
-
-      if (!this.acmeService) {
-        throw new Error(
-          'Error while trying to start a certificate process. E2eIdentityService is not fully initialized',
-        );
-      }
-
       await this.initIdentity(hasActiveCertificate);
       return this.startNewOAuthFlow();
     } catch (error) {


### PR DESCRIPTION
Before the first enrolment, we need to fetch the local root certificate and pass it to core-crypto for it to be validated.

This should be done only once.