### PR TITLE
fix: Allow new created client to be legal hold ready

### DIFF
--- a/packages/api-client/src/client/NewClient.ts
+++ b/packages/api-client/src/client/NewClient.ts
@@ -21,7 +21,7 @@ import {ClientCapabilityData} from './ClientCapabilityData';
 
 import {PreKey} from '../auth/';
 
-import {ClientClassification, ClientType, Location, MLSPublicKeyRecord} from './';
+import {ClientCapability, ClientClassification, ClientType, Location, MLSPublicKeyRecord} from './';
 
 type BaseUpdatePayload = ClientCapabilityData & {label?: string};
 type MLSUpdatePayload = {
@@ -38,6 +38,7 @@ export type UpdateClientPayload = Partial<ProteusUpdatePayload | MLSUpdatePayloa
 
 export type CreateClientPayload = {
   class: ClientClassification.DESKTOP | ClientClassification.PHONE | ClientClassification.TABLET;
+  capabilities?: ClientCapability[];
   cookie: string;
   label?: string;
   lastkey: PreKey;

--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -18,7 +18,7 @@
  */
 
 import {LoginData} from '@wireapp/api-client/lib/auth/';
-import {ClientType, CreateClientPayload, RegisteredClient} from '@wireapp/api-client/lib/client/';
+import {ClientCapability, ClientType, CreateClientPayload, RegisteredClient} from '@wireapp/api-client/lib/client/';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import axios from 'axios';
 import {StatusCodes} from 'http-status-codes';
@@ -164,6 +164,7 @@ export class ClientService {
 
     const newClient: CreateClientPayload = {
       class: clientInfo.classification,
+      capabilities: [ClientCapability.LEGAL_HOLD_IMPLICIT_CONSENT],
       cookie: clientInfo.cookieLabel,
       label: clientInfo.label,
       lastkey: lastPrekey,


### PR DESCRIPTION
Currently, newly created devices do not have the capability to work with clients under legal hold. 
We need to add this capability to newly created clients