### PR TITLE
fix: strip https scheme from fetched self crls

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.44",
+    "@wireapp/core-crypto": "1.0.0-rc.43",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/promise-queue": "workspace:^",
     "@wireapp/protocol-messaging": "1.44.0",

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Connection/AcmeServer/AcmeService.ts
@@ -117,7 +117,8 @@ export class AcmeService {
     const crl = CrlResponseSchema.parse(data);
     const crlUint8Array = new Uint8Array(crl);
 
-    return {url, crl: crlUint8Array};
+    const fixedUrl = url.replace('https://', 'http://');
+    return {url: fixedUrl, crl: crlUint8Array};
   }
 
   public async getLocalCertificateRoot(): Promise<string> {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -203,11 +203,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     this._acmeService = new AcmeService(discoveryUrl);
     await this.registerServerCertificates();
     await this.initialiseCrlDistributionTimers();
-    try {
-      await this.validateSelfCrl();
-    } catch (error) {
-      console.warn('Error validating self CRL', error);
-    }
+    await this.validateSelfCrl();
   }
 
   private get acmeService(): AcmeService {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -202,8 +202,8 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   public async initialize(discoveryUrl: string): Promise<void> {
     this._acmeService = new AcmeService(discoveryUrl);
     await this.registerServerCertificates();
-    await this.initialiseCrlDistributionTimers();
     await this.validateSelfCrl();
+    await this.initialiseCrlDistributionTimers();
   }
 
   private get acmeService(): AcmeService {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5202,10 +5202,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:1.0.0-rc.44":
-  version: 1.0.0-rc.44
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.44"
-  checksum: 856d46c0a9c4212a2b2e1a5dc8802ec42413a86d092d3a8f1469a8bc3cb29496f27c150d74477a4f2039111dcec39b5ed6f818f0489a5724bbefda8157278679
+"@wireapp/core-crypto@npm:1.0.0-rc.43":
+  version: 1.0.0-rc.43
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.43"
+  checksum: 2481ae8a6322c999e5b5260c34dcb6162d79afa568c0cc444975d90828831acd35b759140e63d994d2cad6a82e74b482408b306460a32c028006c4689407ca3a
   languageName: node
   linkType: hard
 
@@ -5222,7 +5222,7 @@ __metadata:
     "@types/tough-cookie": 4.0.5
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 1.0.0-rc.44
+    "@wireapp/core-crypto": 1.0.0-rc.43
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/promise-queue": "workspace:^"
     "@wireapp/protocol-messaging": 1.44.0


### PR DESCRIPTION
## Description

We should not try to eagerly fetch self CRLs. This can cause some problems (as the url we use to fetch them might not match the url set in the certificate). 

Instead we rely only on the new distribution point detection mechanism in place to update CRLs lazily. 

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
