### PR TITLE
runfix: improve error logs

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -859,7 +859,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     // We should not receive a message for a group the client is not aware of
     if (!groupId) {
       throw new Error(
-        `Could not find a group_id for conversation ${qualifiedConversationId.id}@${qualifiedConversationId.domain}`,
+        `Could not find a group_id for conversation ${qualifiedConversationId.id}@${qualifiedConversationId.domain}${event.subconv ? `/subconversation:${event.subconv}` : ''}`,
       );
     }
 


### PR DESCRIPTION
Improve mls message add handler error message when failed finding a group id for a conversation (**or a subconversation**).