### PR TITLE
fix: Rely on new distribution points to update CRL

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -202,7 +202,6 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   public async initialize(discoveryUrl: string): Promise<void> {
     this._acmeService = new AcmeService(discoveryUrl);
     await this.registerServerCertificates();
-    await this.validateSelfCrl();
     await this.initialiseCrlDistributionTimers();
   }
 
@@ -284,14 +283,6 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
 
   private async cancelCrlDistributionTimer(url: string): Promise<void> {
     await this.coreDatabase.delete('crls', url);
-  }
-
-  private async validateSelfCrl(): Promise<void> {
-    const {crl, url} = await this.acmeService.getSelfCRL();
-
-    await this.validateCrl(url, crl, async () => {
-      this.emit('selfCrlChanged');
-    });
   }
 
   private async validateCrlDistributionPoint(distributionPointUrl: string): Promise<void> {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -40,8 +40,7 @@ import {MLSService} from '../MLSService';
 export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {status?: DeviceStatus; deviceId: string};
 
 type Events = {
-  remoteCrlChanged: undefined;
-  selfCrlChanged: undefined;
+  crlChanged: {domain: string};
 };
 
 // This export is meant to be accessible from the outside (e.g the Webapp / UI)
@@ -289,12 +288,10 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     const domain = new URL(distributionPointUrl).hostname;
     const crl = await this.acmeService.getCRLFromDistributionPoint(domain);
 
-    await this.validateCrl(distributionPointUrl, crl, async () => {
-      this.emit('remoteCrlChanged');
-    });
+    await this.validateCrl(distributionPointUrl, crl, () => this.emit('crlChanged', {domain}));
   }
 
-  private async validateCrl(url: string, crl: Uint8Array, onDirty: () => Promise<void>): Promise<void> {
+  private async validateCrl(url: string, crl: Uint8Array, onDirty: () => void): Promise<void> {
     const {expiration: expirationTimestampSeconds, dirty} = await this.coreCryptoClient.e2eiRegisterCRL(url, crl);
 
     const expirationTimestamp = expirationTimestampSeconds && expirationTimestampSeconds * TimeInMillis.SECOND;
@@ -308,7 +305,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
 
     //if it was dirty, trigger e2eiconversationstate for every conversation
     if (dirty) {
-      await onDirty();
+      onDirty();
     }
   }
 


### PR DESCRIPTION
We do not need to eagerly fetch the self crls anymore. They will be provided by CoreCrypto when the user enrolls to E2EI.

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
