### PR TITLE
runfix(api-client): remove unexisting field from user entity type

### DIFF
--- a/packages/api-client/src/user/User.ts
+++ b/packages/api-client/src/user/User.ts
@@ -30,7 +30,6 @@ export interface User {
   assets?: UserAsset[];
   deleted?: boolean;
   email?: string;
-  email_unvalidated?: string;
   expires_at?: string;
   handle?: string;
   id: string;


### PR DESCRIPTION
According to swagger docs https://staging-nginz-https.zinfra.io/v5/api/swagger-ui/#/default/get_users__uid_domain___uid_ (and real-life response from backend), `email_unvalidated` does not exist on user entity. It appears on TeamContact though, see: https://github.com/wireapp/wire-web-packages/pull/5993