### PR TITLE
runfix: add more corecrypto errors to be ignored [WPB-6451]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -24,6 +24,9 @@ export const CoreCryptoMLSError = {
     EXTERNAL_COMMIT_NOT_MERGED:
       'You tried to join with an external commit but did not merge it yet. We will reapply this message for you when you merge your external commit',
     FUTURE_EPOCH: 'Incoming message is for a future epoch. We will buffer it until the commit for that epoch arrives',
+    STALE_COMMIT: 'The received commit is deemed stale and is from an older epoch.',
+    STALE_PROPOSAL: 'The received proposal is deemed stale and is from an older epoch.',
+    DUPLICATE_MESSAGE: 'We already decrypted this message once',
   },
   CONVERSATION_ALREADY_EXISTS: 'Conversation already exists',
 } as const;
@@ -40,6 +43,9 @@ const mlsDecryptionErrorsToIgnore: string[] = [
   CoreCryptoMLSError.DECRYPTION.ALREADY_DECRYPTED,
   CoreCryptoMLSError.DECRYPTION.EXTERNAL_COMMIT_NOT_MERGED,
   CoreCryptoMLSError.DECRYPTION.FUTURE_EPOCH,
+  CoreCryptoMLSError.DECRYPTION.STALE_COMMIT,
+  CoreCryptoMLSError.DECRYPTION.STALE_PROPOSAL,
+  CoreCryptoMLSError.DECRYPTION.DUPLICATE_MESSAGE,
 ];
 
 export const shouldMLSDecryptionErrorBeIgnored = (error: unknown): error is Error => {


### PR DESCRIPTION
We should ignore `StaleCommit`, `StaleProposal` and `DuplicateMessage` errors thrown by corecrypto when decrypting a message.

Error message is currently the only way we can differentiate between various corecrypto errors. Strings source: https://github.com/wireapp/core-crypto/blob/bc6f8e20ff45a883633490863bc98f423022969e/crypto/src/error.rs.