### PR TITLE
runfix: return undefined for user identities if group does not exist [WPB-6864]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
@@ -40,6 +40,7 @@ async function buildE2EIService() {
   const mockedMLSService = {
     on: jest.fn(),
     getClientIds: jest.fn(),
+    conversationExists: jest.fn(),
   } as unknown as MLSService;
 
   const recurringTaskScheduler = new RecurringTaskScheduler({
@@ -81,8 +82,22 @@ const groupId = 'AAEAAhJrE+8TbFFUqiagedTYDUMAZWxuYS53aXJlLmxpbms=';
 
 describe('E2EIServiceExternal', () => {
   describe('getUsersIdentities', () => {
+    it('returns undefined if conversation does not exist', async () => {
+      const [service, {mlsService}] = await buildE2EIService();
+      const user1 = {domain: 'elna.wire.link', id: '48a1c3b0-4b0e-4bcd-93ad-64c7344b1534'};
+      const user2 = {domain: 'elna.wire.link', id: 'b7d287e4-7bbd-40e0-a550-6b18dcaf5f31'};
+      const userIds = [user1, user2];
+
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValue(false);
+
+      const userIdentities = await service.getUsersIdentities(groupId, userIds);
+
+      expect(userIdentities?.get(user1.id)).toEqual(undefined);
+      expect(userIdentities?.get(user2.id)).toEqual(undefined);
+    });
+
     it('returns the user identities', async () => {
-      const [service, {coreCrypto}] = await buildE2EIService();
+      const [service, {coreCrypto, mlsService}] = await buildE2EIService();
       const user1 = {domain: 'elna.wire.link', id: '48a1c3b0-4b0e-4bcd-93ad-64c7344b1534'};
       const user2 = {domain: 'elna.wire.link', id: 'b7d287e4-7bbd-40e0-a550-6b18dcaf5f31'};
       const userIds = [user1, user2];
@@ -94,6 +109,8 @@ describe('E2EIServiceExternal', () => {
         ]),
       );
 
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValue(true);
+
       const userIdentities = await service.getUsersIdentities(groupId, userIds);
 
       expect(userIdentities?.get(user1.id)).toHaveLength(2);
@@ -101,7 +118,7 @@ describe('E2EIServiceExternal', () => {
     });
 
     it('returns MLS basic devices with empty identity', async () => {
-      const [service, {coreCrypto}] = await buildE2EIService();
+      const [service, {coreCrypto, mlsService}] = await buildE2EIService();
       const user1 = {domain: 'elna.wire.link', id: '48a1c3b0-4b0e-4bcd-93ad-64c7344b1534'};
       const user2 = {domain: 'elna.wire.link', id: 'b7d287e4-7bbd-40e0-a550-6b18dcaf5f31'};
       const userIds = [user1, user2];
@@ -120,6 +137,8 @@ describe('E2EIServiceExternal', () => {
       ];
       coreCrypto.getClientIds.mockResolvedValue(allClients.map(clientId => encoder.encode(clientId)));
 
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValue(true);
+
       const userIdentities = await service.getUsersIdentities(groupId, userIds);
 
       expect(userIdentities?.get(user1.id)).toHaveLength(3);
@@ -128,6 +147,30 @@ describe('E2EIServiceExternal', () => {
   });
 
   describe('getAllGroupUsersIdentities', () => {
+    it('returns undefined if mls group does not exist', async () => {
+      const [service, {mlsService}] = await buildE2EIService();
+      const user1 = {
+        domain: 'elna.wire.link',
+        userId: '48a1c3b0-4b0e-4bcd-93ad-64c7344b1534',
+        clientId: '74a50c1f4352b41f',
+      };
+      const user2 = {
+        domain: 'elna.wire.link',
+        userId: 'b7d287e4-7bbd-40e0-a550-6b18dcaf5f31',
+        clientId: '452cb4c65f0369a8',
+      };
+
+      const clientIds = [user1, user2];
+
+      jest.spyOn(mlsService, 'getClientIds').mockResolvedValue(clientIds);
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValue(false);
+
+      const userIdentities = await service.getAllGroupUsersIdentities(groupId);
+
+      expect(userIdentities?.get(user1.userId)).toEqual(undefined);
+      expect(userIdentities?.get(user2.userId)).toEqual(undefined);
+    });
+
     it('returns all the user identities of a mls group', async () => {
       const [service, {coreCrypto, mlsService}] = await buildE2EIService();
       const user1 = {
@@ -143,6 +186,7 @@ describe('E2EIServiceExternal', () => {
       const clientIds = [user1, user2];
 
       jest.spyOn(mlsService, 'getClientIds').mockResolvedValue(clientIds);
+      jest.spyOn(mlsService, 'conversationExists').mockResolvedValue(true);
 
       coreCrypto.getUserIdentities.mockResolvedValue(
         new Map([

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
@@ -96,8 +96,8 @@ describe('E2EIServiceExternal', () => {
 
       const userIdentities = await service.getUsersIdentities(groupId, userIds);
 
-      expect(userIdentities.get(user1.id)).toHaveLength(2);
-      expect(userIdentities.get(user2.id)).toHaveLength(1);
+      expect(userIdentities?.get(user1.id)).toHaveLength(2);
+      expect(userIdentities?.get(user2.id)).toHaveLength(1);
     });
 
     it('returns MLS basic devices with empty identity', async () => {
@@ -122,8 +122,8 @@ describe('E2EIServiceExternal', () => {
 
       const userIdentities = await service.getUsersIdentities(groupId, userIds);
 
-      expect(userIdentities.get(user1.id)).toHaveLength(3);
-      expect(userIdentities.get(user2.id)).toHaveLength(1);
+      expect(userIdentities?.get(user1.id)).toHaveLength(3);
+      expect(userIdentities?.get(user2.id)).toHaveLength(1);
     });
   });
 
@@ -156,8 +156,8 @@ describe('E2EIServiceExternal', () => {
 
       const userIdentities = await service.getAllGroupUsersIdentities(groupId);
 
-      expect(userIdentities.get(user1.userId)).toHaveLength(2);
-      expect(userIdentities.get(user2.userId)).toHaveLength(1);
+      expect(userIdentities?.get(user1.userId)).toHaveLength(2);
+      expect(userIdentities?.get(user2.userId)).toHaveLength(1);
     });
   });
 });

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -81,7 +81,13 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     return this.coreCryptoClient.e2eiIsEnabled(this.mlsService.config.cipherSuite);
   }
 
-  public async getAllGroupUsersIdentities(groupId: string): Promise<Map<string, DeviceIdentity[]>> {
+  public async getAllGroupUsersIdentities(groupId: string): Promise<Map<string, DeviceIdentity[]> | undefined> {
+    const conversationExists = await this.mlsService.conversationExists(groupId);
+
+    if (!conversationExists) {
+      return undefined;
+    }
+
     const allGroupClients = await this.mlsService.getClientIds(groupId);
 
     const userIdsMap = allGroupClients.reduce(
@@ -97,7 +103,16 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     return this.getUsersIdentities(groupId, userIds);
   }
 
-  public async getUsersIdentities(groupId: string, userIds: QualifiedId[]): Promise<Map<string, DeviceIdentity[]>> {
+  public async getUsersIdentities(
+    groupId: string,
+    userIds: QualifiedId[],
+  ): Promise<Map<string, DeviceIdentity[]> | undefined> {
+    const conversationExists = await this.mlsService.conversationExists(groupId);
+
+    if (!conversationExists) {
+      return undefined;
+    }
+
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
     const textDecoder = new TextDecoder();
 


### PR DESCRIPTION
`CoreCrypto.getUserIdentities` would fail when called if the group does not exist in the store anymore (e.g. after user has left it or got removed).
Before trying to call this method, we check if group exists, if it doesn't we return `undefined`.