### PR TITLE
runfix: add method to get all group user identities

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -483,10 +483,8 @@ export class Account extends TypedEventEmitter<Events> {
         this.db,
         this.recurringTaskScheduler,
         clientService,
-        mlsService.config.cipherSuite,
+        mlsService,
       );
-
-      mlsService.on('newCrlDistributionPoints', e2eServiceExternal.handleNewRemoteCrlDistributionPoints);
     }
 
     const connectionService = new ConnectionService(this.apiClient);

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -22,7 +22,7 @@ import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import {Decoder} from 'bazinga64';
 
 import {TypedEventEmitter} from '@wireapp/commons';
-import {Ciphersuite, CoreCrypto, E2eiConversationState, WireIdentity, DeviceStatus} from '@wireapp/core-crypto';
+import {CoreCrypto, E2eiConversationState, WireIdentity, DeviceStatus} from '@wireapp/core-crypto';
 
 import {AcmeService} from './Connection';
 import {getE2EIClientId} from './Helper';
@@ -34,6 +34,7 @@ import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUt
 import {LocalStorageStore} from '../../../util/LocalStorageStore';
 import {LowPrecisionTaskScheduler} from '../../../util/LowPrecisionTaskScheduler';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
+import {MLSService} from '../MLSService';
 
 export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {status?: DeviceStatus; deviceId: string};
 
@@ -51,10 +52,11 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     private readonly coreDatabase: CoreDatabase,
     private readonly recurringTaskScheduler: RecurringTaskScheduler,
     private readonly clientService: ClientService,
-    private readonly cipherSuite: Ciphersuite,
+    private readonly mlsService: MLSService,
   ) {
     super();
     void this.initialiseCrlDistributionTimers();
+    mlsService.on('newCrlDistributionPoints', this.handleNewRemoteCrlDistributionPoints);
   }
 
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
@@ -71,7 +73,13 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   }
 
   public isE2EIEnabled(): Promise<boolean> {
-    return this.coreCryptoClient.e2eiIsEnabled(this.cipherSuite);
+    return this.coreCryptoClient.e2eiIsEnabled(this.mlsService.config.cipherSuite);
+  }
+
+  public async getAllGroupUsersIdentities(groupId: string): Promise<Map<string, DeviceIdentity[]>> {
+    const allGroupClients = await this.mlsService.getClientIds(groupId);
+    const userIds = allGroupClients.map(({userId, domain}) => ({id: userId, domain}));
+    return this.getUsersIdentities(groupId, userIds);
   }
 
   public async getUsersIdentities(groupId: string, userIds: QualifiedId[]): Promise<Map<string, DeviceIdentity[]>> {
@@ -277,7 +285,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     }
   }
 
-  public async handleNewRemoteCrlDistributionPoints(distributionPoints: string[]): Promise<void> {
+  private async handleNewRemoteCrlDistributionPoints(distributionPoints: string[]): Promise<void> {
     for (const distributionPointUrl of distributionPoints) {
       await this.validateRemoteCrlDistributionPoint(distributionPointUrl);
     }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -33,6 +33,7 @@ import {CoreDatabase} from '../../../storage/CoreDB';
 import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUtils';
 import {LocalStorageStore} from '../../../util/LocalStorageStore';
 import {LowPrecisionTaskScheduler} from '../../../util/LowPrecisionTaskScheduler';
+import {stringifyQualifiedId} from '../../../util/qualifiedIdUtil';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {MLSService} from '../MLSService';
 
@@ -78,7 +79,17 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
 
   public async getAllGroupUsersIdentities(groupId: string): Promise<Map<string, DeviceIdentity[]>> {
     const allGroupClients = await this.mlsService.getClientIds(groupId);
-    const userIds = allGroupClients.map(({userId, domain}) => ({id: userId, domain}));
+
+    const userIdsMap = allGroupClients.reduce(
+      (acc, {userId, domain}) => {
+        const qualifiedId = {id: userId, domain};
+        acc[stringifyQualifiedId(qualifiedId)] = qualifiedId;
+        return acc;
+      },
+      {} as Record<string, QualifiedId>,
+    );
+
+    const userIds = Object.values(userIdsMap);
     return this.getUsersIdentities(groupId, userIds);
   }
 

--- a/packages/core/src/util/qualifiedIdUtil.ts
+++ b/packages/core/src/util/qualifiedIdUtil.ts
@@ -1,0 +1,31 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+export const stringifyQualifiedId = (qualifiedId: QualifiedId): `${string}@${string}` =>
+  `${qualifiedId.id}@${qualifiedId.domain}`;
+
+export const parseQualifiedId = (qualifiedId: string): QualifiedId => {
+  const [id, domain] = qualifiedId.split('@');
+  if (!id || !domain) {
+    throw new Error(`given qualified ID is corrupted (${qualifiedId})`);
+  }
+  return {id, domain};
+};


### PR DESCRIPTION
- MLS service is now a dependency of `E2EIServiceExternal`

Added a method to get all the mls group user identities - it's needed to calculate the list of degraded users when adding a client without a certificate into the group. We were using webapps conversation.particupating_user_ids() which is not always up-to-date with mls group state in core-crypto. Before receiving member-join event the list of participants was still empty even though user was already a member of mls group.

Webapp PR will follow.
