### PR TITLE
refactor: lazily ask consumer for oAuth token

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.42",
+    "@wireapp/core-crypto": "1.0.0-rc.43",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.41",
+    "@wireapp/core-crypto": "1.0.0-rc.42",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -59,6 +59,7 @@ import {
   resumeRejoiningMLSConversations,
 } from './messagingProtocols/mls/conversationRejoinQueue';
 import {E2EIServiceExternal, User} from './messagingProtocols/mls/E2EIdentityService';
+import {getTokenCallback} from './messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal';
 import {CoreCallbacks, CoreCryptoConfig, SecretCrypto} from './messagingProtocols/mls/types';
 import {NewClient, ProteusService} from './messagingProtocols/proteus';
 import {CryptoClientType} from './messagingProtocols/proteus/ProteusService/CryptoClient';
@@ -70,7 +71,6 @@ import {CoreDatabase, deleteDB, openDB} from './storage/CoreDB';
 import {TeamService} from './team/';
 import {UserService} from './user/';
 import {RecurringTaskScheduler} from './util/RecurringTaskScheduler';
-import {getTokenCallback} from './messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal';
 
 export type ProcessedEventPayload = HandledEventPayload;
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -70,6 +70,7 @@ import {CoreDatabase, deleteDB, openDB} from './storage/CoreDB';
 import {TeamService} from './team/';
 import {UserService} from './user/';
 import {RecurringTaskScheduler} from './util/RecurringTaskScheduler';
+import {getTokenCallback} from './messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal';
 
 export type ProcessedEventPayload = HandledEventPayload;
 
@@ -234,14 +235,14 @@ export class Account extends TypedEventEmitter<Events> {
     handle,
     teamId,
     discoveryUrl,
-    oAuthIdToken,
+    getOAuthToken,
     certificateTtl = 90 * (TimeInMillis.DAY / 1000),
   }: {
     displayName: string;
     handle: string;
     teamId: string;
     discoveryUrl: string;
-    oAuthIdToken?: string;
+    getOAuthToken: getTokenCallback;
     /** number of seconds the certificate should be valid (default 90 days) */
     certificateTtl?: number;
   }) {
@@ -270,7 +271,7 @@ export class Account extends TypedEventEmitter<Events> {
       this.currentClient,
       this.options.nbPrekeys,
       certificateTtl,
-      oAuthIdToken,
+      getOAuthToken,
     );
   }
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -238,7 +238,9 @@ export class Account extends TypedEventEmitter<Events> {
     getOAuthToken,
     certificateTtl = 90 * (TimeInMillis.DAY / 1000),
   }: {
+    /** display name of the user (should match the identity provider) */
     displayName: string;
+    /** handle of the user (should match the identity provider) */
     handle: string;
     teamId: string;
     discoveryUrl: string;

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -854,7 +854,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     certificateTtl: number,
     getOAuthToken: getTokenCallback,
   ): Promise<EnrollmentProcessState> {
-    const hasActiveCertificate = await this.coreCryptoClient.e2eiIsEnabled(this.config.cipherSuite);
+    const isCertificateRenewal = await this.coreCryptoClient.e2eiIsEnabled(this.config.cipherSuite);
     const e2eiServiceInternal = new E2EIServiceInternal(
       this.coreDatabase,
       this.coreCryptoClient,
@@ -864,11 +864,11 @@ export class MLSService extends TypedEventEmitter<Events> {
       {user, clientId: client.id, discoveryUrl},
     );
 
-    const rotateBundle = await e2eiServiceInternal.generateCertificate(getOAuthToken, hasActiveCertificate);
+    const rotateBundle = await e2eiServiceInternal.generateCertificate(getOAuthToken, isCertificateRenewal);
 
     this.dispatchNewCrlDistributionPoints(rotateBundle);
     // upload the clients public keys
-    if (!hasActiveCertificate) {
+    if (!isCertificateRenewal) {
       // we only upload public keys for the initial certification process. Renewals do not need to upload new public keys
       await this.uploadMLSPublicKeys(client);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5080,10 +5080,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:1.0.0-rc.41":
-  version: 1.0.0-rc.41
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.41"
-  checksum: e9b41fac8ecaac3f4934aca8bd58deeae4f45aa597caa9c880bee6df2acf9a5973a06f93b459fb1b3005df30a258df6b5dc9dfda42c45ea4a22c6697e0d9596c
+"@wireapp/core-crypto@npm:1.0.0-rc.43":
+  version: 1.0.0-rc.43
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.43"
+  checksum: 2481ae8a6322c999e5b5260c34dcb6162d79afa568c0cc444975d90828831acd35b759140e63d994d2cad6a82e74b482408b306460a32c028006c4689407ca3a
   languageName: node
   linkType: hard
 
@@ -5100,7 +5100,7 @@ __metadata:
     "@types/tough-cookie": 4.0.5
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 1.0.0-rc.41
+    "@wireapp/core-crypto": 1.0.0-rc.43
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
BREAKING CHANGE: enrolling to E2EI doesn't take an `oAuthToken` directly but rather a function that will be called when the token is needed. This makes the consumer not needing to be aware of the start/continuation of the flow (in case there is a redirect needed). 

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
