### PR TITLE
fix: Do not upload public key for registered MLS devices

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -242,8 +242,10 @@ export class Account extends TypedEventEmitter<Events> {
     displayName: string;
     /** handle of the user (should match the identity provider) */
     handle: string;
+    /** team of the user */
     teamId: string;
     discoveryUrl: string;
+    /** function called to get the oauth token */
     getOAuthToken: getTokenCallback;
     /** number of seconds the certificate should be valid (default 90 days) */
     certificateTtl?: number;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -25,7 +25,7 @@ import {TypedEventEmitter} from '@wireapp/commons';
 import {CoreCrypto, E2eiConversationState, WireIdentity, DeviceStatus} from '@wireapp/core-crypto';
 
 import {AcmeService} from './Connection';
-import {getE2EIClientId} from './Helper';
+import {getE2EIClientId, isMLSDevice} from './Helper';
 import {createE2EIEnrollmentStorage} from './Storage/E2EIStorage';
 
 import {ClientService} from '../../../client';
@@ -183,7 +183,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     if (!client) {
       return true;
     }
-    return typeof client.mls_public_keys.ed25519 !== 'string' || client.mls_public_keys.ed25519.length === 0;
+    return !isMLSDevice(client);
   }
 
   private async registerLocalCertificateRoot(acmeService: AcmeService): Promise<string> {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {RegisteredClient} from '@wireapp/api-client/lib/client';
+
 import {ClientIdStringType, constructFullyQualifiedClientId} from '../../../../util/fullyQualifiedClientIdUtils';
 
 export const jsonToByteArray = (data: any): Uint8Array => {
@@ -36,5 +38,8 @@ export const getE2EIClientId = (clientId: string, userId: string, userDomain: st
     asBytes,
   };
 };
+
+export const isMLSDevice = ({mls_public_keys}: RegisteredClient) =>
+  typeof mls_public_keys.ed25519 === 'string' && mls_public_keys.ed25519.length > 0;
 
 export const isResponseStatusValid = (status: string | undefined) => status && status === 'valid';


### PR DESCRIPTION
## Description

Will make sure we will not try to upload a device public key after enrollment when an MLS device was already registered

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
