### PR TITLE
feat: Queue recovering MLS conversations on notification stream processing

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -54,7 +54,10 @@ import {SubconversationService} from './conversation/SubconversationService/Subc
 import {GiphyService} from './giphy/';
 import {LinkPreviewService} from './linkPreview';
 import {MLSService} from './messagingProtocols/mls';
-import {resumeRejoiningMLSConversations} from './messagingProtocols/mls/conversationRejoinQueue';
+import {
+  pauseRejoiningMLSConversations,
+  resumeRejoiningMLSConversations,
+} from './messagingProtocols/mls/conversationRejoinQueue';
 import {E2EIServiceExternal, User} from './messagingProtocols/mls/E2EIdentityService';
 import {CoreCallbacks, CoreCryptoConfig, SecretCrypto} from './messagingProtocols/mls/types';
 import {NewClient, ProteusService} from './messagingProtocols/proteus';
@@ -659,8 +662,8 @@ export class Account extends TypedEventEmitter<Events> {
       // Lock websocket in order to buffer any message that arrives while we handle the notification stream
       this.apiClient.transport.ws.lock();
       pauseMessageSending();
-      // We want  to avoid triggering rejoins of out-of-sync MLS conversations while we are processing the notification stream
-      //pauseRejoiningMLSConversations();
+      // We want to avoid triggering rejoins of out-of-sync MLS conversations while we are processing the notification stream
+      pauseRejoiningMLSConversations();
       onConnectionStateChanged(ConnectionState.PROCESSING_NOTIFICATIONS);
 
       const results = await this.service!.notification.processNotificationStream(

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -77,11 +77,6 @@ const mockedProteusService = {
 } as unknown as ProteusService;
 
 describe('ConversationService', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date(0));
-  });
-
   async function buildConversationService() {
     const client = new APIClient({urls: APIClient.BACKEND.STAGING});
     jest.spyOn(client.api.conversation, 'postMlsMessage').mockReturnValue(
@@ -242,12 +237,6 @@ describe('ConversationService', () => {
         conversationId: mockConversationId,
       });
       expect(apiClient.api.conversation.postMlsMessage).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  describe('handleConversationsEpochMismatch', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
     });
   });
 
@@ -440,6 +429,8 @@ describe('ConversationService', () => {
 
       await conversationService.handleEvent(mockMLSMessageAddEvent);
 
+      await new Promise(resolve => setImmediate(resolve));
+
       expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(conversationId);
       expect(conversationService.emit).toHaveBeenCalledWith('MLSConversationRecovered', {conversationId});
     });
@@ -471,6 +462,8 @@ describe('ConversationService', () => {
       jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(mockedSubconversationResponse);
 
       await conversationService.handleEvent(mockMLSMessageAddEvent);
+
+      await new Promise(resolve => setImmediate(resolve));
 
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId);

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -249,67 +249,6 @@ describe('ConversationService', () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
-
-    const createConversation = (epoch: number, conversationId?: string) => {
-      return {
-        group_id: 'group-id',
-        qualified_id: {id: conversationId || 'conversation-id', domain: 'staging.zinfra.io'},
-        protocol: ConversationProtocol.MLS,
-        epoch,
-      } as Conversation;
-    };
-
-    it('re-joins multiple not-established conversations', async () => {
-      const [conversationService, {apiClient}] = await buildConversationService();
-
-      const remoteEpoch = 1;
-
-      const mlsConversation1 = createConversation(remoteEpoch, 'conversation1');
-      const mlsConversation2 = createConversation(remoteEpoch, 'conversation2');
-
-      const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
-      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
-
-      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValue(false);
-
-      await conversationService.handleConversationsEpochMismatch();
-      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
-      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
-    });
-
-    it('re-joins multiple conversations when mismatches detected', async () => {
-      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
-
-      const mlsConversation1 = createConversation(1, 'conversation1');
-      const mlsConversation2 = createConversation(1, 'conversation2');
-
-      const mockedDBResponse: Conversation[] = [mlsConversation1, mlsConversation2];
-      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
-
-      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValue(true);
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValue(2);
-
-      await conversationService.handleConversationsEpochMismatch();
-      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation1.qualified_id);
-      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(mlsConversation2.qualified_id);
-    });
-
-    it("does not re-join when there's no mismatch", async () => {
-      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
-
-      const mlsConversation = createConversation(1);
-
-      const mockedDBResponse: Conversation[] = [mlsConversation];
-      jest.spyOn(apiClient.api.conversation, 'getConversationList').mockResolvedValueOnce({found: mockedDBResponse});
-
-      jest.spyOn(conversationService, 'mlsGroupExistsLocally').mockResolvedValueOnce(true);
-
-      jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(1);
-      jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
-
-      await conversationService.handleConversationsEpochMismatch();
-      expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
-    });
   });
 
   describe('establishMLS1to1Conversation', () => {

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -61,6 +61,7 @@ import {
 import {MessageTimer, MessageSendingState, RemoveUsersParams} from '../../conversation/';
 import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService} from '../../messagingProtocols/mls';
+import {queueConversationRejoin} from '../../messagingProtocols/mls/conversationRejoinQueue';
 import {isCoreCryptoMLSWrongEpochError} from '../../messagingProtocols/mls/MLSService/CoreCryptoMLSError';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
 import {
@@ -457,21 +458,6 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return BigInt(localEpoch) === BigInt(backendEpoch);
   }
 
-  public async handleConversationsEpochMismatch() {
-    this.logger.info(`There were some missed messages, handling possible epoch mismatch in MLS conversations.`);
-
-    //fetch all the mls conversations from backend
-    const conversations = await this.apiClient.api.conversation.getConversationList();
-    const foundConversations = conversations.found || [];
-
-    const mlsConversations = foundConversations.filter(isMLSConversation);
-
-    //check all the established conversations' epoch with the core-crypto epoch
-    for (const mlsConversation of mlsConversations) {
-      await this.handleConversationEpochMismatch(mlsConversation);
-    }
-  }
-
   /**
    * Handles epoch mismatch in a subconversation.
    * @param subconversation - subconversation
@@ -484,28 +470,22 @@ export class ConversationService extends TypedEventEmitter<Events> {
       subconv_id: subconversationId,
     } = subconversation;
 
-    try {
-      await this.handleEpochMismatch({
-        groupId,
-        epoch,
-        onEpochMismatch: async () => {
-          this.logger.log(
-            `Subconversation "${subconversationId}" (parent id: ${parentConversationId.id}) was not established or it's epoch number was out of date, joining via external commit`,
-          );
-
-          // We only support conference subconversations for now
-          if (subconversationId !== SUBCONVERSATION_ID.CONFERENCE) {
-            throw new Error('Unexpected subconversation id');
-          }
-
-          await this.subconversationService.joinConferenceSubconversation(parentConversationId);
-        },
-      });
-    } catch (error) {
-      this.logger.error(
-        `There was an error while handling epoch mismatch in MLS subconversation (id: ${parentConversationId.id}, subconv: ${subconversationId}):`,
-        error,
+    if (await this.hasEpochMismatch(groupId, epoch)) {
+      this.logger.log(
+        `Subconversation "${subconversationId}" (parent id: ${parentConversationId.id}) was not established or its epoch number was out of date, joining via external commit`,
       );
+
+      // We only support conference subconversations for now
+      if (subconversationId !== SUBCONVERSATION_ID.CONFERENCE) {
+        throw new Error('Unexpected subconversation id');
+      }
+
+      try {
+        await this.subconversationService.joinConferenceSubconversation(parentConversationId);
+      } catch (error) {
+        const message = `There was an error while handling epoch mismatch in MLS subconversation (id: ${parentConversationId.id}, subconv: ${subconversationId}):`;
+        this.logger.error(message, error);
+      }
     }
   }
 
@@ -519,24 +499,18 @@ export class ConversationService extends TypedEventEmitter<Events> {
   ) {
     const {qualified_id: qualifiedId, group_id: groupId, epoch} = remoteMlsConversation;
 
-    try {
-      return this.handleEpochMismatch({
-        groupId,
-        epoch,
-        onEpochMismatch: async () => {
-          this.logger.log(
-            `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
-          );
-          await this.joinByExternalCommit(qualifiedId);
-
-          onSuccessfulRejoin?.();
-        },
-      });
-    } catch (error) {
-      this.logger.error(
-        `There was an error while handling epoch mismatch in MLS conversation (id: ${qualifiedId.id}):`,
-        error,
+    if (await this.hasEpochMismatch(groupId, epoch)) {
+      this.logger.log(
+        `Conversation (id ${qualifiedId.id}) was not established or it's epoch number was out of date, joining via external commit`,
       );
+
+      try {
+        await this.joinByExternalCommit(qualifiedId);
+        onSuccessfulRejoin?.();
+      } catch (error) {
+        const message = `There was an error while handling epoch mismatch in MLS conversation (id: ${qualifiedId.id}):`;
+        this.logger.error(message, error);
+      }
     }
   }
 
@@ -548,22 +522,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * @param epoch - epoch of the remote conversation
    * @param onEpochMismatch - callback to be called when epochs do not match
    */
-  private async handleEpochMismatch({
-    groupId,
-    epoch,
-    onEpochMismatch,
-  }: {
-    groupId: string;
-    epoch: number;
-    onEpochMismatch: () => Promise<any>;
-  }) {
+  private async hasEpochMismatch(groupId: string, epoch: number) {
     const isEstablished = await this.mlsGroupExistsLocally(groupId);
     const doesEpochMatch = isEstablished && (await this.matchesEpoch(groupId, epoch));
 
     //if conversation is not established or epoch does not match -> try to rejoin
-    if (!isEstablished || !doesEpochMatch) {
-      await onEpochMismatch();
-    }
+    return !isEstablished || !doesEpochMatch;
   }
 
   /**
@@ -701,7 +665,9 @@ export class ConversationService extends TypedEventEmitter<Events> {
           throw new Error('Qualified conversation id is missing in the event');
         }
 
-        await this.recoverMLSGroupFromEpochMismatch(conversationId, subconv);
+        queueConversationRejoin(conversationId.id, () =>
+          this.recoverMLSGroupFromEpochMismatch(conversationId, subconv),
+        );
         return null;
       }
       throw error;
@@ -715,7 +681,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         subconversationId,
       );
 
-      return this.handleSubconversationEpochMismatch(subconversation);
+      await this.handleSubconversationEpochMismatch(subconversation);
     }
 
     const mlsConversation = await this.apiClient.api.conversation.getConversation(conversationId);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -458,6 +458,21 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return BigInt(localEpoch) === BigInt(backendEpoch);
   }
 
+  public async handleConversationsEpochMismatch() {
+    this.logger.info(`There were some missed messages, handling possible epoch mismatch in MLS conversations.`);
+
+    //fetch all the mls conversations from backend
+    const conversations = await this.apiClient.api.conversation.getConversationList();
+    const foundConversations = conversations.found || [];
+
+    const mlsConversations = foundConversations.filter(isMLSConversation);
+
+    //check all the established conversations' epoch with the core-crypto epoch
+    for (const mlsConversation of mlsConversations) {
+      await this.handleConversationEpochMismatch(mlsConversation);
+    }
+  }
+
   /**
    * Handles epoch mismatch in a subconversation.
    * @param subconversation - subconversation

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -681,7 +681,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         subconversationId,
       );
 
-      await this.handleSubconversationEpochMismatch(subconversation);
+      return this.handleSubconversationEpochMismatch(subconversation);
     }
 
     const mlsConversation = await this.apiClient.api.conversation.getConversation(conversationId);

--- a/packages/core/src/messagingProtocols/mls/conversationRejoinQueue.test.ts
+++ b/packages/core/src/messagingProtocols/mls/conversationRejoinQueue.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {queueConversationRejoin} from './conversationRejoinQueue';
+
+describe('queueConversationRejoin', () => {
+  it('should queue conversation rejoin', async () => {
+    const rejoinFn = jest.fn(() => Promise.resolve());
+    await queueConversationRejoin('groupId', rejoinFn);
+    expect(rejoinFn).toHaveBeenCalled();
+  });
+
+  it('should not queue conversation rejoin if already in queue', async () => {
+    const rejoinFn = jest.fn(() => Promise.resolve());
+    await Promise.all([1, 2, 3].map(() => queueConversationRejoin('groupId', rejoinFn)));
+    expect(rejoinFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should run the function a second time if the task has been executed', async () => {
+    const rejoinFn = jest.fn(() => Promise.resolve());
+    await queueConversationRejoin('groupId', rejoinFn);
+    await queueConversationRejoin('groupId', rejoinFn);
+    expect(rejoinFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/messagingProtocols/mls/conversationRejoinQueue.ts
+++ b/packages/core/src/messagingProtocols/mls/conversationRejoinQueue.ts
@@ -1,0 +1,48 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {Task, PromiseQueue} from '@wireapp/promise-queue';
+
+const sendingQueue = new PromiseQueue({name: 'mls-conversation-rejoin', paused: false});
+
+const queuedJobs = new Set<string>();
+
+/**
+ * Will queue a rejoin task for a conversation. This could be useful if conversation is out of sync with current epoch
+ * @param groupId the groupId in which we will trigger the rejoin (will be used as ID, in order not to add another rejoin task for the same conversation if it's already in the queue)
+ * @param rejoinFn the function to be executed to trigger the rejoin
+ */
+export async function queueConversationRejoin<T>(groupId: string, rejoinFn: Task<T>): Promise<T | undefined> {
+  if (queuedJobs.has(groupId)) {
+    return undefined;
+  }
+  queuedJobs.add(groupId);
+
+  const result = await sendingQueue.push(rejoinFn);
+  queuedJobs.delete(groupId);
+  return result;
+}
+
+export function resumeRejoiningMLSConversations(): void {
+  sendingQueue.pause(false);
+}
+
+export function pauseRejoiningMLSConversations(): void {
+  sendingQueue.pause(true);
+}

--- a/packages/core/src/messagingProtocols/mls/conversationRejoinQueue.ts
+++ b/packages/core/src/messagingProtocols/mls/conversationRejoinQueue.ts
@@ -28,15 +28,14 @@ const queuedJobs = new Set<string>();
  * @param groupId the groupId in which we will trigger the rejoin (will be used as ID, in order not to add another rejoin task for the same conversation if it's already in the queue)
  * @param rejoinFn the function to be executed to trigger the rejoin
  */
-export async function queueConversationRejoin<T>(groupId: string, rejoinFn: Task<T>): Promise<T | undefined> {
-  if (queuedJobs.has(groupId)) {
-    return undefined;
-  }
-  queuedJobs.add(groupId);
+export async function queueConversationRejoin<T>(groupId: string, rejoinFn: Task<T>): Promise<T | void> {
+  if (!queuedJobs.has(groupId)) {
+    queuedJobs.add(groupId);
 
-  const result = await sendingQueue.push(rejoinFn);
-  queuedJobs.delete(groupId);
-  return result;
+    const result = await sendingQueue.push(rejoinFn);
+    queuedJobs.delete(groupId);
+    return result;
+  }
 }
 
 export function resumeRejoiningMLSConversations(): void {


### PR DESCRIPTION
When we detect an epoch mismatch when handling the notification stream, we should avoid directly trying to rejoin the conversation. This could trigger some unexpected behavior. 

So we should first: 
- process the entire notification streams (we might even be able to decrypt some messages as there is a certain tolerance threshold for decrypting messages from future epochs)
- then rejoin the conversations that are on the wrong epoch.

