### PR TITLE
perf: improve enrollment performances

### DIFF
--- a/packages/api-client/src/client/ClientAPI.ts
+++ b/packages/api-client/src/client/ClientAPI.ts
@@ -148,6 +148,21 @@ export class ClientAPI {
   }
 
   /**
+   * Will replace all keypackages on backend by the keypackages provided
+   * @see https://staging-nginz-https.zinfra.io/v5/api/swagger-ui/#/default/put_mls_key_packages_self__client_
+   * @param {string} clientId The client to upload the key packages for
+   * @param {string[]} keyPackages The key packages to upload
+   */
+  public async replaceMLSKeyPackages(clientId: string, keyPackages: string[]) {
+    const config: AxiosRequestConfig = {
+      data: {key_packages: keyPackages},
+      method: 'PUT',
+      url: `/${ClientAPI.URL.MLS_CLIENTS}/${ClientAPI.URL.MLS_KEY_PACKAGES}/self/${clientId}`,
+    };
+
+    await this.client.sendJSON<PreKeyBundle>(config, true);
+  }
+  /**
    * Will upload keypackages for an MLS capable client
    * @see https://staging-nginz-https.zinfra.io/api/swagger-ui/#/default/post_mls_key_packages_self__client_
    * @param {string} clientId The client to upload the key packages for

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.types.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Steps/DpopChallenge/DpopChallenge.types.ts
@@ -36,10 +36,3 @@ export interface DoWireDpopChallengeParams {
 }
 
 export type GetClientNonceParams = Pick<DoWireDpopChallengeParams, 'clientId' | 'apiClient'>;
-
-export type GetClientAccessTokenParams = Pick<
-  DoWireDpopChallengeParams,
-  'clientId' | 'apiClient' | 'identity' | 'expirySecs' | 'userDomain'
-> & {
-  clientNonce: Nonce;
-};


### PR DESCRIPTION
This will:
- remove unecessary waiting time when validating the dpop challenge
- use a single URL to replace all the key packages at once (rather than a delete + post request)
