### PR TITLE
feat: add optional delay to promise queue

### DIFF
--- a/packages/promise-queue/src/PromiseQueue.ts
+++ b/packages/promise-queue/src/PromiseQueue.ts
@@ -24,6 +24,7 @@ const defaultOptions = {
   timeout: 1000 * 60, // 1 minute
   concurrent: 1,
   paused: false,
+  delay: 0,
 };
 
 export class PromiseQueue {
@@ -35,6 +36,7 @@ export class PromiseQueue {
   private readonly logger?: {warn: (...args: any[]) => void};
   private readonly queue: QueueEntry<any>[];
   private readonly timeout: number;
+  private delay: number;
 
   constructor(options?: PromiseQueueOptions) {
     this.blocked = false;
@@ -44,6 +46,7 @@ export class PromiseQueue {
     this.paused = options?.paused ?? defaultOptions.paused;
     this.queue = [];
     this.timeout = options?.timeout ?? defaultOptions.timeout;
+    this.delay = options?.delay ?? defaultOptions.delay;
   }
 
   /**
@@ -91,7 +94,11 @@ export class PromiseQueue {
           this.blocked = false;
         }
 
-        this.execute();
+        if (this.delay) {
+          setTimeout(() => this.execute(), this.delay);
+        } else {
+          this.execute();
+        }
       });
   }
 

--- a/packages/promise-queue/src/PromiseQueueOptions.ts
+++ b/packages/promise-queue/src/PromiseQueueOptions.ts
@@ -26,6 +26,8 @@ export interface PromiseQueueOptions {
   paused?: boolean;
   /** Timeout in ms. Default is 1000 (1 minute). */
   timeout?: number;
+  /** Delay between each promise execution in ms. Default is 0 (no delay). */
+  delay?: number;
   /** logger used to log errors */
   logger?: {warn: (...args: any[]) => void};
 }


### PR DESCRIPTION
Add a delay field to `PromiseQueue` which will indicate the time between each promise exectution. E.g if the value is set to 1000, queue will resolve its promises one by one but always waiting 1s in between.