### PR TITLE
feat(react-ui-kit): Add start & end content to input (WPB-5949)

### DIFF
--- a/packages/react-ui-kit/src/Form/Input.tsx
+++ b/packages/react-ui-kit/src/Form/Input.tsx
@@ -37,6 +37,10 @@ export interface InputProps<T = HTMLInputElement> extends TextProps<T> {
   helperText?: string;
   placeholderTextTransform?: Property.TextTransform;
   wrapperCSS?: CSSObject;
+  inputCSS?: CSSObject;
+  size?: number;
+  startContent?: React.ReactNode;
+  endContent?: React.ReactNode;
 }
 
 export const inputStyle: <T>(theme: Theme, props: InputProps<T>, hasError?: boolean) => CSSObject = (
@@ -101,77 +105,100 @@ const centerInputAction: CSSObject = {
 export const Input: React.FC<InputProps<HTMLInputElement>> = React.forwardRef<
   HTMLInputElement,
   InputProps<HTMLInputElement>
->(({type, label, error, helperText, wrapperCSS = {}, className = '', ...props}, ref) => {
-  const [togglePassword, setTogglePassword] = useState<boolean>(false);
+>(
+  (
+    {
+      type,
+      label,
+      error,
+      helperText,
+      startContent = null,
+      endContent = null,
+      inputCSS = {},
+      wrapperCSS = {},
+      className = '',
+      ...props
+    },
+    ref,
+  ) => {
+    const [togglePassword, setTogglePassword] = useState<boolean>(false);
 
-  const hasError = !!error;
-  const isPasswordInput = type === 'password';
-  const toggledPasswordType = togglePassword ? 'text' : 'password';
+    const hasError = !!error;
+    const isPasswordInput = type === 'password';
+    const toggledPasswordType = togglePassword ? 'text' : 'password';
 
-  const toggleSetPassword = () => setTogglePassword(prevState => !prevState);
+    const toggleSetPassword = () => setTogglePassword(prevState => !prevState);
 
-  return (
-    <div
-      className={INPUT_GROUP}
-      css={(theme: Theme) => ({
-        marginBottom: hasError ? '2px' : '20px',
-        width: '100%',
-        '&:focus-within label': {
-          color: theme.general.primaryColor,
-        },
-        ...wrapperCSS,
-      })}
-    >
-      {label && (
-        <InputLabel htmlFor={props.id} isRequired={props.required} markInvalid={props.markInvalid}>
-          {label}
-        </InputLabel>
-      )}
-
-      <div css={{marginBottom: hasError && '8px', position: 'relative'}}>
-        <input
-          className={INPUT_CLASSNAME}
-          css={(theme: Theme) => inputStyle(theme, props, hasError)}
-          ref={ref}
-          type={isPasswordInput ? toggledPasswordType : type}
-          aria-required={props.required}
-          {...filterInputProps(props)}
-        />
-
-        {hasError && !isPasswordInput && (
-          <ErrorIcon css={centerInputAction} width={16} height={16} aria-hidden="true" />
+    return (
+      <div
+        className={INPUT_GROUP}
+        css={(theme: Theme) => ({
+          marginBottom: hasError ? '2px' : '20px',
+          width: '100%',
+          '&:focus-within label': {
+            color: theme.general.primaryColor,
+          },
+          ...wrapperCSS,
+        })}
+      >
+        {label && (
+          <InputLabel htmlFor={props.id} isRequired={props.required} markInvalid={props.markInvalid}>
+            {label}
+          </InputLabel>
         )}
 
-        {isPasswordInput && (
-          <button
-            type="button"
-            data-uie-name={!togglePassword ? 'do-show-password' : 'do-hide-password'}
-            css={{...centerInputAction, background: 'transparent', border: 'none', cursor: 'pointer', padding: 0}}
-            onClick={toggleSetPassword}
-            title="Toggle password visibility"
-            aria-controls={props.id}
-            aria-expanded={togglePassword}
+        <div css={{marginBottom: hasError && '8px', position: 'relative'}}>
+          {startContent}
+
+          <input
+            className={INPUT_CLASSNAME}
+            css={(theme: Theme) => ({
+              ...inputStyle(theme, props, hasError),
+              ...inputCSS,
+            })}
+            ref={ref}
+            type={isPasswordInput ? toggledPasswordType : type}
+            aria-required={props.required}
+            {...filterInputProps(props)}
+          />
+
+          {endContent}
+
+          {hasError && !isPasswordInput && (
+            <ErrorIcon css={centerInputAction} width={16} height={16} aria-hidden="true" />
+          )}
+
+          {isPasswordInput && (
+            <button
+              type="button"
+              data-uie-name={!togglePassword ? 'do-show-password' : 'do-hide-password'}
+              css={{...centerInputAction, background: 'transparent', border: 'none', cursor: 'pointer', padding: 0}}
+              onClick={toggleSetPassword}
+              title="Toggle password visibility"
+              aria-controls={props.id}
+              aria-expanded={togglePassword}
+            >
+              {togglePassword ? <HideIcon /> : <ShowIcon />}
+            </button>
+          )}
+        </div>
+
+        {!hasError && helperText && (
+          <p
+            css={(theme: Theme) => ({
+              fontSize: theme.fontSizes.small,
+              fontWeight: 400,
+              color: theme.Input.placeholderColor,
+              marginTop: 8,
+            })}
           >
-            {togglePassword ? <HideIcon /> : <ShowIcon />}
-          </button>
+            {helperText}
+          </p>
         )}
+
+        {error}
       </div>
-
-      {!hasError && helperText && (
-        <p
-          css={(theme: Theme) => ({
-            fontSize: theme.fontSizes.small,
-            fontWeight: 400,
-            color: theme.Input.placeholderColor,
-            marginTop: 8,
-          })}
-        >
-          {helperText}
-        </p>
-      )}
-
-      {error}
-    </div>
-  );
-});
+    );
+  },
+);
 Input.displayName = 'Input';


### PR DESCRIPTION
### Description:
Our previous Input Component lacked the ability to be customized with additional content at the start and end. This limitation made it challenging for developers to tailor the input fields according to specific design requirements. The update was necessary to address this gap and empower users with more flexibility in styling and functionality.

### Enhanced Customization:
The new version allows developers to easily customize the input fields by adding start and end content. This opens up possibilities for incorporating icons, buttons, or other UI elements.

### No Previous Customization Option: 
The prior version did not offer a straightforward way to include extra content within the input component, making it less adaptable to diverse design needs.

### Inspired by User Interface Trends: 
The decision to introduce this feature was inspired by observing popular UI libraries.

### How to Use:

To leverage the enhanced customization options, developers can now include the startContent and endContent props in their code. Here's a quick example:

```jsx
<Input
  startContent={
    <SearchIcon
      css={{
        top: '50%',
        left: 10,
        position: 'absolute',
        transform: 'translateY(-50%)',
      }}
    />
  }
  endContent={
    conversationsFilter && (
      <CloseIcon
        className="cursor-pointer"
        onClick={() => setConversationsFilter('')}
        css={{
          top: '50%',
          right: 10,
          position: 'absolute',
          transform: 'translateY(-50%)',
        }}
      />
    )
  }
/>
```
<img width="319" alt="image" src="https://github.com/wireapp/wire-web-packages/assets/63250054/c833a9fe-56ac-4f72-b418-a9e7f0f4a18f">