### PR TITLE
refactor: Improve E2EI enrollment error handling

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -53,7 +53,7 @@ import {SubconversationService} from './conversation/SubconversationService/Subc
 import {GiphyService} from './giphy/';
 import {LinkPreviewService} from './linkPreview';
 import {MLSService} from './messagingProtocols/mls';
-import {E2EIServiceExternal, StartNewOAuthFlowReturnValue, User} from './messagingProtocols/mls/E2EIdentityService';
+import {E2EIServiceExternal, User} from './messagingProtocols/mls/E2EIdentityService';
 import {CoreCallbacks, CoreCryptoConfig, SecretCrypto} from './messagingProtocols/mls/types';
 import {NewClient, ProteusService} from './messagingProtocols/proteus';
 import {CryptoClientType} from './messagingProtocols/proteus/ProteusService/CryptoClient';
@@ -237,14 +237,16 @@ export class Account extends TypedEventEmitter<Events> {
   public async enrollE2EI({
     displayName,
     handle,
+    teamId,
     discoveryUrl,
     oAuthIdToken,
   }: {
     displayName: string;
     handle: string;
+    teamId: string;
     discoveryUrl: string;
     oAuthIdToken?: string;
-  }): Promise<StartNewOAuthFlowReturnValue | boolean> {
+  }) {
     const context = this.apiClient.context;
     const domain = context?.domain ?? '';
 
@@ -253,14 +255,14 @@ export class Account extends TypedEventEmitter<Events> {
     }
 
     if (!this.service?.mls || !this.service?.e2eIdentity) {
-      this.logger.info('MLS not initialized, unable to enroll E2EI');
-      return false;
+      throw new Error('MLS not initialized, unable to enroll E2EI');
     }
 
     const user: User = {
       displayName,
       handle,
       domain,
+      teamId,
       id: this.userId,
     };
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -27,26 +27,18 @@ import {
   PostJoseRequestReturnValue,
 } from './AcmeService.types';
 import {
-  AuthorizationResponseData,
   AuthorizationResponseSchema,
   DirectoryResponseSchema,
-  NewAccountResponseData,
   NewAccountResponseSchema,
-  NewOrderResponseData,
   NewOrderResponseSchema,
   ResponseHeaderLocation,
   ResponseHeaderLocationSchema,
   ResponseHeaderNonce,
   ResponseHeaderNonceSchema,
-  CheckStatusOfOrderResponseData,
   CheckStatusOfOrderResponseSchema,
-  DpopChallengeResponseData,
   DpopChallengeResponseSchema,
-  FinalizeOrderResponseData,
   FinalizeOrderResponseSchema,
-  OidcChallengeResponseData,
   OidcChallengeResponseSchema,
-  GetCertificateResponseData,
   GetCertificateResponseSchema,
   LocalCertificateRootResponseSchema,
 } from './schema';
@@ -81,30 +73,20 @@ export class AcmeService {
     payload,
     schema,
     url,
-    errorMessage,
     shouldGetLocation = false,
-  }: PostJoseRequestParams<T>): PostJoseRequestReturnValue<T> {
-    try {
-      const {data, headers} = await this.axiosInstance.post(url, payload, {
-        headers: {
-          'Content-Type': 'application/jose+json',
-        },
-      });
-      let location = undefined;
-      const nonce = this.extractNonce(headers);
-      if (shouldGetLocation) {
-        location = this.extractLocation(headers);
-      }
-      const accountData = schema.parse(data);
-      return {
-        data: accountData,
-        nonce,
-        location,
-      };
-    } catch (e) {
-      this.logger.error(errorMessage, e);
-      return undefined;
-    }
+  }: PostJoseRequestParams<T>): Promise<PostJoseRequestReturnValue<T>> {
+    const {data, headers} = await this.axiosInstance.post(url, payload, {
+      headers: {
+        'Content-Type': 'application/jose+json',
+      },
+    });
+    const nonce = this.extractNonce(headers);
+    const accountData = schema.parse(data);
+    return {
+      data: accountData,
+      nonce,
+      location: shouldGetLocation ? this.extractLocation(headers) : undefined,
+    };
   }
 
   // ############ Public Functions ############
@@ -138,8 +120,7 @@ export class AcmeService {
   }
 
   public async createNewAccount(url: AcmeDirectory['newAccount'], payload: Uint8Array) {
-    return this.postJoseRequest<NewAccountResponseData>({
-      errorMessage: 'Error while creating new Account',
+    return this.postJoseRequest({
       payload,
       schema: NewAccountResponseSchema,
       url,
@@ -147,8 +128,7 @@ export class AcmeService {
   }
 
   public async createNewOrder(url: AcmeDirectory['newOrder'], payload: Uint8Array) {
-    return this.postJoseRequest<NewOrderResponseData>({
-      errorMessage: 'Error while creating new Order',
+    return this.postJoseRequest({
       payload,
       schema: NewOrderResponseSchema,
       url,
@@ -157,8 +137,7 @@ export class AcmeService {
   }
 
   public async getAuthorization(url: string, payload: Uint8Array) {
-    return this.postJoseRequest<AuthorizationResponseData>({
-      errorMessage: 'Error while receiving Authorization',
+    return this.postJoseRequest({
       payload,
       schema: AuthorizationResponseSchema,
       url,
@@ -166,8 +145,7 @@ export class AcmeService {
   }
 
   public async validateDpopChallenge(url: AcmeChallenge['url'], payload: Uint8Array) {
-    return this.postJoseRequest<DpopChallengeResponseData>({
-      errorMessage: 'Error while validating DPOP challenge',
+    return this.postJoseRequest({
       payload,
       schema: DpopChallengeResponseSchema,
       url,
@@ -175,8 +153,7 @@ export class AcmeService {
   }
 
   public async validateOidcChallenge(url: AcmeChallenge['url'], payload: Uint8Array) {
-    return this.postJoseRequest<OidcChallengeResponseData>({
-      errorMessage: 'Error while validating OIDC challenge',
+    return this.postJoseRequest({
       payload,
       schema: OidcChallengeResponseSchema,
       url,
@@ -184,8 +161,7 @@ export class AcmeService {
   }
 
   public async checkStatusOfOrder(url: string, payload: Uint8Array) {
-    return this.postJoseRequest<CheckStatusOfOrderResponseData>({
-      errorMessage: 'Error while checking status of Order',
+    return this.postJoseRequest({
       payload,
       schema: CheckStatusOfOrderResponseSchema,
       url,
@@ -193,8 +169,7 @@ export class AcmeService {
   }
 
   public async finalizeOrder(url: string, payload: Uint8Array) {
-    return this.postJoseRequest<FinalizeOrderResponseData>({
-      errorMessage: 'Error while finalizing Order',
+    return this.postJoseRequest({
       payload,
       schema: FinalizeOrderResponseSchema,
       url,
@@ -202,8 +177,7 @@ export class AcmeService {
   }
 
   public async getCertificate(url: string, payload: Uint8Array) {
-    return this.postJoseRequest<GetCertificateResponseData>({
-      errorMessage: 'Error while receiving Certificate',
+    return this.postJoseRequest({
       payload,
       schema: GetCertificateResponseSchema,
       url,

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.types.ts
@@ -29,14 +29,10 @@ export interface PostJoseRequestParams<T> {
   url: string;
   payload: Uint8Array;
   schema: ZodSchema<T>;
-  errorMessage: string;
   shouldGetLocation?: boolean;
 }
-export type PostJoseRequestReturnValue<T> = Promise<
-  | {
-      data: T;
-      nonce: Nonce;
-      location?: string;
-    }
-  | undefined
->;
+export type PostJoseRequestReturnValue<T> = {
+  data: T;
+  nonce: Nonce;
+  location?: string;
+};

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIService.types.ts
@@ -36,7 +36,7 @@ import {E2EIServiceExternal} from './E2EIServiceExternal';
 type OmitFree<T> = Omit<T, 'free'>;
 type NewAcmeAuthzOriginal = OmitFree<Awaited<ReturnType<E2eiEnrollment['newAuthzResponse']>>>;
 export type AcmeDirectory = OmitFree<Awaited<ReturnType<E2eiEnrollment['directoryResponse']>>>;
-export type AcmeChallenge = OmitFree<NonNullable<NewAcmeAuthzOriginal['wireDpopChallenge']>>;
+export type AcmeChallenge = OmitFree<NonNullable<NewAcmeAuthzOriginal['wireOidcChallenge']>>;
 export type NewAcmeOrder = OmitFree<Awaited<ReturnType<E2eiEnrollment['newOrderResponse']>>>;
 export type NewAcmeAuthz = Pick<Awaited<ReturnType<E2eiEnrollment['newAuthzResponse']>>, 'identifier' | 'keyauth'> & {
   wireDpopChallenge?: AcmeChallenge;
@@ -48,6 +48,7 @@ export type User = {
   id: string;
   domain: string;
   displayName: string;
+  teamId: string;
   handle: string;
 };
 export type Account = Uint8Array;
@@ -74,9 +75,4 @@ export interface InitParams {
   skipInit?: boolean;
   discoveryUrl?: string;
   keyPackagesAmount: number;
-}
-
-export interface StartNewOAuthFlowReturnValue {
-  challenge: AcmeChallenge;
-  keyAuth: KeyAuth;
 }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/Authorization.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/Authorization.ts
@@ -27,14 +27,14 @@ interface GetAuthorizationParams {
   identity: E2eiEnrollment;
   connection: AcmeService;
 }
-export type GetAuthorizationReturnValue = {authorization: NewAcmeAuthz; nonce: Nonce};
+export type AuthorizationChallenge = {authorization: NewAcmeAuthz; nonce: Nonce};
 
-export const getAuthorization = async ({
+export const getAuthorizationChallenges = async ({
   authzUrl,
   nonce,
   identity,
   connection,
-}: GetAuthorizationParams): Promise<GetAuthorizationReturnValue> => {
+}: GetAuthorizationParams): Promise<AuthorizationChallenge> => {
   const reqBody = await identity.newAuthzRequest(authzUrl, nonce);
   const response = await connection.getAuthorization(authzUrl, reqBody);
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.types.ts
@@ -22,13 +22,13 @@ import {APIClient} from '@wireapp/api-client';
 import {ClientId} from '../../../types';
 import {AcmeService} from '../../Connection/AcmeServer';
 import {E2eiEnrollment, Nonce, User} from '../../E2EIService.types';
-import {GetAuthorizationReturnValue} from '../Authorization';
+import {AuthorizationChallenge} from '../Authorization';
 
 export interface DoWireDpopChallengeParams {
   apiClient: APIClient;
   clientId: ClientId;
   userDomain: User['domain'];
-  authData: GetAuthorizationReturnValue;
+  authData: AuthorizationChallenge;
   identity: E2eiEnrollment;
   connection: AcmeService;
   nonce: Nonce;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/OidcChallenge.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/OidcChallenge.ts
@@ -19,14 +19,14 @@
 
 import {Converter} from 'bazinga64';
 
-import {GetAuthorizationReturnValue} from './Authorization';
+import {AuthorizationChallenge} from './Authorization';
 
 import {AcmeService} from '../Connection/AcmeServer';
 import {CoreCrypto, E2eiEnrollment, Nonce} from '../E2EIService.types';
 
 interface DoWireOidcChallengeParams {
   coreCryptoClient: CoreCrypto;
-  authData: GetAuthorizationReturnValue;
+  authData: AuthorizationChallenge;
   identity: E2eiEnrollment;
   connection: AcmeService;
   nonce: Nonce;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.schema.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.schema.ts
@@ -27,6 +27,7 @@ export const InitialDataSchema = z.object({
     displayName: z.string(),
     handle: z.string(),
     domain: z.string(),
+    teamId: z.string(),
   }),
 });
 export type InitialData = z.infer<typeof InitialDataSchema>;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
@@ -50,8 +50,8 @@ const getAndVerifyAuthData = (): AuthData => {
   if (!data) {
     throw new Error('ACME: AuthData not found');
   }
-  const atob = window.atob(data);
-  return AuthDataSchema.parse(JSON.parse(atob));
+  const decodedData = window.atob(data);
+  return AuthDataSchema.parse(JSON.parse(decodedData));
 };
 
 const getInitialData = (): InitialData => {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -51,8 +51,9 @@ import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUt
 import {numberToHex} from '../../../util/numberToHex';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {TaskScheduler} from '../../../util/TaskScheduler';
-import {E2EIServiceExternal, StartNewOAuthFlowReturnValue, User} from '../E2EIdentityService';
+import {E2EIServiceExternal, User} from '../E2EIdentityService';
 import {E2EIServiceInternal} from '../E2EIdentityService/E2EIServiceInternal';
+import {AuthorizationChallenge} from '../E2EIdentityService/Steps/Authorization';
 import {handleMLSMessageAdd, handleMLSWelcomeMessage} from '../EventHandler/events';
 import {
   deleteMLSMessagesQueue,
@@ -67,6 +68,13 @@ import {generateMLSDeviceId} from '../utils/MLSId';
 export const optionalToUint8Array = (array: Uint8Array | []): Uint8Array => {
   return Array.isArray(array) ? Uint8Array.from(array) : array;
 };
+
+type EnrollmentProcessState =
+  | {
+      status: 'authentication';
+      authenticationChallenge: AuthorizationChallenge;
+    }
+  | {status: 'successful'};
 
 interface LocalMLSServiceConfig extends MLSServiceConfig {
   /**
@@ -779,7 +787,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     client: RegisteredClient,
     nbPrekeys: number,
     oAuthIdToken?: string,
-  ): Promise<StartNewOAuthFlowReturnValue | boolean> {
+  ): Promise<EnrollmentProcessState> {
     try {
       const hasActiveCertificate = await this.coreCryptoClient.e2eiIsEnabled(this.config.cipherSuite);
       const instance = await E2EIServiceInternal.getInstance({
@@ -795,50 +803,48 @@ export class MLSService extends TypedEventEmitter<Events> {
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth
       if (!oAuthIdToken) {
         const data = await instance.startCertificateProcess(hasActiveCertificate);
-        if (data) {
-          return data;
+        const oidcChallenge = data.authorization.wireOidcChallenge;
+        if (!oidcChallenge) {
+          throw new Error('Not oidc challenge found');
         }
-        // If we have an OAuth id token, we can continue the certificate process / start a refresh
-      } else {
-        let rotateBundle;
-
-        // If we are not refreshing the active certificate, we need to continue the certificate process with Oauth
-        if (!hasActiveCertificate) {
-          rotateBundle = await instance.continueCertificateProcess(oAuthIdToken);
-          // If we are refreshing the active certificate, can start the refresh process
-        } else {
-          rotateBundle = await instance.startRefreshCertficateFlow(oAuthIdToken, hasActiveCertificate);
-        }
-
-        if (rotateBundle !== undefined) {
-          // upload the clients public keys
-          if (!hasActiveCertificate) {
-            // we only upload public keys for the initial certification process. Renewals do not need to upload new public keys
-            await this.uploadMLSPublicKeys(client);
-          }
-          // Remove old key packages
-          await this.deleteMLSKeyPackages(client.id, rotateBundle.keyPackageRefsToRemove);
-          // Upload new key packages with x509 certificate
-          await this.uploadMLSKeyPackages(client.id, rotateBundle.newKeyPackages);
-          // Verify that we have enough key packages
-          await this.verifyRemoteMLSKeyPackagesAmount(client.id);
-          // Update keying material
-          for (const [groupId, commitBundle] of rotateBundle.commits) {
-            const groupIdAsBytes = Converter.hexStringToArrayBufferView(groupId);
-            // manual copy of the commit bundle data because of a problem while cloning it
-            const newCommitBundle = {
-              commit: commitBundle.commit,
-              // @ts-ignore
-              groupInfo: commitBundle?.group_info || commitBundle.groupInfo,
-              welcome: commitBundle?.welcome,
-            };
-
-            await this.uploadCommitBundle(groupIdAsBytes, newCommitBundle);
-          }
-          return true;
-        }
+        return {status: 'authentication', authenticationChallenge: oidcChallenge};
       }
-      return false;
+
+      // If we have an OAuth id token, we can continue the certificate process / start a refresh
+      const rotateBundle = !hasActiveCertificate
+        ? // If we are not refreshing the active certificate, we need to continue the certificate process with Oauth
+          await instance.continueCertificateProcess(oAuthIdToken)
+        : // If we are refreshing the active certificate, can start the refresh process
+          await instance.startRefreshCertficateFlow(oAuthIdToken, hasActiveCertificate);
+
+      if (rotateBundle === undefined) {
+        throw new Error('Could not get the rotate bundle');
+      }
+      // upload the clients public keys
+      if (!hasActiveCertificate) {
+        // we only upload public keys for the initial certification process. Renewals do not need to upload new public keys
+        await this.uploadMLSPublicKeys(client);
+      }
+      // Remove old key packages
+      await this.deleteMLSKeyPackages(client.id, rotateBundle.keyPackageRefsToRemove);
+      // Upload new key packages with x509 certificate
+      await this.uploadMLSKeyPackages(client.id, rotateBundle.newKeyPackages);
+      // Verify that we have enough key packages
+      await this.verifyRemoteMLSKeyPackagesAmount(client.id);
+      // Update keying material
+      for (const [groupId, commitBundle] of rotateBundle.commits) {
+        const groupIdAsBytes = Converter.hexStringToArrayBufferView(groupId);
+        // manual copy of the commit bundle data because of a problem while cloning it
+        const newCommitBundle = {
+          commit: commitBundle.commit,
+          // @ts-ignore
+          groupInfo: commitBundle?.group_info || commitBundle.groupInfo,
+          welcome: commitBundle?.welcome,
+        };
+
+        await this.uploadCommitBundle(groupIdAsBytes, newCommitBundle);
+      }
+      return {status: 'successful'};
     } catch (error) {
       this.logger.error('E2EI - Failed to enroll', error);
       throw error;

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -51,9 +51,8 @@ import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUt
 import {numberToHex} from '../../../util/numberToHex';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {TaskScheduler} from '../../../util/TaskScheduler';
-import {E2EIServiceExternal, User} from '../E2EIdentityService';
+import {AcmeChallenge, E2EIServiceExternal, User} from '../E2EIdentityService';
 import {E2EIServiceInternal} from '../E2EIdentityService/E2EIServiceInternal';
-import {AuthorizationChallenge} from '../E2EIdentityService/Steps/Authorization';
 import {handleMLSMessageAdd, handleMLSWelcomeMessage} from '../EventHandler/events';
 import {
   deleteMLSMessagesQueue,
@@ -72,7 +71,7 @@ export const optionalToUint8Array = (array: Uint8Array | []): Uint8Array => {
 type EnrollmentProcessState =
   | {
       status: 'authentication';
-      authenticationChallenge: AuthorizationChallenge;
+      authenticationChallenge: {keyAuth: string; challenge: AcmeChallenge};
     }
   | {status: 'successful'};
 
@@ -803,11 +802,11 @@ export class MLSService extends TypedEventEmitter<Events> {
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth
       if (!oAuthIdToken) {
         const data = await instance.startCertificateProcess(hasActiveCertificate);
-        const oidcChallenge = data.authorization.wireOidcChallenge;
+        const oidcChallenge = data.challenge;
         if (!oidcChallenge) {
           throw new Error('Not oidc challenge found');
         }
-        return {status: 'authentication', authenticationChallenge: oidcChallenge};
+        return {status: 'authentication', authenticationChallenge: data};
       }
 
       // If we have an OAuth id token, we can continue the certificate process / start a refresh


### PR DESCRIPTION
This is preparation of installing core-crypto 1.0.0-rc.31 that will change the format of the challenges returned.
It improves a few areas:
- error reporting (avoid, as much as possible, catching errors in the deep layers of the flow, and let them bubble up)
- types refactoring (avoid having duplicated definitions)
- minor code improvements