### PR TITLE
runfix: epoch mismatch subconversations

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -492,14 +492,15 @@ export class Account extends TypedEventEmitter<Events> {
     const connectionService = new ConnectionService(this.apiClient);
     const giphyService = new GiphyService(this.apiClient);
     const linkPreviewService = new LinkPreviewService(assetService);
+    const subconversationService = new SubconversationService(this.apiClient, this.db, mlsService);
     const conversationService = new ConversationService(
       this.apiClient,
       proteusService,
       this.db,
       this.groupIdFromConversationId,
+      subconversationService,
       mlsService,
     );
-    const subconversationService = new SubconversationService(this.apiClient, this.db, mlsService);
     const notificationService = new NotificationService(this.apiClient, this.storeEngine, conversationService);
 
     const selfService = new SelfService(this.apiClient);

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -40,6 +40,7 @@ import * as MessagingProtocols from '../../messagingProtocols/proteus';
 import {openDB} from '../../storage/CoreDB';
 import * as PayloadHelper from '../../test/PayloadHelper';
 import * as MessageBuilder from '../message/MessageBuilder';
+import {SubconversationService} from '../SubconversationService/SubconversationService';
 
 const createMLSMessageAddEventMock = (conversationId: QualifiedId): ConversationMLSMessageAddEvent => ({
   data: '',
@@ -124,11 +125,14 @@ describe('ConversationService', () => {
 
     const groupIdFromConversationId = jest.fn();
 
+    const mockedSubconversationService = {} as unknown as SubconversationService;
+
     const conversationService = new ConversationService(
       client,
       mockedProteusService,
       mockedDb,
       groupIdFromConversationId,
+      mockedSubconversationService,
       mockedMLSService,
     );
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -23,6 +23,8 @@ import {
   ConversationProtocol,
   MLSConversation,
   PostMlsMessageResponse,
+  Subconversation,
+  SUBCONVERSATION_ID,
 } from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_EVENT, ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
@@ -42,7 +44,10 @@ import * as PayloadHelper from '../../test/PayloadHelper';
 import * as MessageBuilder from '../message/MessageBuilder';
 import {SubconversationService} from '../SubconversationService/SubconversationService';
 
-const createMLSMessageAddEventMock = (conversationId: QualifiedId): ConversationMLSMessageAddEvent => ({
+const createMLSMessageAddEventMock = (
+  conversationId: QualifiedId,
+  subconversationId?: SUBCONVERSATION_ID,
+): ConversationMLSMessageAddEvent => ({
   data: '',
   conversation: conversationId.id,
   qualified_conversation: conversationId,
@@ -50,6 +55,7 @@ const createMLSMessageAddEventMock = (conversationId: QualifiedId): Conversation
   senderClientId: '',
   type: CONVERSATION_EVENT.MLS_MESSAGE_ADD,
   time: '2023-08-21T06:47:43.387Z',
+  subconv: subconversationId,
 });
 
 jest.mock('../../messagingProtocols/proteus', () => ({
@@ -125,7 +131,9 @@ describe('ConversationService', () => {
 
     const groupIdFromConversationId = jest.fn();
 
-    const mockedSubconversationService = {} as unknown as SubconversationService;
+    const mockedSubconversationService = {
+      joinConferenceSubconversation: jest.fn(),
+    } as unknown as SubconversationService;
 
     const conversationService = new ConversationService(
       client,
@@ -139,7 +147,10 @@ describe('ConversationService', () => {
     jest.spyOn(conversationService, 'joinByExternalCommit');
     jest.spyOn(conversationService, 'emit');
 
-    return [conversationService, {apiClient: client, mlsService: mockedMLSService}] as const;
+    return [
+      conversationService,
+      {apiClient: client, mlsService: mockedMLSService, subconversationService: mockedSubconversationService},
+    ] as const;
   }
 
   describe('"send PROTEUS"', () => {
@@ -492,6 +503,38 @@ describe('ConversationService', () => {
 
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(conversationId);
       expect(conversationService.emit).toHaveBeenCalledWith('MLSConversationRecovered', {conversationId});
+    });
+
+    it('rejoins a conference subconversation if epoch mismatch detected when decrypting mls message', async () => {
+      const [conversationService, {apiClient, mlsService, subconversationService}] = await buildConversationService();
+      const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
+      const mockGroupId = 'mock-group-id';
+
+      const mockMLSMessageAddEvent = createMLSMessageAddEventMock(conversationId, SUBCONVERSATION_ID.CONFERENCE);
+
+      jest
+        .spyOn(mlsService, 'handleMLSMessageAddEvent')
+        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.DECRYPTION.WRONG_EPOCH));
+
+      const remoteEpoch = 5;
+      const localEpoch = 4;
+
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
+      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(localEpoch);
+
+      const mockedSubconversationResponse = {
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
+        parent_qualified_id: conversationId,
+        subconv_id: SUBCONVERSATION_ID.CONFERENCE,
+      } as unknown as Subconversation;
+
+      jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(mockedSubconversationResponse);
+
+      await conversationService.handleEvent(mockMLSMessageAddEvent);
+
+      expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
+      expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId);
     });
   });
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -544,7 +544,9 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * Handles epoch mismatch in a MLS group.
    * Compares the epoch of the local group with the epoch of the remote conversation.
    * If the epochs do not match, it will call onEpochMismatch callback.
-   * @param mlsConversation - mls conversation
+   * @param groupId - id of the MLS group
+   * @param epoch - epoch of the remote conversation
+   * @param onEpochMismatch - callback to be called when epochs do not match
    */
   private async handleEpochMismatch({
     groupId,

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -28,6 +28,7 @@ import {
   PostMlsMessageResponse,
   MLSConversation,
   SUBCONVERSATION_ID,
+  Subconversation,
 } from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_TYPING, ConversationMemberUpdateData} from '@wireapp/api-client/lib/conversation/data';
 import {
@@ -72,6 +73,7 @@ import {isMLSConversation} from '../../util';
 import {mapQualifiedUserClientIdsToFullyQualifiedClientIds} from '../../util/fullyQualifiedClientIdUtils';
 import {RemoteData} from '../content';
 import {isSendingMessage, sendMessage} from '../message/messageSender';
+import {SubconversationService} from '../SubconversationService/SubconversationService';
 
 type Events = {
   MLSConversationRecovered: {conversationId: QualifiedId};
@@ -89,6 +91,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       conversationId: QualifiedId,
       subconversationId?: SUBCONVERSATION_ID,
     ) => Promise<string | undefined>,
+    private readonly subconversationService: SubconversationService,
     private readonly _mlsService?: MLSService,
   ) {
     super();
@@ -334,7 +337,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       const isMLSStaleMessageError =
         error instanceof BackendError && error.label === BackendErrorLabel.MLS_STALE_MESSAGE;
       if (isMLSStaleMessageError) {
-        await this.recoverMLSConversationFromEpochMismatch(conversationId);
+        await this.recoverMLSGroupFromEpochMismatch(conversationId);
         if (shouldRetry) {
           return this.sendMLSMessage(params, false);
         }
@@ -470,9 +473,44 @@ export class ConversationService extends TypedEventEmitter<Events> {
   }
 
   /**
-   * Handles epoch mismatch in a single MLS conversation.
-   * Compares the epoch of the local conversation with the epoch of the remote conversation.
-   * If the epochs do not match, it will try to rejoin the conversation via external commit.
+   * Handles epoch mismatch in a subconversation.
+   * @param subconversation - subconversation
+   */
+  private async handleSubconversationEpochMismatch(subconversation: Subconversation) {
+    const {
+      parent_qualified_id: parentConversationId,
+      group_id: groupId,
+      epoch,
+      subconv_id: subconversationId,
+    } = subconversation;
+
+    try {
+      await this.handleEpochMismatch({
+        groupId,
+        epoch,
+        onEpochMismatch: async () => {
+          this.logger.log(
+            `Subconversation "${subconversationId}" (parent id: ${parentConversationId.id}) was not established or it's epoch number was out of date, joining via external commit`,
+          );
+
+          // We only support conference subconversations for now
+          if (subconversationId !== SUBCONVERSATION_ID.CONFERENCE) {
+            throw new Error('Unexpected subconversation id');
+          }
+
+          await this.subconversationService.joinConferenceSubconversation(parentConversationId);
+        },
+      });
+    } catch (error) {
+      this.logger.error(
+        `There was an error while handling epoch mismatch in MLS subconversation (id: ${parentConversationId.id}, subconv: ${subconversationId}):`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Handles epoch mismatch in a MLS conversation.
    * @param mlsConversation - mls conversation
    */
   private async handleConversationEpochMismatch(
@@ -482,25 +520,47 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const {qualified_id: qualifiedId, group_id: groupId, epoch} = remoteMlsConversation;
 
     try {
-      const isEstablished = await this.mlsGroupExistsLocally(groupId);
-      const doesEpochMatch = isEstablished && (await this.matchesEpoch(groupId, epoch));
+      return this.handleEpochMismatch({
+        groupId,
+        epoch,
+        onEpochMismatch: async () => {
+          this.logger.log(
+            `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
+          );
+          await this.joinByExternalCommit(qualifiedId);
 
-      //if conversation is not established or epoch does not match -> try to rejoin
-      if (!isEstablished || !doesEpochMatch) {
-        this.logger.log(
-          `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
-        );
-        await this.joinByExternalCommit(qualifiedId);
-
-        if (onSuccessfulRejoin) {
-          onSuccessfulRejoin();
-        }
-      }
+          onSuccessfulRejoin?.();
+        },
+      });
     } catch (error) {
       this.logger.error(
         `There was an error while handling epoch mismatch in MLS conversation (id: ${qualifiedId.id}):`,
         error,
       );
+    }
+  }
+
+  /**
+   * Handles epoch mismatch in a MLS group.
+   * Compares the epoch of the local group with the epoch of the remote conversation.
+   * If the epochs do not match, it will call onEpochMismatch callback.
+   * @param mlsConversation - mls conversation
+   */
+  private async handleEpochMismatch({
+    groupId,
+    epoch,
+    onEpochMismatch,
+  }: {
+    groupId: string;
+    epoch: number;
+    onEpochMismatch: () => Promise<any>;
+  }) {
+    const isEstablished = await this.mlsGroupExistsLocally(groupId);
+    const doesEpochMatch = isEstablished && (await this.matchesEpoch(groupId, epoch));
+
+    //if conversation is not established or epoch does not match -> try to rejoin
+    if (!isEstablished || !doesEpochMatch) {
+      await onEpochMismatch();
     }
   }
 
@@ -634,19 +694,28 @@ export class ConversationService extends TypedEventEmitter<Events> {
         this.logger.info(
           `Received message for the wrong epoch in conversation ${event.conversation}, handling epoch mismatch...`,
         );
-        const conversationId = event.qualified_conversation;
+        const {qualified_conversation: conversationId, subconv} = event;
         if (!conversationId) {
           throw new Error('Qualified conversation id is missing in the event');
         }
 
-        await this.recoverMLSConversationFromEpochMismatch(conversationId);
+        await this.recoverMLSGroupFromEpochMismatch(conversationId, subconv);
         return null;
       }
       throw error;
     }
   }
 
-  private async recoverMLSConversationFromEpochMismatch(conversationId: QualifiedId) {
+  private async recoverMLSGroupFromEpochMismatch(conversationId: QualifiedId, subconversationId?: SUBCONVERSATION_ID) {
+    if (subconversationId) {
+      const subconversation = await this.apiClient.api.conversation.getSubconversation(
+        conversationId,
+        subconversationId,
+      );
+
+      return this.handleSubconversationEpochMismatch(subconversation);
+    }
+
     const mlsConversation = await this.apiClient.api.conversation.getConversation(conversationId);
 
     if (!isMLSConversation(mlsConversation)) {


### PR DESCRIPTION
When detecting epoch mismatch in a "conference" subconversation (a MLS group we use for mls calls) we were mistakenly rejoining its parent conversation via external commit instead of rejoining the actual subconversation.