### PR TITLE
runfix(api-client): add missing email_unvalidated field to team contact

### DIFF
--- a/packages/api-client/src/team/search/TeamContact.ts
+++ b/packages/api-client/src/team/search/TeamContact.ts
@@ -23,6 +23,7 @@ import {User, ManagedSource} from '../../user/';
 export type TeamContact = Pick<User, 'id' | 'email' | 'accent_id' | 'handle' | 'name' | 'team'> & {
   /** Timestamp of invitation creation. */
   created_at?: string;
+  email_unvalidated: string | null;
   managed_by?: ManagedSource;
   role?: Role;
   /** URL of the SAML identity provider. */


### PR DESCRIPTION
Nullable `email_unvalidated` field was missing in TeamContact's entity type definition.