### PR TITLE
runfix: emit new epoch event for welcome message

### DIFF
--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.test.ts
@@ -46,6 +46,8 @@ const mockParams = {
   mlsService: {
     processWelcomeMessage: jest.fn().mockResolvedValue('conversationId'),
     scheduleKeyMaterialRenewal: jest.fn(),
+    getEpoch: jest.fn(),
+    emit: jest.fn(),
   } as unknown as MLSService,
   dryRun: false,
 };
@@ -62,6 +64,14 @@ describe('MLS welcomeMessage eventHandler', () => {
       const eventHandlerResult = await handleMLSWelcomeMessage(mockParams);
       expect(eventHandlerResult).toBeDefined();
       expect(eventHandlerResult!.event).toEqual({data: 'conversationId', type: 'conversation.mls-welcome'});
+    });
+
+    it('emits new epoch event after processing a welcome message', async () => {
+      jest.spyOn(mockParams.mlsService, 'getEpoch').mockResolvedValue(1);
+
+      await handleMLSWelcomeMessage(mockParams);
+
+      expect(mockParams.mlsService.emit).toHaveBeenCalledWith('newEpoch', {groupId: 'conversationId', epoch: 1});
     });
   });
 });

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
@@ -41,6 +41,10 @@ export const handleMLSWelcomeMessage = async ({
 
   // After we were added to the group we need to schedule a periodic key material renewal
   await mlsService.scheduleKeyMaterialRenewal(groupIdStr);
+
+  const newEpoch = await mlsService.getEpoch(groupIdStr);
+  mlsService.emit('newEpoch', {groupId: groupIdStr, epoch: newEpoch});
+
   return {
     event: {...event, data: groupIdStr},
   };


### PR DESCRIPTION
Emit a `newEpoch` event after processing a welcome message - this will notify a consumer about new (and their first) epoch in a MLS group.