### PR TITLE
feat: maintain revocation list timers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.33",
+    "@wireapp/core-crypto": "1.0.0-rc.34",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -477,11 +477,15 @@ export class Account extends TypedEventEmitter<Events> {
           ...this.coreCryptoConfig?.mls,
         },
       );
+
       e2eServiceExternal = new E2EIServiceExternal(
         cryptoClient.getNativeClient(),
+        this.db,
         clientService,
         mlsService.config.cipherSuite,
       );
+
+      mlsService.on('newCrlDistributionPoints', e2eServiceExternal.handleNewCrlDistributionPoints);
     }
 
     const connectionService = new ConnectionService(this.apiClient);

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -481,9 +481,9 @@ export class Account extends TypedEventEmitter<Events> {
       e2eServiceExternal = new E2EIServiceExternal(
         cryptoClient.getNativeClient(),
         this.db,
+        this.recurringTaskScheduler,
         clientService,
         mlsService.config.cipherSuite,
-        this.recurringTaskScheduler,
       );
 
       mlsService.on('newCrlDistributionPoints', e2eServiceExternal.handleNewCrlDistributionPoints);

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -486,7 +486,7 @@ export class Account extends TypedEventEmitter<Events> {
         mlsService.config.cipherSuite,
       );
 
-      mlsService.on('newCrlDistributionPoints', e2eServiceExternal.handleNewCrlDistributionPoints);
+      mlsService.on('newCrlDistributionPoints', e2eServiceExternal.handleNewRemoteCrlDistributionPoints);
     }
 
     const connectionService = new ConnectionService(this.apiClient);

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -50,7 +50,8 @@ export class AcmeService {
   private readonly axiosInstance: AxiosInstance = axios.create();
   private readonly url = {
     ROOTS: '/roots.pem',
-  };
+    PROXY_CRL: '/proxyCrl',
+  } as const;
 
   constructor(private discoveryUrl: string) {}
 
@@ -106,6 +107,22 @@ export class AcmeService {
     const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.ROOTS}`);
     const localCertificateRoot = LocalCertificateRootResponseSchema.parse(data);
     return localCertificateRoot;
+  }
+
+  public async getCRLFromDistributionPoint(distributionPointUrl: string): Promise<Uint8Array> {
+    const response = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.PROXY_CRL}/${distributionPointUrl}`, {
+      headers: {
+        'Content-Type': '*/*',
+        Accept: '*/*',
+      },
+      responseType: 'arraybuffer',
+    });
+    const {data} = response;
+
+    return data;
+
+    // eslint-disable-next-line no-console
+    console.log('patryk', {data, response});
   }
 
   public async getInitialNonce(url: AcmeDirectory['newNonce']): GetInitialNonceReturnValue {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -42,6 +42,7 @@ import {
   GetCertificateResponseSchema,
   LocalCertificateRootResponseSchema,
   FederationCrossSignedCertificatesResponseSchema,
+  CrlResponseSchema,
 } from './schema';
 
 import {AcmeChallenge, AcmeDirectory} from '../../E2EIService.types';
@@ -112,16 +113,13 @@ export class AcmeService {
   }
 
   public async getCRLFromDistributionPoint(distributionPointUrl: string): Promise<Uint8Array> {
-    const response = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.PROXY_CRL}/${distributionPointUrl}`, {
-      headers: {
-        'Content-Type': '*/*',
-        Accept: '*/*',
-      },
+    const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.PROXY_CRL}/${distributionPointUrl}`, {
       responseType: 'arraybuffer',
     });
-    const {data} = response;
+    const crl = CrlResponseSchema.parse(data);
+    const crlUint8Array = new Uint8Array(crl);
 
-    return data;
+    return crlUint8Array;
   }
 
   public async getFederationCrossSignedCertificates(): Promise<string[]> {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -52,6 +52,7 @@ export class AcmeService {
   private readonly axiosInstance: AxiosInstance = axios.create();
   private readonly url = {
     ROOTS: '/roots.pem',
+    CRL: '/crl',
     PROXY_CRL: '/proxyCrl',
     FEDERATION: '/federation',
   } as const;
@@ -106,6 +107,19 @@ export class AcmeService {
     }
   }
 
+  public async getSelfCRL(): Promise<{crl: Uint8Array; url: string}> {
+    const url = `${this.acmeBaseUrl}${this.url.CRL}`;
+
+    const {data} = await this.axiosInstance.get(url, {
+      responseType: 'arraybuffer',
+    });
+
+    const crl = CrlResponseSchema.parse(data);
+    const crlUint8Array = new Uint8Array(crl);
+
+    return {url, crl: crlUint8Array};
+  }
+
   public async getLocalCertificateRoot(): Promise<string> {
     const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.ROOTS}`);
     const localCertificateRoot = LocalCertificateRootResponseSchema.parse(data);
@@ -116,6 +130,7 @@ export class AcmeService {
     const {data} = await this.axiosInstance.get(`${this.acmeBaseUrl}${this.url.PROXY_CRL}/${distributionPointUrl}`, {
       responseType: 'arraybuffer',
     });
+
     const crl = CrlResponseSchema.parse(data);
     const crlUint8Array = new Uint8Array(crl);
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/schema.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/schema.ts
@@ -44,6 +44,11 @@ export type DirectoryResponseData = z.infer<typeof DirectoryResponseSchema>;
 export const LocalCertificateRootResponseSchema = nonOptionalString;
 export type LocalCertificateRootResonseData = z.infer<typeof LocalCertificateRootResponseSchema>;
 
+export const CrlResponseSchema = z.instanceof(ArrayBuffer).refine(arr => arr.byteLength > 0, {
+  message: 'CRL is empty',
+});
+export type CrlResponseData = z.infer<typeof CrlResponseSchema>;
+
 export const FederationCrossSignedCertificatesResponseSchema = z.object({crts: z.array(nonOptionalString)});
 export type FederationCrossSignedCertificatesResponseData = z.infer<
   typeof FederationCrossSignedCertificatesResponseSchema

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
@@ -22,9 +22,10 @@ import {Ciphersuite, CoreCrypto, WireIdentity} from '@wireapp/core-crypto';
 import {E2EIServiceExternal} from './E2EIServiceExternal';
 
 import {ClientService} from '../../../client';
+import {openDB} from '../../../storage/CoreDB';
 import {getUUID} from '../../../test/PayloadHelper';
 
-function buildE2EIService() {
+async function buildE2EIService() {
   const coreCrypto = {
     getUserIdentities: jest.fn(),
     getClientIds: jest.fn().mockResolvedValue([]),
@@ -32,8 +33,10 @@ function buildE2EIService() {
 
   const clientService = {} as jest.Mocked<ClientService>;
 
+  const mockedDb = await openDB('core-test-db');
+
   return [
-    new E2EIServiceExternal(coreCrypto, clientService, Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256),
+    new E2EIServiceExternal(coreCrypto, mockedDb, clientService, Ciphersuite.MLS_128_DHKEMP256_AES128GCM_SHA256_P256),
     {coreCrypto},
   ] as const;
 }
@@ -64,7 +67,7 @@ const groupId = 'AAEAAhJrE+8TbFFUqiagedTYDUMAZWxuYS53aXJlLmxpbms=';
 describe('E2EIServiceExternal', () => {
   describe('getUsersIdentities', () => {
     it('returns the user identities', async () => {
-      const [service, {coreCrypto}] = buildE2EIService();
+      const [service, {coreCrypto}] = await buildE2EIService();
       const user1 = {domain: 'elna.wire.link', id: '48a1c3b0-4b0e-4bcd-93ad-64c7344b1534'};
       const user2 = {domain: 'elna.wire.link', id: 'b7d287e4-7bbd-40e0-a550-6b18dcaf5f31'};
       const userIds = [user1, user2];
@@ -83,7 +86,7 @@ describe('E2EIServiceExternal', () => {
     });
 
     it('returns MLS basic devices with empty identity', async () => {
-      const [service, {coreCrypto}] = buildE2EIService();
+      const [service, {coreCrypto}] = await buildE2EIService();
       const user1 = {domain: 'elna.wire.link', id: '48a1c3b0-4b0e-4bcd-93ad-64c7344b1534'};
       const user2 = {domain: 'elna.wire.link', id: 'b7d287e4-7bbd-40e0-a550-6b18dcaf5f31'};
       const userIds = [user1, user2];

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -211,7 +211,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     });
   }
 
-  public async getCRLFromDistributionPoint(distributionPointUrl: string): Promise<any> {
+  public async getCRLFromDistributionPoint(distributionPointUrl: string): Promise<Uint8Array> {
     return this.acmeService.getCRLFromDistributionPoint(distributionPointUrl);
   }
 
@@ -243,16 +243,15 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
 
   private async validateCrlDistributionPoint(distributionPointUrl: string): Promise<void> {
     const domain = new URL(distributionPointUrl).hostname;
-
     const crl = await this.getCRLFromDistributionPoint(domain);
 
-    const {expiration, dirty} = await this.coreCryptoClient.e2eiRegisterCRL(domain, crl);
+    const {expiration, dirty} = await this.coreCryptoClient.e2eiRegisterCRL(distributionPointUrl, crl);
 
-    await this.cancelCrlDistributionTimer(domain);
+    await this.cancelCrlDistributionTimer(distributionPointUrl);
 
     //set a new timer that will execute a task once the CRL is expired
     if (expiration) {
-      await this.addCrlDistributionTimer({expiresAt: expiration, url: domain});
+      await this.addCrlDistributionTimer({expiresAt: expiration, url: distributionPointUrl});
     }
 
     //if it was dirty, trigger e2eiconversationstate for every conversation

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -18,6 +18,7 @@
  */
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {Decoder} from 'bazinga64';
 
 import {Ciphersuite, CoreCrypto, E2eiConversationState, WireIdentity, DeviceStatus} from '@wireapp/core-crypto';
@@ -27,18 +28,25 @@ import {getE2EIClientId} from './Helper';
 import {E2EIStorage} from './Storage/E2EIStorage';
 
 import {ClientService} from '../../../client';
+import {CoreDatabase} from '../../../storage/CoreDB';
 import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUtils';
 import {LocalStorageStore} from '../../../util/LocalStorageStore';
+import {LowPrecisionTaskScheduler} from '../../../util/LowPrecisionTaskScheduler';
 
 export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {status?: DeviceStatus; deviceId: string};
 
 // This export is meant to be accessible from the outside (e.g the Webapp / UI)
 export class E2EIServiceExternal {
+  private _acmeService?: AcmeService;
+
   public constructor(
     private readonly coreCryptoClient: CoreCrypto,
+    private readonly coreDatabase: CoreDatabase,
     private readonly clientService: ClientService,
     private readonly cipherSuite: Ciphersuite,
-  ) {}
+  ) {
+    void this.initialiseCrlDistributionTimers();
+  }
 
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
   public isEnrollmentInProgress(): boolean {
@@ -135,6 +143,17 @@ export class E2EIServiceExternal {
     return localCertificateRoot;
   }
 
+  public async initialize(discoveryUrl: string): Promise<void> {
+    this._acmeService = new AcmeService(discoveryUrl);
+  }
+
+  private get acmeService(): AcmeService {
+    if (!this._acmeService) {
+      throw new Error('AcmeService not initialized');
+    }
+    return this._acmeService;
+  }
+
   /**
    * This function is used to register different server certificates in CoreCrypto.
    *
@@ -150,15 +169,14 @@ export class E2EIServiceExternal {
    *
    * @param discoveryUrl
    */
-  public async registerServerCertificates(discoveryUrl: string): Promise<void> {
+  public async registerServerCertificates(): Promise<void> {
     const ROOT_CA_KEY = 'e2ei_root-registered';
     const store = LocalStorageStore(ROOT_CA_KEY);
-    const acmeService = new AcmeService(discoveryUrl);
 
     // Register root certificate if not already registered
     if (!store.has(ROOT_CA_KEY)) {
       try {
-        await this.registerLocalCertificateRoot(acmeService);
+        await this.registerLocalCertificateRoot(this.acmeService);
         store.add(ROOT_CA_KEY, 'true');
       } catch (error) {
         console.error('Failed to register root certificate', error);
@@ -166,5 +184,58 @@ export class E2EIServiceExternal {
     }
 
     // Register intermediate certificate and update it every 24 hours
+  }
+
+  public async getCRLFromDistributionPoint(distributionPointUrl: string): Promise<any> {
+    return this.acmeService.getCRLFromDistributionPoint(distributionPointUrl);
+  }
+
+  private scheduleCrlDistributionTimer({expiresAt, url}: {expiresAt: number; url: string}): void {
+    LowPrecisionTaskScheduler.addTask({
+      intervalDelay: TimeInMillis.SECOND,
+      firingDate: expiresAt,
+      key: url,
+      task: () => this.validateCrlDistributionPoint(url),
+    });
+  }
+
+  private async initialiseCrlDistributionTimers(): Promise<void> {
+    const crls = await this.coreDatabase.getAll('crls');
+
+    for (const crl of crls) {
+      this.scheduleCrlDistributionTimer(crl);
+    }
+  }
+
+  private async addCrlDistributionTimer({expiresAt, url}: {expiresAt: number; url: string}): Promise<void> {
+    await this.coreDatabase.add('crls', {expiresAt, url}, url);
+    this.scheduleCrlDistributionTimer({expiresAt, url});
+  }
+
+  private async cancelCrlDistributionTimer(url: string): Promise<void> {
+    await this.coreDatabase.delete('crls', url);
+  }
+
+  private async validateCrlDistributionPoint(distributionPointUrl: string): Promise<void> {
+    const domain = new URL(distributionPointUrl).hostname;
+
+    const crl = await this.getCRLFromDistributionPoint(domain);
+
+    const {expiration} = await this.coreCryptoClient.e2eiRegisterCRL(domain, crl);
+
+    await this.cancelCrlDistributionTimer(domain);
+
+    //set a new timer that will execute a task once the CRL is expired
+    if (expiration) {
+      await this.addCrlDistributionTimer({expiresAt: expiration, url: domain});
+    }
+
+    //if it was dirty, trigger e2eiconversationstate for every conversation
+  }
+
+  public async handleNewCrlDistributionPoints(distributionPoints: string[]): Promise<void> {
+    for (const distributionPointUrl of distributionPoints) {
+      await this.validateCrlDistributionPoint(distributionPointUrl);
+    }
   }
 }

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
@@ -80,7 +80,9 @@ describe('handleMLSMessageAdd', () => {
     const message = createMockedMessage();
 
     jest.spyOn(mockedMLSService, 'decryptMessage').mockResolvedValueOnce({
-      proposals: [{proposal: new Uint8Array(), proposalRef: new Uint8Array()}],
+      proposals: [
+        {proposal: new Uint8Array(), proposalRef: new Uint8Array(), free: () => {}, crlNewDistributionPoints: []},
+      ],
       commitDelay: 2000,
       message,
       hasEpochChanged: false,

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -356,7 +356,9 @@ describe('MLSService', () => {
       jest.spyOn(coreCrypto, 'clientValidKeypackagesCount').mockResolvedValueOnce(numberOfKeysBelowThreshold);
 
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
-      jest.spyOn(coreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+      jest
+        .spyOn(coreCrypto, 'processWelcomeMessage')
+        .mockResolvedValueOnce({id: new Uint8Array(), crlNewDistributionPoints: [], free: () => {}});
 
       jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation(jest.fn());
 
@@ -390,7 +392,9 @@ describe('MLSService', () => {
       jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(numberOfKeysAboveThreshold);
 
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
-      jest.spyOn(coreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+      jest
+        .spyOn(coreCrypto, 'processWelcomeMessage')
+        .mockResolvedValueOnce({id: new Uint8Array(), crlNewDistributionPoints: [], free: () => {}});
 
       jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation(jest.fn());
 
@@ -426,7 +430,9 @@ describe('MLSService', () => {
       jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(numberOfKeysAboveThreshold);
 
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
-      jest.spyOn(coreCrypto, 'processWelcomeMessage').mockResolvedValueOnce(new Uint8Array());
+      jest
+        .spyOn(coreCrypto, 'processWelcomeMessage')
+        .mockResolvedValueOnce({id: new Uint8Array(), crlNewDistributionPoints: [], free: () => {}});
 
       jest.spyOn(mlsService, 'scheduleKeyMaterialRenewal').mockImplementation(jest.fn());
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -267,10 +267,12 @@ export class MLSService extends TypedEventEmitter<Events> {
     const credentialType = await this.getCredentialType();
     const generateCommit = async () => {
       const groupInfo = await getGroupInfo();
-      const {conversationId, ...commitBundle} = await this.coreCryptoClient.joinByExternalCommit(
-        groupInfo,
-        credentialType,
-      );
+      const {conversationId, crlNewDistributionPoints, ...commitBundle} =
+        await this.coreCryptoClient.joinByExternalCommit(groupInfo, credentialType);
+
+      if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
+        this.emit('newCrlDistributionPoints', crlNewDistributionPoints);
+      }
       return {groupId: conversationId, commitBundle};
     };
     const {commitBundle, groupId} = await generateCommit();

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -295,7 +295,11 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   public async processWelcomeMessage(welcomeMessage: Uint8Array): Promise<ConversationId> {
-    return this.coreCryptoClient.processWelcomeMessage(welcomeMessage);
+    const {id, crlNewDistributionPoints} = await this.coreCryptoClient.processWelcomeMessage(welcomeMessage);
+    if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
+      this.emit('newCrlDistributionPoints', crlNewDistributionPoints);
+    }
+    return id;
   }
 
   public async decryptMessage(conversationId: ConversationId, payload: Uint8Array): Promise<DecryptedMessage> {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -822,6 +822,10 @@ export class MLSService extends TypedEventEmitter<Events> {
         keyPackagesAmount: nbPrekeys,
       });
 
+      instance.on('newCrlDistributionPoints', crlDistributionPoints => {
+        this.emit('newCrlDistributionPoints', crlDistributionPoints);
+      });
+
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth
       if (!oAuthIdToken) {
         const data = await instance.startCertificateProcess(hasActiveCertificate);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -39,6 +39,7 @@ import {
   ProposalArgs,
   ProposalType,
   RemoveProposalArgs,
+  WelcomeBundle,
 } from '@wireapp/core-crypto';
 
 import {isCoreCryptoMLSConversationAlreadyExistsError, shouldMLSDecryptionErrorBeIgnored} from './CoreCryptoMLSError';
@@ -306,7 +307,14 @@ export class MLSService extends TypedEventEmitter<Events> {
   }
 
   public async processWelcomeMessage(welcomeMessage: Uint8Array): Promise<ConversationId> {
-    const {id, crlNewDistributionPoints} = await this.coreCryptoClient.processWelcomeMessage(welcomeMessage);
+    const response = await this.coreCryptoClient.processWelcomeMessage(welcomeMessage);
+
+    //FIXME: this is temporary (it should be camel case), we wait for the update from core-crypto side
+    const {id, crl_new_distribution_points: crlNewDistributionPoints} = response as unknown as {
+      id: WelcomeBundle['id'];
+      crl_new_distribution_points: WelcomeBundle['crlNewDistributionPoints'];
+    };
+
     if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
       this.emit('newCrlDistributionPoints', crlNewDistributionPoints);
     }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -90,6 +90,7 @@ const defaultConfig: MLSServiceConfig = {
 
 type Events = {
   newEpoch: {epoch: number; groupId: string};
+  newCrlDistributionPoints: string[];
 };
 export class MLSService extends TypedEventEmitter<Events> {
   logger = logdown('@wireapp/core/MLSService');
@@ -300,6 +301,13 @@ export class MLSService extends TypedEventEmitter<Events> {
   public async decryptMessage(conversationId: ConversationId, payload: Uint8Array): Promise<DecryptedMessage> {
     try {
       const decryptedMessage = await this.coreCryptoClient.decryptMessage(conversationId, payload);
+
+      const {crlNewDistributionPoints} = decryptedMessage;
+
+      if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
+        this.emit('newCrlDistributionPoints', crlNewDistributionPoints);
+      }
+
       return decryptedMessage;
     } catch (error) {
       // According to CoreCrypto JS doc on .decryptMessage method, we should ignore some errors (corecrypto handle them internally)

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -206,9 +206,18 @@ export class MLSService extends TypedEventEmitter<Events> {
     if (keyPackages.length < 1) {
       throw new Error('Empty list of keys provided to addUsersToExistingConversation');
     }
-    return this.processCommitAction(groupIdBytes, () =>
-      this.coreCryptoClient.addClientsToConversation(groupIdBytes, keyPackages),
-    );
+    return this.processCommitAction(groupIdBytes, async () => {
+      const {crlNewDistributionPoints, ...commitBundle} = await this.coreCryptoClient.addClientsToConversation(
+        groupIdBytes,
+        keyPackages,
+      );
+
+      if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
+        this.emit('newCrlDistributionPoints', crlNewDistributionPoints);
+      }
+
+      return commitBundle;
+    });
   }
 
   public async getKeyPackagesPayload(qualifiedUsers: KeyPackageClaimUser[]) {

--- a/packages/core/src/storage/CoreDB.ts
+++ b/packages/core/src/storage/CoreDB.ts
@@ -43,6 +43,10 @@ interface CoreDBSchema extends DBSchema {
     key: string;
     value: {parentConversationId: QualifiedId; subconversationId: SUBCONVERSATION_ID; groupId: string};
   };
+  crls: {
+    key: string;
+    value: {expiresAt: number; url: string};
+  };
 }
 
 export type CoreDatabase = IDBPDatabase<CoreDBSchema>;
@@ -62,6 +66,8 @@ export async function openDB(dbName: string): Promise<CoreDatabase> {
           db.createObjectStore('conversationBlacklist');
         case 4:
           db.createObjectStore('subconversations');
+        case 5:
+          db.createObjectStore('crls');
       }
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,10 +5120,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:1.0.0-rc.33":
-  version: 1.0.0-rc.33
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.33"
-  checksum: 44b88f4b7a1ec2ce9c13ce48329c53193c91833f13345abf28e3bfcf51f41ab510187d1192dcf76293c23b9fa4167e67ee1bd084a9739f2dc598ca7987258d27
+"@wireapp/core-crypto@npm:1.0.0-rc.34":
+  version: 1.0.0-rc.34
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.34"
+  checksum: 919d9c78c31856857551e4e70ed96d22e5e34a08fb69df36ba1f4a34ea22ebd3ab3e55aca12d266cbfd873d31149519cfae17bf4a9a45a20a2f1f938b40b45d7
   languageName: node
   linkType: hard
 
@@ -5140,7 +5140,7 @@ __metadata:
     "@types/tough-cookie": 4.0.5
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 1.0.0-rc.33
+    "@wireapp/core-crypto": 1.0.0-rc.34
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
Once corecrypto finds any new crl distribution points (array of urls):
- for every URL in the list, fetch CRL
- pass CRL to e2ei_register_crl
- it will return expiration time and `dirty` boolean flag
- we set a new timer that will execute a task* on expiration time
- if it was `dirty`, call `e2eiConversationState` for every conversation

This PR also bumps core-crypto to version `rc32`