### PR TITLE
feat(e2ei): Allow configuring the certificate time to live

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -36,6 +36,7 @@ import {AbortHandler, WebSocketClient} from '@wireapp/api-client/lib/tcp/';
 import {WEBSOCKET_STATE} from '@wireapp/api-client/lib/tcp/ReconnectingWebsocket';
 import {FEATURE_KEY, FeatureStatus} from '@wireapp/api-client/lib/team';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import logdown from 'logdown';
 
 import {APIClient, BackendFeatures} from '@wireapp/api-client';
@@ -240,14 +241,14 @@ export class Account extends TypedEventEmitter<Events> {
     teamId,
     discoveryUrl,
     oAuthIdToken,
-    certificateTtl = 90,
+    certificateTtl = 90 * TimeInMillis.DAY,
   }: {
     displayName: string;
     handle: string;
     teamId: string;
     discoveryUrl: string;
     oAuthIdToken?: string;
-    /** number of seconds the certificate should be valid (default 90) */
+    /** number of seconds the certificate should be valid (default 90 days) */
     certificateTtl?: number;
   }) {
     const context = this.apiClient.context;

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -240,12 +240,15 @@ export class Account extends TypedEventEmitter<Events> {
     teamId,
     discoveryUrl,
     oAuthIdToken,
+    certificateTtl = 90,
   }: {
     displayName: string;
     handle: string;
     teamId: string;
     discoveryUrl: string;
     oAuthIdToken?: string;
+    /** number of days the certificate should be valid (default 90) */
+    certificateTtl?: number;
   }) {
     const context = this.apiClient.context;
     const domain = context?.domain ?? '';
@@ -272,6 +275,7 @@ export class Account extends TypedEventEmitter<Events> {
       user,
       this.currentClient,
       this.options.nbPrekeys,
+      certificateTtl,
       oAuthIdToken,
     );
   }

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -241,7 +241,7 @@ export class Account extends TypedEventEmitter<Events> {
     teamId,
     discoveryUrl,
     oAuthIdToken,
-    certificateTtl = 90 * TimeInMillis.DAY,
+    certificateTtl = 90 * (TimeInMillis.DAY / 1000),
   }: {
     displayName: string;
     handle: string;

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -247,7 +247,7 @@ export class Account extends TypedEventEmitter<Events> {
     teamId: string;
     discoveryUrl: string;
     oAuthIdToken?: string;
-    /** number of days the certificate should be valid (default 90) */
+    /** number of seconds the certificate should be valid (default 90) */
     certificateTtl?: number;
   }) {
     const context = this.apiClient.context;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIService.types.ts
@@ -75,7 +75,7 @@ export interface InitParams {
   clientId?: string;
   // If a entrollment is in progress, the init function will not start a new enrollment
   skipInit?: boolean;
-  /** number of days the certificate should be valid */
+  /** number of seconds the certificate should be valid */
   certificateTtl: number;
   discoveryUrl?: string;
   keyPackagesAmount: number;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIService.types.ts
@@ -75,6 +75,8 @@ export interface InitParams {
   clientId?: string;
   // If a entrollment is in progress, the init function will not start a new enrollment
   skipInit?: boolean;
+  /** number of days the certificate should be valid */
+  certificateTtl: number;
   discoveryUrl?: string;
   keyPackagesAmount: number;
   dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -48,7 +48,7 @@ export class E2EIServiceInternal {
     private readonly coreCryptoClient: CoreCrypto,
     private readonly apiClient: APIClient,
     private readonly e2eiServiceExternal: E2EIServiceExternal,
-    /** number of days the certificate should be valid */
+    /** number of seconds the certificate should be valid */
     private readonly certificateTtl: number,
     private readonly keyPackagesAmount: number,
     private readonly dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -40,28 +40,19 @@ import {NewCrlDistributionPointsPayload} from '../MLSService/MLSService.types';
 export class E2EIServiceInternal {
   private static instance: E2EIServiceInternal;
   private readonly logger = logdown('@wireapp/core/E2EIdentityServiceInternal');
-  private readonly coreCryptoClient: CoreCrypto;
-  private readonly apiClient: APIClient;
-  private readonly e2eServiceExternal: E2EIServiceExternal;
-  private readonly keyPackagesAmount;
   private identity?: E2eiEnrollment;
   private acmeService?: AcmeService;
   private isInitialized = false;
-  private readonly dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void;
 
   private constructor(
-    coreCryptClient: CoreCrypto,
-    apiClient: APIClient,
-    e2eiServiceExternal: E2EIServiceExternal,
-    keyPackagesAmount: number = 100,
-    dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void,
+    private readonly coreCryptoClient: CoreCrypto,
+    private readonly apiClient: APIClient,
+    private readonly e2eiServiceExternal: E2EIServiceExternal,
+    /** number of days the certificate should be valid */
+    private readonly certificateTtl: number,
+    private readonly keyPackagesAmount: number,
+    private readonly dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void;
   ) {
-    this.coreCryptoClient = coreCryptClient;
-    this.apiClient = apiClient;
-    this.e2eServiceExternal = e2eiServiceExternal;
-    this.keyPackagesAmount = keyPackagesAmount;
-    this.dispatchNewCrlDistributionPoints = dispatchNewCrlDistributionPoints;
-    this.logger.log('Instance of E2EIServiceInternal created');
   }
 
   // ############ Public Functions ############
@@ -78,11 +69,13 @@ export class E2EIServiceInternal {
         e2eiServiceExternal,
         keyPackagesAmount,
         dispatchNewCrlDistributionPoints,
+        certificateTtl,
       } = params;
       E2EIServiceInternal.instance = new E2EIServiceInternal(
         coreCryptClient,
         apiClient,
         e2eiServiceExternal,
+        certificateTtl,
         keyPackagesAmount,
         dispatchNewCrlDistributionPoints,
       );
@@ -107,7 +100,7 @@ export class E2EIServiceInternal {
 
   public async continueCertificateProcess(oAuthIdToken: string): Promise<RotateBundle | undefined> {
     // If we don't have a handle, we need to start a new OAuth flow
-    if (this.e2eServiceExternal.isEnrollmentInProgress()) {
+    if (this.e2eiServiceExternal.isEnrollmentInProgress()) {
       return this.continueOAuthFlow(oAuthIdToken);
     }
     throw new Error('Error while trying to continue OAuth flow. No enrollment in progress found');
@@ -119,13 +112,11 @@ export class E2EIServiceInternal {
     const {user} = E2EIStorage.get.initialData();
 
     // How long the issued certificate should be maximal valid
-    const expiryDays = 90;
-    const expirySecs = expiryDays * 24 * 60 * 60;
     const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
     if (hasActiveCertificate) {
       this.identity = await this.coreCryptoClient.e2eiNewRotateEnrollment(
-        expirySecs,
+        this.certificateTtl,
         ciphersuite,
         user.displayName,
         user.handle,
@@ -135,7 +126,7 @@ export class E2EIServiceInternal {
       this.identity = await this.coreCryptoClient.e2eiNewActivationEnrollment(
         user.displayName,
         user.handle,
-        expirySecs,
+        this.certificateTtl,
         ciphersuite,
         user.teamId,
       );
@@ -303,7 +294,7 @@ export class E2EIServiceInternal {
    *  or a client that wants to refresh its certificate but has no valid refresh token
    */
   private async startNewOAuthFlow() {
-    if (this.e2eServiceExternal.isEnrollmentInProgress()) {
+    if (this.e2eiServiceExternal.isEnrollmentInProgress()) {
       throw new Error('Error while trying to start OAuth flow. There is already a flow in progress');
     }
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -51,9 +51,8 @@ export class E2EIServiceInternal {
     /** number of seconds the certificate should be valid */
     private readonly certificateTtl: number,
     private readonly keyPackagesAmount: number,
-    private readonly dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void;
-  ) {
-  }
+    private readonly dispatchNewCrlDistributionPoints: (payload: NewCrlDistributionPointsPayload) => void,
+  ) {}
 
   // ############ Public Functions ############
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -797,6 +797,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     user: User,
     client: RegisteredClient,
     nbPrekeys: number,
+    certificateTtl: number,
     oAuthIdToken?: string,
   ): Promise<EnrollmentProcessState> {
     try {
@@ -810,6 +811,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         discoveryUrl,
         keyPackagesAmount: nbPrekeys,
         dispatchNewCrlDistributionPoints: payload => this.dispatchNewCrlDistributionPoints(payload),
+        certificateTtl,
       });
 
       // If we don't have an OAuth id token, we need to start the certificate process with Oauth


### PR DESCRIPTION
When calling `account.enrollE2EI` you can now give a `certificateTtl` that will define the number of days the generated certificate will be valid