### PR TITLE
runfix: system message keys claiming failure [WPB-6641]

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -33,7 +33,7 @@ import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {APIClient} from '@wireapp/api-client';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
-import {ConversationService, MessageSendingState} from '..';
+import {AddUsersFailure, AddUsersFailureReasons, ConversationService, MessageSendingState} from '..';
 import {MLSService} from '../../messagingProtocols/mls';
 import {CoreCryptoMLSError} from '../../messagingProtocols/mls/MLSService/CoreCryptoMLSError';
 import {ProteusService} from '../../messagingProtocols/proteus';
@@ -646,6 +646,54 @@ describe('ConversationService', () => {
 
       expect(mlsService.getKeyPackagesPayload).toHaveBeenCalledWith(qualifiedUsers);
       expect(mlsService.resetKeyMaterialRenewal).toHaveBeenCalledWith(mockGroupId);
+    });
+
+    it('should return failure reasons for users it was not possible to claim keys for', async () => {
+      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
+
+      const mockGroupId = 'groupId';
+      const mockConversationId = {id: PayloadHelper.getUUID(), domain: 'local.wire.com'};
+
+      const otherUsersToAdd = Array(3)
+        .fill(0)
+        .map(() => ({id: PayloadHelper.getUUID(), domain: 'local.wire.com'}));
+
+      const selfUserToAdd = {id: 'self-user-id', domain: 'local.wire.com', skipOwnClientId: apiClient.clientId};
+
+      const qualifiedUsers = [...otherUsersToAdd, selfUserToAdd];
+
+      const keysClaimingFailure: AddUsersFailure = {
+        reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG,
+        users: [otherUsersToAdd[0]],
+      };
+      const addUsersFailure: AddUsersFailure = {
+        reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+        users: [otherUsersToAdd[1]],
+        backends: [otherUsersToAdd[1].domain],
+      };
+
+      jest.spyOn(mlsService, 'getKeyPackagesPayload').mockResolvedValueOnce({
+        keyPackages: [new Uint8Array(0)],
+        failures: [keysClaimingFailure],
+      });
+
+      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: 1,
+        group_id: mockGroupId,
+      } as unknown as Conversation);
+
+      const mlsMessage = {events: [], time: '', failures: [addUsersFailure]};
+      jest.spyOn(mlsService, 'addUsersToExistingConversation').mockResolvedValueOnce(mlsMessage);
+
+      const {failedToAdd} = await conversationService.addUsersToMLSConversation({
+        qualifiedUsers,
+        groupId: mockGroupId,
+        conversationId: mockConversationId,
+      });
+
+      expect(failedToAdd).toEqual([keysClaimingFailure, addUsersFailure]);
     });
   });
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -22,7 +22,6 @@ import {
   Conversation,
   ConversationProtocol,
   MLSConversation,
-  PostMlsMessageResponse,
   Subconversation,
   SUBCONVERSATION_ID,
 } from '@wireapp/api-client/lib/conversation';
@@ -627,9 +626,7 @@ describe('ConversationService', () => {
 
       const qualifiedUsers = [...otherUsersToAdd, selfUserToAdd];
 
-      jest
-        .spyOn(mlsService, 'getKeyPackagesPayload')
-        .mockResolvedValueOnce({coreCryptoKeyPackagesPayload: [], failedToFetchKeyPackages: []});
+      jest.spyOn(mlsService, 'getKeyPackagesPayload').mockResolvedValueOnce({keyPackages: [], failures: []});
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: mockConversationId,
@@ -638,7 +635,7 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as Conversation);
 
-      const mlsMessage: PostMlsMessageResponse = {events: [], time: ''};
+      const mlsMessage = {events: [], time: '', failures: []};
       jest.spyOn(mlsService, 'addUsersToExistingConversation').mockResolvedValueOnce(mlsMessage);
 
       await conversationService.addUsersToMLSConversation({

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -50,7 +50,7 @@ import {TypedEventEmitter} from '@wireapp/commons';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {
-  AddUsersFailureReasons,
+  AddUsersFailure,
   AddUsersParams,
   KeyPackageClaimUser,
   MLSCreateConversationResponse,
@@ -303,7 +303,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       throw new Error('No group_id found in response which is required for creating MLS conversations.');
     }
 
-    const response = await this.mlsService.registerConversation(groupId, qualifiedUsers.concat(selfUserId), {
+    const {events, failures} = await this.mlsService.registerConversation(groupId, qualifiedUsers.concat(selfUserId), {
       creator: {
         user: selfUserId,
         client: selfClientId,
@@ -314,11 +314,9 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const conversation = await this.apiClient.api.conversation.getConversation(qualifiedId);
 
     return {
-      events: response.events,
+      events,
       conversation,
-      failedToAdd: response.failed
-        ? [{users: response.failed, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}]
-        : undefined,
+      failedToAdd: failures,
     };
   }
 
@@ -377,25 +375,22 @@ export class ConversationService extends TypedEventEmitter<Events> {
     groupId,
     conversationId,
   }: Required<AddUsersParams>): Promise<MLSCreateConversationResponse> {
-    const {coreCryptoKeyPackagesPayload, failedToFetchKeyPackages} =
-      await this.mlsService.getKeyPackagesPayload(qualifiedUsers);
+    const {keyPackages, failures: keysUploadFailures} = await this.mlsService.getKeyPackagesPayload(qualifiedUsers);
 
-    const response =
-      coreCryptoKeyPackagesPayload.length > 0
-        ? await this.mlsService.addUsersToExistingConversation(groupId, coreCryptoKeyPackagesPayload)
-        : {events: []};
+    const {events, failures} =
+      keyPackages.length > 0
+        ? await this.mlsService.addUsersToExistingConversation(groupId, keyPackages)
+        : {events: [], failures: [] as AddUsersFailure[]};
 
     const conversation = await this.getConversation(conversationId);
 
     //We store the info when user was added (and key material was created), so we will know when to renew it
     await this.mlsService.resetKeyMaterialRenewal(groupId);
+
     return {
-      events: response.events,
+      events,
       conversation,
-      failedToAdd:
-        failedToFetchKeyPackages.length > 0
-          ? [{users: failedToFetchKeyPackages, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}]
-          : undefined,
+      failedToAdd: [...keysUploadFailures, ...failures],
     };
   }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -375,7 +375,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     groupId,
     conversationId,
   }: Required<AddUsersParams>): Promise<MLSCreateConversationResponse> {
-    const {keyPackages, failures: keysUploadFailures} = await this.mlsService.getKeyPackagesPayload(qualifiedUsers);
+    const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(qualifiedUsers);
 
     const {events, failures} =
       keyPackages.length > 0
@@ -390,7 +390,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     return {
       events,
       conversation,
-      failedToAdd: [...keysUploadFailures, ...failures],
+      failedToAdd: [...keysClaimingFailures, ...failures],
     };
   }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -317,7 +317,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       events: response.events,
       conversation,
       failedToAdd: response.failed
-        ? {users: response.failed, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
+        ? [{users: response.failed, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}]
         : undefined,
     };
   }
@@ -394,7 +394,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
       conversation,
       failedToAdd:
         failedToFetchKeyPackages.length > 0
-          ? {users: failedToFetchKeyPackages, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}
+          ? [{users: failedToFetchKeyPackages, backends: [], reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS}]
           : undefined,
     };
   }

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -118,34 +118,44 @@ export type RemoveUsersParams = {
 export enum AddUsersFailureReasons {
   NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
   UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
+  OFFLINE_FOR_TOO_LONG = 'OFFLINE_FOR_TOO_LONG',
 }
 
 /**
  * List of users that were originaly requested to be in the conversation
  * but could not be added due to their backend not being available
  * @note Added since version 4: https://staging-nginz-https.z
- ra.io/v4/api/swagger-ui/#/default/post_conversations
- * @note Federation only
- */
-export type AddUsersFailure = {
-  users: QualifiedId[];
-  reason: AddUsersFailureReasons;
-  /** the backends that caused the failure */
-  backends: string[];
-};
+ra.io/v4/api/swagger-ui/#/default/post_conversations
+* @note Federation only
+*/
+export type AddUsersFailure =
+  | {
+      reason: AddUsersFailureReasons.NON_FEDERATING_BACKENDS;
+      users: QualifiedId[];
+      backends: string[];
+    }
+  | {
+      reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS;
+      users: QualifiedId[];
+      backends: string[];
+    }
+  | {
+      reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG;
+      users: QualifiedId[];
+    };
 
 /**
  * The backend response of any method that will create (or add users to) a conversation
  */
 export interface BaseCreateConversationResponse {
   conversation: Conversation;
-  failedToAdd?: AddUsersFailure;
+  failedToAdd?: AddUsersFailure[];
 }
 
 export type ProteusCreateConversationResponse = BaseCreateConversationResponse;
 export type ProteusAddUsersResponse = {
   event?: ConversationMemberJoinEvent;
-  failedToAdd?: AddUsersFailure;
+  failedToAdd?: AddUsersFailure[];
 };
 
 export interface MLSCreateConversationResponse extends BaseCreateConversationResponse {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -554,7 +554,7 @@ describe('MLSService', () => {
       const mockGroupId = 'mock-group-id2';
 
       jest.spyOn(mlsService, 'conversationExists').mockResolvedValueOnce(false);
-      jest.spyOn(mlsService, 'registerConversation').mockResolvedValueOnce({events: [], time: ''});
+      jest.spyOn(mlsService, 'registerConversation').mockResolvedValueOnce({events: [], time: '', failures: []});
       jest.spyOn(mlsService, 'wipeConversation').mockImplementation(jest.fn());
 
       const wasConversationEstablished = await mlsService.tryEstablishingMLSGroup(mockGroupId);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -46,7 +46,7 @@ import {
 import {isCoreCryptoMLSConversationAlreadyExistsError, shouldMLSDecryptionErrorBeIgnored} from './CoreCryptoMLSError';
 import {MLSServiceConfig, NewCrlDistributionPointsPayload, UploadCommitOptions} from './MLSService.types';
 
-import {KeyPackageClaimUser} from '../../../conversation';
+import {AddUsersFailure, AddUsersFailureReasons, KeyPackageClaimUser} from '../../../conversation';
 import {sendMessage} from '../../../conversation/message/messageSender';
 import {CoreDatabase} from '../../../storage/CoreDB';
 import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUtils';
@@ -232,17 +232,36 @@ export class MLSService extends TypedEventEmitter<Events> {
    * @param groupId - the group id of the MLS group
    * @param keyPackages - the list of keys of clients to add to the MLS group
    */
-  public addUsersToExistingConversation(groupId: string, keyPackages: Uint8Array[]) {
+  public async addUsersToExistingConversation(
+    groupId: string,
+    keyPackages: Uint8Array[],
+  ): Promise<PostMlsMessageResponse & {failures: AddUsersFailure[]}> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     if (keyPackages.length < 1) {
       throw new Error('Empty list of keys provided to addUsersToExistingConversation');
     }
-    return this.processCommitAction(groupIdBytes, async () => {
+
+    //TODO: return failures array based on the response here - check .failed field and/or 503 "federation-unreachable-domains-error"
+    const response = await this.processCommitAction(groupIdBytes, async () => {
       const commitBundle = await this.coreCryptoClient.addClientsToConversation(groupIdBytes, keyPackages);
       this.dispatchNewCrlDistributionPoints(commitBundle);
       return commitBundle;
     });
+
+    const failedUsers = response.failed;
+
+    const failures = failedUsers
+      ? [
+          {
+            users: failedUsers,
+            backends: failedUsers.map(({domain}) => domain),
+            reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+          },
+        ]
+      : [];
+
+    return {...response, failures};
   }
 
   public async getKeyPackagesPayload(qualifiedUsers: KeyPackageClaimUser[]) {
@@ -252,6 +271,8 @@ export class MLSService extends TypedEventEmitter<Events> {
      * includes self user too.
      */
     const failedToFetchKeyPackages: QualifiedId[] = [];
+    const emptyKeyPackagesUsers: QualifiedId[] = [];
+
     const keyPackagesSettledResult = await Promise.allSettled(
       qualifiedUsers.map(async ({id, domain, skipOwnClientId}) => {
         try {
@@ -265,7 +286,7 @@ export class MLSService extends TypedEventEmitter<Events> {
           // It's possible that user's backend is reachable but they have not uploaded their MLS key packages (or all of them have been claimed already)
           if (keys.key_packages.length === 0) {
             this.logger.warn(`User ${id} has no key packages uploaded`);
-            throw new Error(`User ${id} has no key packages uploaded`);
+            emptyKeyPackagesUsers.push({id, domain});
           }
 
           return keys;
@@ -298,7 +319,21 @@ export class MLSService extends TypedEventEmitter<Events> {
       return previousValue;
     }, []);
 
-    return {coreCryptoKeyPackagesPayload, failedToFetchKeyPackages};
+    const failures: AddUsersFailure[] = [];
+
+    if (emptyKeyPackagesUsers.length > 0) {
+      failures.push({reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG, users: emptyKeyPackagesUsers});
+    }
+
+    if (failedToFetchKeyPackages.length > 0) {
+      failures.push({
+        reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+        users: failedToFetchKeyPackages,
+        backends: failedToFetchKeyPackages.map(({domain}) => domain),
+      });
+    }
+
+    return {keyPackages: coreCryptoKeyPackagesPayload, failures};
   }
 
   public getEpoch(groupId: string | Uint8Array) {
@@ -437,11 +472,12 @@ export class MLSService extends TypedEventEmitter<Events> {
     groupId: string,
     users: QualifiedId[],
     options?: {creator?: {user: QualifiedId; client?: string}; parentGroupId?: string},
-  ): Promise<PostMlsMessageResponse> {
+  ): Promise<PostMlsMessageResponse & {failures: AddUsersFailure[]}> {
     await this.registerEmptyConversation(groupId, options?.parentGroupId);
 
     const creator = options?.creator;
-    const {coreCryptoKeyPackagesPayload: keyPackages, failedToFetchKeyPackages} = await this.getKeyPackagesPayload(
+
+    const {keyPackages, failures: keysUploadFailures} = await this.getKeyPackagesPayload(
       users.map(user => {
         if (user.id === creator?.user.id) {
           /**
@@ -454,11 +490,15 @@ export class MLSService extends TypedEventEmitter<Events> {
       }),
     );
 
-    const response =
-      keyPackages.length > 0
-        ? await this.addUsersToExistingConversation(groupId, keyPackages)
-        : // If there are no clients to add, just update the keying material
-          await this.updateKeyingMaterial(groupId);
+    if (keyPackages.length <= 0) {
+      // If there are no clients to add, just update the keying material
+      const response = await this.updateKeyingMaterial(groupId);
+      await this.scheduleKeyMaterialRenewal(groupId);
+
+      return {...response, failures: keysUploadFailures};
+    }
+
+    const response = await this.addUsersToExistingConversation(groupId, keyPackages);
 
     // We schedule a periodic key material renewal
     await this.scheduleKeyMaterialRenewal(groupId);
@@ -467,7 +507,7 @@ export class MLSService extends TypedEventEmitter<Events> {
      * @note If we can't fetch a user's key packages then we can not add them to mls conversation
      * so we're adding them to the list of failed users.
      */
-    response.failed = response.failed ? [...response.failed, ...failedToFetchKeyPackages] : failedToFetchKeyPackages;
+    response.failures = response.failures ? [...keysUploadFailures, ...response.failures] : keysUploadFailures;
     return response;
   }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -242,7 +242,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       throw new Error('Empty list of keys provided to addUsersToExistingConversation');
     }
 
-    //TODO: return failures array based on the response here - check .failed field and/or 503 "federation-unreachable-domains-error"
+    //TODO: handle federation error when sending a commit bundle to backend like we do in ProteusService
     const response = await this.processCommitAction(groupIdBytes, async () => {
       const commitBundle = await this.coreCryptoClient.addClientsToConversation(groupIdBytes, keyPackages);
       this.dispatchNewCrlDistributionPoints(commitBundle);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -507,7 +507,7 @@ export class MLSService extends TypedEventEmitter<Events> {
      * @note If we can't fetch a user's key packages then we can not add them to mls conversation
      * so we're adding them to the list of failed users.
      */
-    response.failures = response.failures ? [...keysUploadFailures, ...response.failures] : keysUploadFailures;
+    response.failures = [...keysUploadFailures, ...response.failures];
     return response;
   }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -477,7 +477,7 @@ export class MLSService extends TypedEventEmitter<Events> {
 
     const creator = options?.creator;
 
-    const {keyPackages, failures: keysUploadFailures} = await this.getKeyPackagesPayload(
+    const {keyPackages, failures: keysClaimingFailures} = await this.getKeyPackagesPayload(
       users.map(user => {
         if (user.id === creator?.user.id) {
           /**
@@ -495,7 +495,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       const response = await this.updateKeyingMaterial(groupId);
       await this.scheduleKeyMaterialRenewal(groupId);
 
-      return {...response, failures: keysUploadFailures};
+      return {...response, failures: keysClaimingFailures};
     }
 
     const response = await this.addUsersToExistingConversation(groupId, keyPackages);
@@ -507,7 +507,7 @@ export class MLSService extends TypedEventEmitter<Events> {
      * @note If we can't fetch a user's key packages then we can not add them to mls conversation
      * so we're adding them to the list of failed users.
      */
-    response.failures = [...keysUploadFailures, ...response.failures];
+    response.failures = [...keysClaimingFailures, ...response.failures];
     return response;
   }
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -627,8 +627,8 @@ describe('ProteusService', () => {
       );
       expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining(usersDomain2));
 
-      expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.UNREACHABLE_BACKENDS);
-      expect(result.failedToAdd?.users).toEqual([...usersDomain1]);
+      expect(result.failedToAdd?.[0]?.reason).toBe(AddUsersFailureReasons.UNREACHABLE_BACKENDS);
+      expect(result.failedToAdd?.[0]?.users).toEqual([...usersDomain1]);
     });
 
     it('completely fails to add users if some backends are unreachable', async () => {
@@ -648,8 +648,8 @@ describe('ProteusService', () => {
       expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining(allUsers));
       expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining(usersDomain2));
 
-      expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.UNREACHABLE_BACKENDS);
-      expect(result.failedToAdd?.users).toEqual(allUsers);
+      expect(result.failedToAdd?.[0]?.reason).toBe(AddUsersFailureReasons.UNREACHABLE_BACKENDS);
+      expect(result.failedToAdd?.[0]?.users).toEqual(allUsers);
     });
 
     it('partially add users if some users are part of not-connected backends', async () => {
@@ -674,8 +674,8 @@ describe('ProteusService', () => {
       );
       expect(postMembersSpy).toHaveBeenCalledWith(conversationId, expect.arrayContaining(usersDomain1));
 
-      expect(result.failedToAdd?.reason).toBe(AddUsersFailureReasons.NON_FEDERATING_BACKENDS);
-      expect(result.failedToAdd?.users).toEqual([...usersDomain2, ...usersDomain3]);
+      expect(result.failedToAdd?.[0]?.reason).toBe(AddUsersFailureReasons.NON_FEDERATING_BACKENDS);
+      expect(result.failedToAdd?.[0]?.users).toEqual([...usersDomain2, ...usersDomain3]);
     });
   });
 
@@ -737,11 +737,13 @@ describe('ProteusService', () => {
       );
       expect(postConversationSpy).toHaveBeenCalledWith(expect.objectContaining({qualified_users: usersDomain2}));
 
-      expect(failedToAdd).toEqual({
-        reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
-        backends: ['domain1'],
-        users: expect.arrayContaining([...usersDomain1, ...usersDomain1]),
-      });
+      expect(failedToAdd).toEqual([
+        {
+          reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+          backends: ['domain1'],
+          users: expect.arrayContaining([...usersDomain1, ...usersDomain1]),
+        },
+      ]);
     });
 
     it('creates an empty conversation if no backend is reachable', async () => {
@@ -765,11 +767,13 @@ describe('ProteusService', () => {
       );
       expect(postConversationSpy).toHaveBeenCalledWith(expect.objectContaining({qualified_users: []}));
 
-      expect(failedToAdd).toEqual({
-        reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
-        backends: [domain1, domain2],
-        users: expect.arrayContaining([...usersDomain1, ...usersDomain1]),
-      });
+      expect(failedToAdd).toEqual([
+        {
+          reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS,
+          backends: [domain1, domain2],
+          users: expect.arrayContaining([...usersDomain1, ...usersDomain1]),
+        },
+      ]);
     });
 
     it('fails to create a conversation if there are users from non-connected backends', async () => {

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.ts
@@ -179,7 +179,7 @@ export class ProteusService {
                 // on a succesfull conversation creation with the available users,
                 // we append the users from an unreachable backend to the response
                 unreachableUsers.length > 0
-                  ? {reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS, backends, users: unreachableUsers}
+                  ? [{reason: AddUsersFailureReasons.UNREACHABLE_BACKENDS, backends, users: unreachableUsers}]
                   : undefined,
             };
           }
@@ -216,7 +216,7 @@ export class ProteusService {
               backends,
             );
             if (availableUsers.length === 0) {
-              return {failedToAdd: {reason: failureReasonsMap[error.label], backends, users: unreachableUsers}};
+              return {failedToAdd: [{reason: failureReasonsMap[error.label], backends, users: unreachableUsers}]};
             }
             // In case the request to add users failed with a `UNREACHABLE_BACKENDS` or `NOT_CONNECTED_BACKENDS` errors, we try again with the users from available backends
             try {
@@ -225,17 +225,19 @@ export class ProteusService {
                 event: response,
                 failedToAdd:
                   unreachableUsers.length > 0
-                    ? {reason: failureReasonsMap[error.label], backends, users: unreachableUsers}
+                    ? [{reason: failureReasonsMap[error.label], backends, users: unreachableUsers}]
                     : undefined,
               };
             } catch (error) {
               if (isFederatedBackendsError(error)) {
                 return {
-                  failedToAdd: {
-                    reason: failureReasonsMap[error.label],
-                    backends: error.backends,
-                    users: qualifiedUsers,
-                  },
+                  failedToAdd: [
+                    {
+                      reason: failureReasonsMap[error.label],
+                      backends: error.backends,
+                      users: qualifiedUsers,
+                    },
+                  ],
                 };
               }
               throw error;


### PR DESCRIPTION
End user was not informed at all if adding a user to a conversation was not possible because of the lack of their keys on backend.

We're returning an array of failures currently. It was not a case for proteus as there was only one request needed to add all the users, so we ended up with one error message. With MLS we're claiming each user's keys separately, it's possible that we can have a different failure reason for each users. E.g one of them have not uploaded keys, the other one's backend is unreachable.

There are still federation error left to handle (this PR only covers non-uploaded keys on backend).

A webapp PR adapting failure reason as a list of failures will follow.