### PR TITLE
fix: Pass parent conversation external senders to subconversation creation

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -124,7 +124,7 @@ describe('ConversationService', () => {
 
     const mockedDb = await openDB('core-test-db');
 
-    const groupIdFromConversationId = jest.fn();
+    const groupIdFromConversationId = jest.fn(async () => 'groupId');
 
     const mockedSubconversationService = {
       joinConferenceSubconversation: jest.fn(),
@@ -412,7 +412,9 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.registerConversation).toHaveBeenCalledTimes(1);
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], selfUser);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], {
+        creator: selfUser,
+      });
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });
@@ -463,7 +465,9 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.registerConversation).toHaveBeenCalledTimes(2);
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], selfUser);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], {
+        creator: selfUser,
+      });
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });
@@ -533,7 +537,7 @@ describe('ConversationService', () => {
       await new Promise(resolve => setImmediate(resolve));
 
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
-      expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId);
+      expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId, 'groupId');
     });
   });
 

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
@@ -113,7 +113,7 @@ describe('SubconversationService', () => {
       await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(subconversationGroupId);
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, [], {parentGroupId});
     });
 
     it('registers a group if remote epoch is 0 and group does not exist locally', async () => {
@@ -137,7 +137,7 @@ describe('SubconversationService', () => {
       await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, [], {parentGroupId});
     });
 
     it('deletes conference subconversation from backend if group is already established and epoch is older than one day, then rejoins', async () => {
@@ -254,7 +254,7 @@ describe('SubconversationService', () => {
       await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, [], {parentGroupId});
       expect(mlsService.registerConversation).toHaveBeenCalledTimes(2);
     });
 
@@ -282,7 +282,7 @@ describe('SubconversationService', () => {
       const response = await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
+      expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, [], {parentGroupId});
       expect(response).toEqual({epoch: updatedEpoch, groupId: subconversationGroupId});
     });
   });

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
@@ -96,6 +96,7 @@ describe('SubconversationService', () => {
       const [subconversationService, {apiClient, mlsService}] = await buildSubconversationService();
 
       const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const parentGroupId = 'parentGroupId';
       const subconversationGroupId = 'subconversationGroupId';
 
       const subconversationResponse = getSubconversationResponse({
@@ -109,7 +110,7 @@ describe('SubconversationService', () => {
       jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(true);
 
-      await subconversationService.joinConferenceSubconversation(parentConversationId);
+      await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(subconversationGroupId);
       expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
@@ -119,6 +120,7 @@ describe('SubconversationService', () => {
       const [subconversationService, {apiClient, mlsService}] = await buildSubconversationService();
 
       const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const parentGroupId = 'parentGroupId';
       const subconversationGroupId = 'subconversationGroupId';
 
       const subconversationResponse = getSubconversationResponse({
@@ -132,7 +134,7 @@ describe('SubconversationService', () => {
       jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
 
-      await subconversationService.joinConferenceSubconversation(parentConversationId);
+      await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();
       expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
@@ -143,6 +145,7 @@ describe('SubconversationService', () => {
       const [subconversationService, {apiClient, mlsService}] = await buildSubconversationService();
 
       const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const parentGroupId = 'parentGroupId';
       const subconversationGroupId = 'subconversationGroupId';
       const initialSubconversationEpoch = 1;
 
@@ -176,7 +179,7 @@ describe('SubconversationService', () => {
 
       jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse2);
 
-      await subconversationService.joinConferenceSubconversation(parentConversationId);
+      await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(apiClient.api.conversation.deleteSubconversation).toHaveBeenCalledWith(
         parentConversationId,
@@ -197,6 +200,7 @@ describe('SubconversationService', () => {
 
       const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
       const subconversationGroupId = 'subconversationGroupId';
+      const parentGroupId = 'parentGroupId';
       const subconversationEpoch = 1;
 
       const currentTimeISO = '2023-10-24T12:00:00.000Z';
@@ -217,7 +221,7 @@ describe('SubconversationService', () => {
 
       jest.spyOn(apiClient.api.conversation, 'getSubconversation').mockResolvedValueOnce(subconversationResponse);
 
-      await subconversationService.joinConferenceSubconversation(parentConversationId);
+      await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(apiClient.api.conversation.deleteSubconversation).not.toHaveBeenCalled();
       expect(mlsService.registerConversation).not.toHaveBeenCalled();
@@ -229,6 +233,7 @@ describe('SubconversationService', () => {
       const [subconversationService, {apiClient, mlsService}] = await buildSubconversationService();
 
       const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const parentGroupId = 'parentGroupId';
       const subconversationGroupId = 'subconversationGroupId';
 
       const subconversationResponse = getSubconversationResponse({
@@ -246,7 +251,7 @@ describe('SubconversationService', () => {
         .spyOn(mlsService, 'registerConversation')
         .mockRejectedValueOnce(new BackendError('', BackendErrorLabel.MLS_STALE_MESSAGE, StatusCode.CONFLICT));
 
-      await subconversationService.joinConferenceSubconversation(parentConversationId);
+      await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();
       expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);
@@ -257,6 +262,7 @@ describe('SubconversationService', () => {
       const [subconversationService, {apiClient, mlsService}] = await buildSubconversationService();
 
       const parentConversationId = {id: 'parentConversationId', domain: 'domain'};
+      const parentGroupId = 'parentGroupId';
       const subconversationGroupId = 'subconversationGroupId';
 
       const subconversationResponse = getSubconversationResponse({
@@ -273,7 +279,7 @@ describe('SubconversationService', () => {
       const updatedEpoch = 1;
       jest.spyOn(mlsService, 'getEpoch').mockResolvedValueOnce(updatedEpoch);
 
-      const response = await subconversationService.joinConferenceSubconversation(parentConversationId);
+      const response = await subconversationService.joinConferenceSubconversation(parentConversationId, parentGroupId);
 
       expect(mlsService.wipeConversation).not.toHaveBeenCalled();
       expect(mlsService.registerConversation).toHaveBeenCalledWith(subconversationGroupId, []);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -108,7 +108,7 @@ describe('MLSService', () => {
       const creator = {user: selfUser, client: 'client-1'};
       const users = [createUserId(), createUserId()];
 
-      await mlsService.registerConversation(groupId, [...users, selfUser], creator);
+      await mlsService.registerConversation(groupId, [...users, selfUser], {creator});
 
       expect(apiClient.api.client.claimMLSKeyPackages).toHaveBeenCalledTimes(3);
       expect(apiClient.api.client.claimMLSKeyPackages).toHaveBeenCalledWith(

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -390,14 +390,22 @@ export class MLSService extends TypedEventEmitter<Events> {
   /**
    * Will create an empty conversation inside of coreCrypto.
    * @param groupId the id of the group to create inside of coreCrypto
+   * @param parentGroupId in case the conversation is a subconversation, the id of the parent conversation
    */
-  public async registerEmptyConversation(groupId: string): Promise<void> {
+  public async registerEmptyConversation(groupId: string, parentGroupId?: string): Promise<void> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
-    const mlsKeys = (await this.apiClient.api.client.getPublicKeys()).removal;
-    const mlsKeyBytes = Object.values(mlsKeys).map((key: string) => Decoder.fromBase64(key).asBytes);
+    let externalSenders: Uint8Array[] = [];
+    if (parentGroupId) {
+      const parentGroupIdBytes = Decoder.fromBase64(parentGroupId).asBytes;
+      externalSenders = [await this.coreCryptoClient.getExternalSender(parentGroupIdBytes)];
+    } else {
+      const mlsKeys = (await this.apiClient.api.client.getPublicKeys()).removal;
+      externalSenders = Object.values(mlsKeys).map((key: string) => Decoder.fromBase64(key).asBytes);
+    }
+
     const configuration: ConversationConfiguration = {
-      externalSenders: mlsKeyBytes,
+      externalSenders: externalSenders,
       ciphersuite: this.config.cipherSuite,
     };
 
@@ -409,15 +417,17 @@ export class MLSService extends TypedEventEmitter<Events> {
    * Will create a conversation inside of coreCrypto, add users to it or update the keying material if empty key packages list is provided.
    * @param groupId the id of the group to create inside of coreCrypto
    * @param users the list of users that will be members of the conversation (including the self user)
-   * @param creator the creator of the list. Most of the time will be the self user (or empty if the conversation was created by backend first)
+   * @param options.creator the creator of the list. Most of the time will be the self user (or empty if the conversation was created by backend first)
+   * @param options.parentGroupId in case the conversation is a subconversation, the id of the parent conversation
    */
   public async registerConversation(
     groupId: string,
     users: QualifiedId[],
-    creator?: {user: QualifiedId; client?: string},
+    options?: {creator?: {user: QualifiedId; client?: string}; parentGroupId?: string},
   ): Promise<PostMlsMessageResponse> {
-    await this.registerEmptyConversation(groupId);
+    await this.registerEmptyConversation(groupId, options?.parentGroupId);
 
+    const creator = options?.creator;
     const {coreCryptoKeyPackagesPayload: keyPackages, failedToFetchKeyPackages} = await this.getKeyPackagesPayload(
       users.map(user => {
         if (user.id === creator?.user.id) {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -405,7 +405,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     }
 
     const configuration: ConversationConfiguration = {
-      externalSenders: externalSenders,
+      externalSenders,
       ciphersuite: this.config.cipherSuite,
     };
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
