### PR TITLE
runfix: low precision task scheduler with exact same delay and key

### DIFF
--- a/packages/core/src/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.ts
+++ b/packages/core/src/util/LowPrecisionTaskScheduler/LowPrecisionTaskScheduler.test.ts
@@ -86,6 +86,30 @@ describe('LowPrecisionTaskScheduler', () => {
     expect(mockedTask2).toHaveBeenCalled();
   });
 
+  it('adding a task with the same delay and key should overwrite the previous task', async () => {
+    const mockedTask1 = jest.fn().mockReturnValue(Promise.resolve('hello task 1'));
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'same-key',
+      firingDate: 5000,
+      intervalDelay: 1000,
+      task: mockedTask1,
+    });
+
+    LowPrecisionTaskScheduler.addTask({
+      key: 'same-key',
+      firingDate: 7000,
+      intervalDelay: 1000,
+      task: mockedTask1,
+    });
+
+    await advanceJestTimersWithPromise(5000);
+    expect(mockedTask1).not.toHaveBeenCalled();
+
+    await advanceJestTimersWithPromise(2000);
+    expect(mockedTask1).toHaveBeenCalled();
+  });
+
   it('cancels tasks', async () => {
     const mockedTask3 = jest.fn().mockReturnValue(Promise.resolve('hello task 3'));
     const mockedTask4 = jest.fn().mockReturnValue(Promise.resolve('hello task 4'));


### PR DESCRIPTION
When LowPrecisionTaskScheduler.addTask is called, the pending task with exactly the same delay and key should be overwritten by new values. Previously we were just pushing the task to the list of tasks, allowing duplicate tasks to be executed.