### PR TITLE
runfix: check pending timeout in task scheduler

### DIFF
--- a/packages/core/src/util/TaskScheduler/TaskScheduler.ts
+++ b/packages/core/src/util/TaskScheduler/TaskScheduler.ts
@@ -99,9 +99,11 @@ const continueTask = ({key, task}: Omit<ScheduleTaskParams, 'firingDate' | 'pers
   }
 };
 
+const hasActiveTask = (key: string) => !!activeTimeouts[key];
+
 export const TaskScheduler = {
   addTask,
   cancelTask,
   continueTask,
-  hasActiveTask: TaskSchedulerStore.has,
+  hasActiveTask,
 };


### PR DESCRIPTION
We should check whether there's actually ongoing timer with given key, not just if the key is stored (not all the tasks use the built-in storage).