### PR TITLE
feat: federation cross signed certs [WPB-5391]

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.32",
+    "@wireapp/core-crypto": "1.0.0-rc.33",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -481,6 +481,7 @@ export class Account extends TypedEventEmitter<Events> {
         cryptoClient.getNativeClient(),
         clientService,
         mlsService.config.cipherSuite,
+        this.recurringTaskScheduler,
       );
     }
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -41,6 +41,7 @@ import {
   OidcChallengeResponseSchema,
   GetCertificateResponseSchema,
   LocalCertificateRootResponseSchema,
+  FederationCrossSignedCertificatesResponseSchema,
 } from './schema';
 
 import {AcmeChallenge, AcmeDirectory} from '../../E2EIService.types';
@@ -50,6 +51,7 @@ export class AcmeService {
   private readonly axiosInstance: AxiosInstance = axios.create();
   private readonly url = {
     ROOTS: '/roots.pem',
+    FEDERATION: '/federation',
   };
 
   constructor(private discoveryUrl: string) {}
@@ -106,6 +108,12 @@ export class AcmeService {
     const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.ROOTS}`);
     const localCertificateRoot = LocalCertificateRootResponseSchema.parse(data);
     return localCertificateRoot;
+  }
+
+  public async getFederationCrossSignedCertificates(): Promise<string[]> {
+    const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.FEDERATION}`);
+    const federationCrossSignedCertificates = FederationCrossSignedCertificatesResponseSchema.parse(data);
+    return federationCrossSignedCertificates.crts;
   }
 
   public async getInitialNonce(url: AcmeDirectory['newNonce']): GetInitialNonceReturnValue {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/schema.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/schema.ts
@@ -44,6 +44,11 @@ export type DirectoryResponseData = z.infer<typeof DirectoryResponseSchema>;
 export const LocalCertificateRootResponseSchema = nonOptionalString;
 export type LocalCertificateRootResonseData = z.infer<typeof LocalCertificateRootResponseSchema>;
 
+export const FederationCrossSignedCertificatesResponseSchema = z.object({crts: z.array(nonOptionalString)});
+export type FederationCrossSignedCertificatesResponseData = z.infer<
+  typeof FederationCrossSignedCertificatesResponseSchema
+>;
+
 export const NewAccountResponseSchema = z.object({
   status: nonOptionalString,
   orders: nonOptionalUrl,

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -131,15 +131,15 @@ export class E2EIServiceExternal {
     return typeof client.mls_public_keys.ed25519 !== 'string' || client.mls_public_keys.ed25519.length === 0;
   }
 
-  private async registerLocalCertificateRoot(connection: AcmeService): Promise<string> {
-    const localCertificateRoot = await connection.getLocalCertificateRoot();
+  private async registerLocalCertificateRoot(acmeService: AcmeService): Promise<string> {
+    const localCertificateRoot = await acmeService.getLocalCertificateRoot();
     await this.coreCryptoClient.e2eiRegisterAcmeCA(localCertificateRoot);
 
     return localCertificateRoot;
   }
 
-  private async registerCrossSignedCertificates(connection: AcmeService): Promise<void> {
-    const certificates = await connection.getFederationCrossSignedCertificates();
+  private async registerCrossSignedCertificates(acmeService: AcmeService): Promise<void> {
+    const certificates = await acmeService.getFederationCrossSignedCertificates();
     await Promise.all(certificates.map(cert => this.coreCryptoClient.e2eiRegisterIntermediateCA(cert)));
   }
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -170,12 +170,20 @@ export class E2EIServiceExternal {
     }
 
     // Register intermediate certificate and update it every 24 hours
+
+    const INTERMEDIATE_CA_KEY = 'update-intermediate-certificates';
+    const hasPendingTask = await this.recurringTaskScheduler.hasTask(INTERMEDIATE_CA_KEY);
+
     const task = () => this.registerCrossSignedCertificates(acmeService);
 
-    await task();
+    // If the task was never registered, we run it once, and then register it to run every 24 hours
+    if (!hasPendingTask) {
+      await task();
+    }
+
     await this.recurringTaskScheduler.registerTask({
       every: TimeInMillis.DAY,
-      key: 'update-intermediate-certificates',
+      key: INTERMEDIATE_CA_KEY,
       task,
     });
   }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -165,22 +165,12 @@ export class E2EIServiceExternal {
 
     // Register root certificate if not already registered
     if (!store.has(ROOT_CA_KEY)) {
-      try {
-        await this.registerLocalCertificateRoot(acmeService);
-        store.add(ROOT_CA_KEY, 'true');
-      } catch (error) {
-        console.error('Failed to register root certificate', error);
-      }
+      await this.registerLocalCertificateRoot(acmeService);
+      store.add(ROOT_CA_KEY, 'true');
     }
 
     // Register intermediate certificate and update it every 24 hours
-    const task = async () => {
-      try {
-        await this.registerCrossSignedCertificates(acmeService);
-      } catch (error) {
-        console.error('Failed to register intermediate certificates', error);
-      }
-    };
+    const task = () => this.registerCrossSignedCertificates(acmeService);
 
     await task();
     await this.recurringTaskScheduler.registerTask({

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -226,7 +226,6 @@ export class E2EIServiceInternal {
 
     // Step 7: Do OIDC client challenge
     const oidcData = await doWireOidcChallenge({
-      coreCryptoClient: this.coreCryptoClient,
       oAuthIdToken,
       authData,
       connection: this.acmeService,

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -148,6 +148,19 @@ export class E2EIServiceInternal {
     return undefined;
   }
 
+  private async validateLocalCertificateRoot(connection: AcmeService): Promise<string> {
+    try {
+      const localCertificateRoot = await connection.getLocalCertificateRoot();
+      //TODO: pass the cert to core-crypto
+      return localCertificateRoot;
+    } catch (error) {
+      //TODO: handle errors from corecrypto
+      //open question: how do we recover from these errors
+      this.logger.error('Error while trying to set a local certificate root', error);
+      throw error;
+    }
+  }
+
   private async getInitialNonce(directory: AcmeDirectory, connection: AcmeService): Promise<string> {
     const nonce = await connection.getInitialNonce(directory.newNonce);
     if (!nonce) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -148,20 +148,6 @@ export class E2EIServiceInternal {
     return undefined;
   }
 
-  private async registerLocalCertificateRoot(connection: AcmeService): Promise<string> {
-    try {
-      const localCertificateRoot = await connection.getLocalCertificateRoot();
-      await this.coreCryptoClient.e2eiRegisterAcmeCA(localCertificateRoot);
-
-      return localCertificateRoot;
-    } catch (error) {
-      //TODO: handle errors from corecrypto
-      //open question: how do we recover from these errors
-      this.logger.error('Error while trying to set a local certificate root', error);
-      throw error;
-    }
-  }
-
   private async getInitialNonce(directory: AcmeDirectory, connection: AcmeService): Promise<string> {
     const nonce = await connection.getInitialNonce(directory.newNonce);
     if (!nonce) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -148,10 +148,11 @@ export class E2EIServiceInternal {
     return undefined;
   }
 
-  private async validateLocalCertificateRoot(connection: AcmeService): Promise<string> {
+  private async registerLocalCertificateRoot(connection: AcmeService): Promise<string> {
     try {
       const localCertificateRoot = await connection.getLocalCertificateRoot();
-      //TODO: pass the cert to core-crypto
+      await this.coreCryptoClient.e2eiRegisterAcmeCA(localCertificateRoot);
+
       return localCertificateRoot;
     } catch (error) {
       //TODO: handle errors from corecrypto

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/OidcChallenge.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/OidcChallenge.ts
@@ -20,11 +20,10 @@
 import {Converter} from 'bazinga64';
 
 import {AcmeService} from '../Connection/AcmeServer';
-import {CoreCrypto, E2eiEnrollment, Nonce} from '../E2EIService.types';
+import {E2eiEnrollment, Nonce} from '../E2EIService.types';
 import {AuthData} from '../Storage/E2EIStorage.schema';
 
 interface DoWireOidcChallengeParams {
-  coreCryptoClient: CoreCrypto;
   authData: AuthData;
   identity: E2eiEnrollment;
   connection: AcmeService;
@@ -33,7 +32,6 @@ interface DoWireOidcChallengeParams {
 }
 
 export const doWireOidcChallenge = async ({
-  coreCryptoClient,
   connection,
   authData,
   identity,
@@ -45,15 +43,13 @@ export const doWireOidcChallenge = async ({
     throw new Error('No wireOIDCChallenge defined');
   }
 
-  const refreshToken = 'empty'; // CC just stores the refresh token (which we don't need for web, as our oidc library does that for us)
-  const reqBody = await identity.newOidcChallengeRequest(oAuthIdToken, refreshToken, nonce);
+  const reqBody = await identity.newOidcChallengeRequest(oAuthIdToken, nonce);
 
   const oidcChallengeResponse = await connection.validateOidcChallenge(oidcChallenge.url, reqBody);
   if (!oidcChallengeResponse) {
     throw new Error('No response received while validating OIDC challenge');
   }
   await identity.newOidcChallengeResponse(
-    coreCryptoClient,
     Converter.stringToArrayBufferViewUTF8(JSON.stringify(oidcChallengeResponse.data)),
   );
 

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -68,4 +68,8 @@ export class RecurringTaskScheduler {
     TaskScheduler.cancelTask(taskKey);
     LowPrecisionTaskScheduler.cancelTask({intervalDelay: TimeUtil.TimeInMillis.MINUTE, key: taskKey});
   };
+
+  public readonly hasTask = async (taskKey: string): Promise<boolean> => {
+    return !!(await this.storage.get(taskKey));
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5208,10 +5208,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:1.0.0-rc.32":
-  version: 1.0.0-rc.32
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.32"
-  checksum: b8d5c8b28308e276419fd8528cee1ca2eb55f74e47d1ea7ca24054e6a13dd76a4f8fb761bf0697848942a06f412a6ee22491bb14eae30954bf09e2433f9181b6
+"@wireapp/core-crypto@npm:1.0.0-rc.33":
+  version: 1.0.0-rc.33
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.33"
+  checksum: 44b88f4b7a1ec2ce9c13ce48329c53193c91833f13345abf28e3bfcf51f41ab510187d1192dcf76293c23b9fa4167e67ee1bd084a9739f2dc598ca7987258d27
   languageName: node
   linkType: hard
 
@@ -5228,7 +5228,7 @@ __metadata:
     "@types/tough-cookie": 4.0.5
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 1.0.0-rc.32
+    "@wireapp/core-crypto": 1.0.0-rc.33
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
Fetch cross-signed (federated) certificates from acme server and pass them to core-crypto. We do this periodically - first on app load and then every 24h.

This PR also bumps core-crypto to version `.rc33`.