### PR TITLE
refactor: Improve and streamline client initialization

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -120,7 +120,13 @@ export class MLSService extends TypedEventEmitter<Events> {
     };
   }
 
-  public async initClient(userId: QualifiedId, client: RegisteredClient, blockKeypackageUpload = false) {
+  /**
+   * Will initialize an MLS client
+   * @param userId the user owning the client
+   * @param client id of the client to initialize
+   * @param skipKeypackageUpload avoid uploading key packages to the backend (needed for e2eidentity as keypackages will be uploaded only when enrollment is successful)
+   */
+  public async initClient(userId: QualifiedId, client: RegisteredClient, skipKeypackageUpload = false) {
     await this.coreCryptoClient.mlsInit(
       generateMLSDeviceId(userId, client.id),
       [this.config.cipherSuite],
@@ -134,9 +140,13 @@ export class MLSService extends TypedEventEmitter<Events> {
       userAuthorize: async () => true,
     });
 
-    if (!blockKeypackageUpload) {
+    const isFreshMLSSelfClient =
+      typeof client.mls_public_keys.ed25519 !== 'string' || client.mls_public_keys.ed25519.length === 0;
+    const shouldUploadKeyPackages = !(isFreshMLSSelfClient && skipKeypackageUpload);
+
+    if (shouldUploadKeyPackages) {
       // We need to make sure keypackages and public key are uploaded to the backend
-      if (typeof client.mls_public_keys.ed25519 !== 'string' || client.mls_public_keys.ed25519.length === 0) {
+      if (isFreshMLSSelfClient) {
         await this.uploadMLSPublicKeys(client);
       }
       await this.verifyRemoteMLSKeyPackagesAmount(client.id);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.types.ts
@@ -44,10 +44,6 @@ export interface MLSServiceConfig {
    * default ciphersuite to use for MLS (MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 1 by default)
    */
   cipherSuite: Ciphersuite;
-  /**
-   * signals if the E2E - Identity process should be used
-   */
-  useE2EI?: boolean;
 }
 
 export type NewCrlDistributionPointsPayload = {crlNewDistributionPoints?: string[] | undefined};

--- a/packages/core/src/team/TeamService.ts
+++ b/packages/core/src/team/TeamService.ts
@@ -59,4 +59,8 @@ export class TeamService {
   public updateTeam(teamId: string, teamData: UpdateTeamData): Promise<void> {
     return this.apiClient.api.teams.team.putTeam(teamId, teamData);
   }
+
+  public getTeamFeatureConfig() {
+    return this.apiClient.api.teams.feature.getAllFeatures();
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE: now the `registerClient` does not automatically initialize the client. It needs to be done in 2 steps:

```js
const localClient = await account.registerClient(...)
await account.initClient(localClient);
```