### PR TITLE
fix: Use indexeddb to store e2ei enrollment temporary data

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -65,12 +65,12 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   }
 
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
-  public async isEnrollmentInProgress(userId: string): Promise<boolean> {
-    return !!(await this.enrollmentStorage.getEnrollmentFlowData(userId));
+  public async isEnrollmentInProgress(): Promise<boolean> {
+    return !!(await this.enrollmentStorage.getEnrollmentFlowData());
   }
 
-  public clearAllProgress(userId: string) {
-    return this.enrollmentStorage.delete(userId);
+  public clearAllProgress() {
+    return this.enrollmentStorage.delete();
   }
 
   public getConversationState(conversationId: Uint8Array): Promise<E2eiConversationState> {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -63,7 +63,7 @@ export class E2EIServiceInternal {
 
     // store auth data for continuing the flow later on
     const handle = await this.coreCryptoClient.e2eiEnrollmentStash(identity);
-    await this.enrollmentStorage.save({
+    await this.enrollmentStorage.savePendingEnrollmentData({
       handle,
       ...enrollmentData,
     });
@@ -72,7 +72,7 @@ export class E2EIServiceInternal {
   }
 
   public async continueCertificateProcess(oAuthIdToken: string): Promise<RotateBundle | undefined> {
-    const enrollmentData = await this.enrollmentStorage.getEnrollmentFlowData();
+    const enrollmentData = await this.enrollmentStorage.getPendingEnrollmentData();
     if (!enrollmentData) {
       throw new Error('Error while trying to continue OAuth flow. No enrollment in progress found');
     }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {Decoder, Encoder} from 'bazinga64';
 import logdown from 'logdown';
 
 import {APIClient} from '@wireapp/api-client';
@@ -31,14 +30,18 @@ import {getCertificate} from './Steps/Certificate';
 import {doWireDpopChallenge} from './Steps/DpopChallenge';
 import {doWireOidcChallenge} from './Steps/OidcChallenge';
 import {createNewOrder, finalizeOrder} from './Steps/Order';
-import {E2EIStorage} from './Storage/E2EIStorage';
-import {AuthData, InitialData} from './Storage/E2EIStorage.schema';
+import {createE2EIEnrollmentStorage} from './Storage/E2EIStorage';
+import {InitialData, UnidentifiedEnrollmentFlowData} from './Storage/E2EIStorage.schema';
+
+import {CoreDatabase} from '../../../storage/CoreDB';
 
 export class E2EIServiceInternal {
   private readonly logger = logdown('@wireapp/core/E2EIdentityServiceInternal');
   private acmeService: AcmeService;
+  private enrollmentStorage: ReturnType<typeof createE2EIEnrollmentStorage>;
 
   public constructor(
+    coreDb: CoreDatabase,
     private readonly coreCryptoClient: CoreCrypto,
     private readonly apiClient: APIClient,
     /** number of seconds the certificate should be valid */
@@ -48,36 +51,36 @@ export class E2EIServiceInternal {
   ) {
     const {discoveryUrl} = initialData;
     this.acmeService = new AcmeService(discoveryUrl);
+    this.enrollmentStorage = createE2EIEnrollmentStorage(coreDb);
   }
 
-  public async startCertificateProcess(hasActiveCertificate: boolean) {
+  public async startCertificateProcess(processId: string, hasActiveCertificate: boolean) {
     const identity = await this.initIdentity(hasActiveCertificate);
 
     // Store the values in local storage for later use (e.g. in the continue flow)
-    const {orderUrl, authChallenges} = await this.getEnrollmentChallenges(identity);
-    const {
-      authorization: {keyauth, oidcChallenge},
-    } = authChallenges;
+    const enrollmentData = await this.getEnrollmentChallenges(identity);
+    const {keyauth, oidcChallenge} = enrollmentData.authorization;
 
     // store auth data for continuing the flow later on
     const handle = await this.coreCryptoClient.e2eiEnrollmentStash(identity);
-    E2EIStorage.store.handle(Encoder.toBase64(handle).asString);
-    E2EIStorage.store.authData(authChallenges);
-    E2EIStorage.store.orderData({orderUrl});
+    await this.enrollmentStorage.save(processId, {
+      handle,
+      ...enrollmentData,
+    });
 
     return {challenge: oidcChallenge, keyAuth: keyauth};
   }
 
-  public async continueCertificateProcess(oAuthIdToken: string): Promise<RotateBundle | undefined> {
-    const handle = E2EIStorage.get.handle();
-
-    const identity = await this.coreCryptoClient.e2eiEnrollmentStashPop(Decoder.fromBase64(handle).asBytes);
-    if (!identity) {
+  public async continueCertificateProcess(processId: string, oAuthIdToken: string): Promise<RotateBundle | undefined> {
+    const enrollmentData = await this.enrollmentStorage.getEnrollmentFlowData(processId);
+    if (!enrollmentData) {
       throw new Error('Error while trying to continue OAuth flow. No enrollment in progress found');
     }
 
-    const authData = E2EIStorage.get.authData();
-    return this.getRotateBundle(identity, oAuthIdToken, authData);
+    const {handle} = enrollmentData;
+    const identity = await this.coreCryptoClient.e2eiEnrollmentStashPop(handle);
+
+    return this.getRotateBundle(identity, oAuthIdToken, enrollmentData);
   }
 
   /**
@@ -88,9 +91,9 @@ export class E2EIServiceInternal {
    */
   public async renewCertificate(oAuthIdToken: string, hasActiveCertificate: boolean) {
     const identity = await this.initIdentity(hasActiveCertificate);
-    const authData = await this.getEnrollmentChallenges(identity);
+    const enrollmentData = await this.getEnrollmentChallenges(identity);
 
-    return this.getRotateBundle(identity, oAuthIdToken, authData.authChallenges);
+    return this.getRotateBundle(identity, oAuthIdToken, enrollmentData);
   }
 
   // ############ Internal Functions ############
@@ -180,7 +183,7 @@ export class E2EIServiceInternal {
       nonce: orderData.nonce,
     });
 
-    return {authChallenges, orderUrl: orderData.orderUrl};
+    return {orderUrl: orderData.orderUrl, ...authChallenges};
   }
 
   /**
@@ -191,14 +194,18 @@ export class E2EIServiceInternal {
    * @param oAuthIdToken
    * @returns RotateBundle
    */
-  private async getRotateBundle(identity: E2eiEnrollment, oAuthIdToken: string, authData: AuthData) {
+  private async getRotateBundle(
+    identity: E2eiEnrollment,
+    oAuthIdToken: string,
+    enrollmentData: UnidentifiedEnrollmentFlowData,
+  ) {
     // Step 7: Do OIDC client challenge
     const oidcData = await doWireOidcChallenge({
       oAuthIdToken,
-      authData,
+      authData: enrollmentData,
       connection: this.acmeService,
       identity,
-      nonce: authData.nonce,
+      nonce: enrollmentData.nonce,
     });
     this.logger.log('oidc data', oidcData);
 
@@ -209,7 +216,7 @@ export class E2EIServiceInternal {
     const {user: wireUser, clientId} = this.initialData;
     //Step 8: Do DPOP Challenge
     const dpopData = await doWireDpopChallenge({
-      authData,
+      authData: enrollmentData,
       clientId,
       connection: this.acmeService,
       identity,
@@ -225,12 +232,11 @@ export class E2EIServiceInternal {
     }
 
     //Step 9: Finalize Order
-    const orderData = E2EIStorage.get.orderData();
     const finalizeOrderData = await finalizeOrder({
       connection: this.acmeService,
       identity,
       nonce: dpopData.nonce,
-      orderUrl: orderData.orderUrl,
+      orderUrl: enrollmentData.orderUrl,
     });
 
     if (!finalizeOrderData.certificateUrl) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -54,7 +54,7 @@ export class E2EIServiceInternal {
     this.enrollmentStorage = createE2EIEnrollmentStorage(coreDb);
   }
 
-  public async startCertificateProcess(processId: string, hasActiveCertificate: boolean) {
+  public async startCertificateProcess(hasActiveCertificate: boolean) {
     const identity = await this.initIdentity(hasActiveCertificate);
 
     // Store the values in local storage for later use (e.g. in the continue flow)
@@ -63,7 +63,7 @@ export class E2EIServiceInternal {
 
     // store auth data for continuing the flow later on
     const handle = await this.coreCryptoClient.e2eiEnrollmentStash(identity);
-    await this.enrollmentStorage.save(processId, {
+    await this.enrollmentStorage.save({
       handle,
       ...enrollmentData,
     });
@@ -71,8 +71,8 @@ export class E2EIServiceInternal {
     return {challenge: oidcChallenge, keyAuth: keyauth};
   }
 
-  public async continueCertificateProcess(processId: string, oAuthIdToken: string): Promise<RotateBundle | undefined> {
-    const enrollmentData = await this.enrollmentStorage.getEnrollmentFlowData(processId);
+  public async continueCertificateProcess(oAuthIdToken: string): Promise<RotateBundle | undefined> {
+    const enrollmentData = await this.enrollmentStorage.getEnrollmentFlowData();
     if (!enrollmentData) {
       throw new Error('Error while trying to continue OAuth flow. No enrollment in progress found');
     }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/Authorization.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/Authorization.ts
@@ -20,7 +20,7 @@
 import {AcmeService} from '../Connection';
 import {E2eiEnrollment, NewAcmeAuthz, Nonce} from '../E2EIService.types';
 import {jsonToByteArray} from '../Helper';
-import {AuthData} from '../Storage/E2EIStorage.schema';
+import {EnrollmentFlowData} from '../Storage/E2EIStorage.schema';
 
 interface GetAuthorizationParams {
   nonce: Nonce;
@@ -34,7 +34,7 @@ export const getAuthorizationChallenges = async ({
   nonce,
   identity,
   connection,
-}: GetAuthorizationParams): Promise<AuthData> => {
+}: GetAuthorizationParams): Promise<Pick<EnrollmentFlowData, 'authorization' | 'nonce'>> => {
   const challenges: {type: string; challenge: NewAcmeAuthz}[] = [];
 
   for (const authzUrl of authzUrls) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.types.ts
@@ -22,13 +22,13 @@ import {APIClient} from '@wireapp/api-client';
 import {ClientId} from '../../../types';
 import {AcmeService} from '../../Connection/AcmeServer';
 import {E2eiEnrollment, Nonce, User} from '../../E2EIService.types';
-import {AuthData} from '../../Storage/E2EIStorage.schema';
+import {UnidentifiedEnrollmentFlowData} from '../../Storage/E2EIStorage.schema';
 
 export interface DoWireDpopChallengeParams {
   apiClient: APIClient;
   clientId: ClientId;
   userDomain: User['domain'];
-  authData: AuthData;
+  authData: UnidentifiedEnrollmentFlowData;
   identity: E2eiEnrollment;
   connection: AcmeService;
   nonce: Nonce;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/OidcChallenge.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/OidcChallenge.ts
@@ -21,10 +21,10 @@ import {Converter} from 'bazinga64';
 
 import {AcmeService} from '../Connection/AcmeServer';
 import {E2eiEnrollment, Nonce} from '../E2EIService.types';
-import {AuthData} from '../Storage/E2EIStorage.schema';
+import {UnidentifiedEnrollmentFlowData} from '../Storage/E2EIStorage.schema';
 
 interface DoWireOidcChallengeParams {
-  authData: AuthData;
+  authData: UnidentifiedEnrollmentFlowData;
   identity: E2eiEnrollment;
   connection: AcmeService;
   nonce: Nonce;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.schema.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.schema.ts
@@ -32,15 +32,14 @@ export const InitialDataSchema = z.object({
 });
 export type InitialData = z.infer<typeof InitialDataSchema>;
 
-const Uint8ArraySchema = z.custom<Uint8Array>(value =>
-  value instanceof Uint8Array ? {success: true} : {success: false, message: 'Expected Uint8Array'},
-);
 const AcmeChallengeSchema = z.object({
-  delegate: Uint8ArraySchema,
+  delegate: z.instanceof(Uint8Array),
   url: z.string(),
   target: z.string(),
 });
-export const AuthDataSchema = z.object({
+export const EnrollmentFlowDataSchema = z.object({
+  handle: z.instanceof(Uint8Array),
+  orderUrl: z.string().url(),
   authorization: z.object({
     keyauth: z.string(),
     dpopChallenge: AcmeChallengeSchema,
@@ -48,9 +47,5 @@ export const AuthDataSchema = z.object({
   }),
   nonce: z.string(),
 });
-export type AuthData = z.infer<typeof AuthDataSchema>;
-
-export const OrderDataSchema = z.object({
-  orderUrl: z.string().url(),
-});
-export type OrderData = z.infer<typeof OrderDataSchema>;
+export type EnrollmentFlowData = z.infer<typeof EnrollmentFlowDataSchema>;
+export type UnidentifiedEnrollmentFlowData = Omit<EnrollmentFlowData, 'handle'>;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
@@ -17,77 +17,20 @@
  *
  */
 
-import {Encoder, Decoder} from 'bazinga64';
+import {EnrollmentFlowData} from './E2EIStorage.schema';
 
-import {AuthData, AuthDataSchema, OrderData} from './E2EIStorage.schema';
+import {CoreDatabase} from '../../../../storage/CoreDB';
 
-import {LocalStorageStore} from '../../../../util/LocalStorageStore';
-
-const HandleKey = 'Handle';
-const AuthDataKey = 'AuthData';
-const OderDataKey = 'OrderData';
-
-const storage = LocalStorageStore<string>('E2EIStorage');
-
-const storeHandle = (handle: string) => storage.add(HandleKey, Encoder.toBase64(handle).asString);
-const storeOrderData = (data: OrderData) => storage.add(OderDataKey, Encoder.toBase64(JSON.stringify(data)).asString);
-const storeAuthData = (data: AuthData) => storage.add(AuthDataKey, Encoder.toBase64(JSON.stringify(data)).asString);
-
-const hasHandle = () => storage.has(HandleKey);
-
-const getAndVerifyHandle = () => {
-  const handle = storage.get(HandleKey);
-  if (!handle) {
-    throw new Error('ACME: No handle found');
-  }
-
-  return Decoder.fromBase64(handle).asString;
-};
-
-const getAndVerifyAuthData = (): AuthData => {
-  const data = storage.get(AuthDataKey);
-  if (!data) {
-    throw new Error('ACME: AuthData not found');
-  }
-  const decodedData = Decoder.fromBase64(data).asString;
-  return AuthDataSchema.parse(JSON.parse(decodedData));
-};
-
-const getAndVerifyOrderData = (): OrderData => {
-  const data = storage.get(OderDataKey);
-  if (!data) {
-    throw new Error('ACME: OrderData not found');
-  }
-  const decodedData = Decoder.fromBase64(data).asString;
-  return JSON.parse(decodedData);
-};
-
-const removeTemporaryData = () => {
-  storage.remove(HandleKey);
-  storage.remove(AuthDataKey);
-  storage.remove(OderDataKey);
-};
-
-const removeAll = () => {
-  removeTemporaryData();
-};
-
-export const E2EIStorage = {
-  store: {
-    handle: storeHandle,
-    authData: storeAuthData,
-    orderData: storeOrderData,
-  },
-  get: {
-    handle: getAndVerifyHandle,
-    authData: getAndVerifyAuthData,
-    orderData: getAndVerifyOrderData,
-  },
-  has: {
-    handle: hasHandle,
-  },
-  remove: {
-    temporaryData: removeTemporaryData,
-    all: removeAll,
-  },
-};
+export function createE2EIEnrollmentStorage(coreDB: CoreDatabase) {
+  return {
+    async getEnrollmentFlowData(id: string): Promise<EnrollmentFlowData | undefined> {
+      return coreDB.get('enrollmentFlowData', id);
+    },
+    async save(id: string, data: EnrollmentFlowData): Promise<void> {
+      await coreDB.put('enrollmentFlowData', data, id);
+    },
+    async delete(id: string): Promise<void> {
+      return coreDB.delete('enrollmentFlowData', id);
+    },
+  };
+}

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
@@ -21,16 +21,19 @@ import {EnrollmentFlowData} from './E2EIStorage.schema';
 
 import {CoreDatabase} from '../../../../storage/CoreDB';
 
+const PENDING_ENROLLMENT_TABLE = 'pendingEnrollmentData';
+const STORAGE_KEY = 'data';
+
 export function createE2EIEnrollmentStorage(coreDB: CoreDatabase) {
   return {
-    async getEnrollmentFlowData(): Promise<EnrollmentFlowData | undefined> {
-      return coreDB.get('enrollmentFlowData', 'data');
+    async getPendingEnrollmentData(): Promise<EnrollmentFlowData | undefined> {
+      return coreDB.get(PENDING_ENROLLMENT_TABLE, STORAGE_KEY);
     },
-    async save(data: EnrollmentFlowData): Promise<void> {
-      await coreDB.put('enrollmentFlowData', data, 'data');
+    async savePendingEnrollmentData(data: EnrollmentFlowData): Promise<void> {
+      await coreDB.put(PENDING_ENROLLMENT_TABLE, data, STORAGE_KEY);
     },
-    async delete(): Promise<void> {
-      return coreDB.delete('enrollmentFlowData', 'data');
+    async deletePendingEnrollmentData(): Promise<void> {
+      return coreDB.delete(PENDING_ENROLLMENT_TABLE, STORAGE_KEY);
     },
   };
 }

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.ts
@@ -23,14 +23,14 @@ import {CoreDatabase} from '../../../../storage/CoreDB';
 
 export function createE2EIEnrollmentStorage(coreDB: CoreDatabase) {
   return {
-    async getEnrollmentFlowData(id: string): Promise<EnrollmentFlowData | undefined> {
-      return coreDB.get('enrollmentFlowData', id);
+    async getEnrollmentFlowData(): Promise<EnrollmentFlowData | undefined> {
+      return coreDB.get('enrollmentFlowData', 'data');
     },
-    async save(id: string, data: EnrollmentFlowData): Promise<void> {
-      await coreDB.put('enrollmentFlowData', data, id);
+    async save(data: EnrollmentFlowData): Promise<void> {
+      await coreDB.put('enrollmentFlowData', data, 'data');
     },
-    async delete(id: string): Promise<void> {
-      return coreDB.delete('enrollmentFlowData', id);
+    async delete(): Promise<void> {
+      return coreDB.delete('enrollmentFlowData', 'data');
     },
   };
 }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -856,6 +856,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   ): Promise<EnrollmentProcessState> {
     const hasActiveCertificate = await this.coreCryptoClient.e2eiIsEnabled(this.config.cipherSuite);
     const e2eiServiceInternal = new E2EIServiceInternal(
+      this.coreDatabase,
       this.coreCryptoClient,
       this.apiClient,
       certificateTtl,
@@ -865,14 +866,14 @@ export class MLSService extends TypedEventEmitter<Events> {
 
     // If we don't have an OAuth id token, we need to start the certificate process with Oauth
     if (!oAuthIdToken) {
-      const data = await e2eiServiceInternal.startCertificateProcess(hasActiveCertificate);
+      const data = await e2eiServiceInternal.startCertificateProcess(user.id, hasActiveCertificate);
       return {status: 'authentication', authenticationChallenge: data};
     }
 
     // If we have an OAuth id token, we can continue the certificate process / start a refresh
     const rotateBundle = !hasActiveCertificate
       ? // If we are not refreshing the active certificate, we need to continue the certificate process with Oauth
-        await e2eiServiceInternal.continueCertificateProcess(oAuthIdToken)
+        await e2eiServiceInternal.continueCertificateProcess(user.id, oAuthIdToken)
       : // If we are refreshing the active certificate, can start the refresh process
         await e2eiServiceInternal.renewCertificate(oAuthIdToken, hasActiveCertificate);
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -866,14 +866,14 @@ export class MLSService extends TypedEventEmitter<Events> {
 
     // If we don't have an OAuth id token, we need to start the certificate process with Oauth
     if (!oAuthIdToken) {
-      const data = await e2eiServiceInternal.startCertificateProcess(user.id, hasActiveCertificate);
+      const data = await e2eiServiceInternal.startCertificateProcess(hasActiveCertificate);
       return {status: 'authentication', authenticationChallenge: data};
     }
 
     // If we have an OAuth id token, we can continue the certificate process / start a refresh
     const rotateBundle = !hasActiveCertificate
       ? // If we are not refreshing the active certificate, we need to continue the certificate process with Oauth
-        await e2eiServiceInternal.continueCertificateProcess(user.id, oAuthIdToken)
+        await e2eiServiceInternal.continueCertificateProcess(oAuthIdToken)
       : // If we are refreshing the active certificate, can start the refresh process
         await e2eiServiceInternal.renewCertificate(oAuthIdToken, hasActiveCertificate);
 

--- a/packages/core/src/storage/CoreDB.ts
+++ b/packages/core/src/storage/CoreDB.ts
@@ -49,7 +49,7 @@ interface CoreDBSchema extends DBSchema {
     key: string;
     value: {expiresAt: number; url: string};
   };
-  enrollmentFlowData: {
+  pendingEnrollmentData: {
     key: string;
     value: EnrollmentFlowData;
   };
@@ -75,7 +75,7 @@ export async function openDB(dbName: string): Promise<CoreDatabase> {
         case 5:
           db.createObjectStore('crls');
         case 6:
-          db.createObjectStore('enrollmentFlowData');
+          db.createObjectStore('pendingEnrollmentData');
       }
     },
   });

--- a/packages/core/src/storage/CoreDB.ts
+++ b/packages/core/src/storage/CoreDB.ts
@@ -20,7 +20,9 @@
 import {SUBCONVERSATION_ID} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {DBSchema, deleteDB as idbDeleteDB, IDBPDatabase, openDB as idbOpenDb} from 'idb';
-const VERSION = 5;
+
+import {EnrollmentFlowData} from '../messagingProtocols/mls/E2EIdentityService/Storage/E2EIStorage.schema';
+const VERSION = 6;
 
 interface CoreDBSchema extends DBSchema {
   prekeys: {
@@ -47,6 +49,10 @@ interface CoreDBSchema extends DBSchema {
     key: string;
     value: {expiresAt: number; url: string};
   };
+  enrollmentFlowData: {
+    key: string;
+    value: EnrollmentFlowData;
+  };
 }
 
 export type CoreDatabase = IDBPDatabase<CoreDBSchema>;
@@ -68,6 +74,8 @@ export async function openDB(dbName: string): Promise<CoreDatabase> {
           db.createObjectStore('subconversations');
         case 5:
           db.createObjectStore('crls');
+        case 6:
+          db.createObjectStore('enrollmentFlowData');
       }
     },
   });


### PR DESCRIPTION
Will use indexedDB as storage for temporary e2ei enrollment flow. 

Since indexeddb is unique per user, this will ensure that no other user logged in on the same browser will share enrollment data