### PR TITLE
runfix: join with ext commit on welcome with deleted key

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -553,15 +553,16 @@ describe('ConversationService', () => {
       expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId, 'groupId');
     });
 
-    it('joins a MLS conversation if it was sent a valid welcome message with a deleted key', async () => {
+    it.each([
+      CoreCryptoMLSError.WELCOME_MESSAGE.DELETED_KEY_PACKAGE,
+      CoreCryptoMLSError.WELCOME_MESSAGE.NO_MATCHING_ENCRYPTION_KEY,
+    ])('joins a MLS conversation if it was sent a valid welcome message with a deleted key', async errorMessage => {
       const [conversationService, {apiClient, mlsService}] = await buildConversationService();
       const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
 
       const mockMLSWelcomeMessageEvent = createMLSWelcomeMessageEventMock(conversationId);
 
-      jest
-        .spyOn(mlsService, 'handleMLSWelcomeMessageEvent')
-        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE));
+      jest.spyOn(mlsService, 'handleMLSWelcomeMessageEvent').mockRejectedValueOnce(new Error(errorMessage));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: conversationId,

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -553,16 +553,15 @@ describe('ConversationService', () => {
       expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId, 'groupId');
     });
 
-    it.each([
-      CoreCryptoMLSError.WELCOME_MESSAGE.DELETED_KEY_PACKAGE,
-      CoreCryptoMLSError.WELCOME_MESSAGE.NO_MATCHING_ENCRYPTION_KEY,
-    ])('joins a MLS conversation if it was sent a valid welcome message with a deleted key', async errorMessage => {
+    it('joins a MLS conversation if it was sent a valid welcome message with a deleted key', async () => {
       const [conversationService, {apiClient, mlsService}] = await buildConversationService();
       const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
 
       const mockMLSWelcomeMessageEvent = createMLSWelcomeMessageEventMock(conversationId);
 
-      jest.spyOn(mlsService, 'handleMLSWelcomeMessageEvent').mockRejectedValueOnce(new Error(errorMessage));
+      jest
+        .spyOn(mlsService, 'handleMLSWelcomeMessageEvent')
+        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: conversationId,

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -25,7 +25,11 @@ import {
   Subconversation,
   SUBCONVERSATION_ID,
 } from '@wireapp/api-client/lib/conversation';
-import {CONVERSATION_EVENT, ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
+import {
+  CONVERSATION_EVENT,
+  ConversationMLSMessageAddEvent,
+  ConversationMLSWelcomeEvent,
+} from '@wireapp/api-client/lib/event';
 import {BackendError, BackendErrorLabel} from '@wireapp/api-client/lib/http';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
@@ -55,6 +59,15 @@ const createMLSMessageAddEventMock = (
   type: CONVERSATION_EVENT.MLS_MESSAGE_ADD,
   time: '2023-08-21T06:47:43.387Z',
   subconv: subconversationId,
+});
+
+const createMLSWelcomeMessageEventMock = (conversationId: QualifiedId): ConversationMLSWelcomeEvent => ({
+  data: '',
+  conversation: conversationId.id,
+  qualified_conversation: conversationId,
+  from: '',
+  type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE,
+  time: '2023-08-21T06:47:43.387Z',
 });
 
 jest.mock('../../messagingProtocols/proteus', () => ({
@@ -119,6 +132,7 @@ describe('ConversationService', () => {
       getKeyPackagesPayload: jest.fn(),
       addUsersToExistingConversation: jest.fn(),
       resetKeyMaterialRenewal: jest.fn(),
+      handleMLSWelcomeMessageEvent: jest.fn(),
     } as unknown as MLSService;
 
     const mockedDb = await openDB('core-test-db');
@@ -537,6 +551,28 @@ describe('ConversationService', () => {
 
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId, 'groupId');
+    });
+
+    it('joins a MLS conversation if it was sent a valid welcome message with a deleted key', async () => {
+      const [conversationService, {apiClient, mlsService}] = await buildConversationService();
+      const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
+
+      const mockMLSWelcomeMessageEvent = createMLSWelcomeMessageEventMock(conversationId);
+
+      jest
+        .spyOn(mlsService, 'handleMLSWelcomeMessageEvent')
+        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE));
+
+      jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
+        qualified_id: conversationId,
+        protocol: ConversationProtocol.MLS,
+      } as unknown as Conversation);
+
+      await conversationService.handleEvent(mockMLSWelcomeMessageEvent);
+
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(conversationService.joinByExternalCommit).toHaveBeenCalledWith(conversationId);
     });
   });
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -553,7 +553,7 @@ describe('ConversationService', () => {
       expect(subconversationService.joinConferenceSubconversation).toHaveBeenCalledWith(conversationId, 'groupId');
     });
 
-    it('joins a MLS conversation if it was sent a valid welcome message with a deleted key', async () => {
+    it('joins a MLS conversation if it was sent an orphan welcome message', async () => {
       const [conversationService, {apiClient, mlsService}] = await buildConversationService();
       const conversationId = {id: 'conversationId', domain: 'staging.zinfra.io'};
 
@@ -561,7 +561,7 @@ describe('ConversationService', () => {
 
       jest
         .spyOn(mlsService, 'handleMLSWelcomeMessageEvent')
-        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE));
+        .mockRejectedValueOnce(new Error(CoreCryptoMLSError.ORPHAN_WELCOME_MESSAGE));
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: conversationId,

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -63,7 +63,7 @@ import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService} from '../../messagingProtocols/mls';
 import {queueConversationRejoin} from '../../messagingProtocols/mls/conversationRejoinQueue';
 import {
-  isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError,
+  isCoreCryptoMLSOrphanWelcomeMessageError,
   isCoreCryptoMLSWrongEpochError,
 } from '../../messagingProtocols/mls/MLSService/CoreCryptoMLSError';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
@@ -722,7 +722,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     try {
       return await this.mlsService.handleMLSWelcomeMessageEvent(event, this.apiClient.validatedClientId);
     } catch (error) {
-      if (isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError(error)) {
+      if (isCoreCryptoMLSOrphanWelcomeMessageError(error)) {
         const {qualified_conversation: conversationId} = event;
 
         // Note that we don't care about a subconversation here, as the welcome message is always for the parent conversation.
@@ -733,7 +733,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         }
 
         this.logger.info(
-          `Received welcome message with deleted key package, joining the conversation (${conversationId.id}) via external commit...`,
+          `Received an orphan welcome message, joining the conversation (${conversationId.id}) via external commit...`,
         );
 
         void queueConversationRejoin(conversationId.id, () => this.joinByExternalCommit(conversationId));

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -736,7 +736,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
           `Received welcome message with deleted key package, joining the conversation (${conversationId.id}) via external commit...`,
         );
 
-        await queueConversationRejoin(conversationId.id, () => this.joinByExternalCommit(conversationId));
+        void queueConversationRejoin(conversationId.id, () => this.joinByExternalCommit(conversationId));
         return null;
       }
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -723,9 +723,6 @@ export class ConversationService extends TypedEventEmitter<Events> {
       return await this.mlsService.handleMLSWelcomeMessageEvent(event, this.apiClient.validatedClientId);
     } catch (error) {
       if (isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError(error)) {
-        this.logger.info(
-          'Received welcome message with deleted key package, joining the conversation via external commit...',
-        );
         const {qualified_conversation: conversationId} = event;
 
         // Note that we don't care about a subconversation here, as the welcome message is always for the parent conversation.
@@ -734,6 +731,10 @@ export class ConversationService extends TypedEventEmitter<Events> {
         if (!conversationId) {
           throw new Error('Qualified conversation id is missing in the event');
         }
+
+        this.logger.info(
+          `Received welcome message with deleted key package, joining the conversation (${conversationId.id}) via external commit...`,
+        );
 
         await queueConversationRejoin(conversationId.id, () => this.joinByExternalCommit(conversationId));
         return null;

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -63,7 +63,7 @@ import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService} from '../../messagingProtocols/mls';
 import {queueConversationRejoin} from '../../messagingProtocols/mls/conversationRejoinQueue';
 import {
-  isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError,
+  isCoreCryptoMLSWelcomeMessageMissingKeyPackageError,
   isCoreCryptoMLSWrongEpochError,
 } from '../../messagingProtocols/mls/MLSService/CoreCryptoMLSError';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
@@ -722,7 +722,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     try {
       return await this.mlsService.handleMLSWelcomeMessageEvent(event, this.apiClient.validatedClientId);
     } catch (error) {
-      if (isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError(error)) {
+      if (isCoreCryptoMLSWelcomeMessageMissingKeyPackageError(error)) {
         const {qualified_conversation: conversationId} = event;
 
         // Note that we don't care about a subconversation here, as the welcome message is always for the parent conversation.
@@ -733,7 +733,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         }
 
         this.logger.info(
-          `Received welcome message with deleted key package, joining the conversation (${conversationId.id}) via external commit...`,
+          `Received welcome message with a key package that is no longer in the store, joining the conversation (${conversationId.id}) via external commit...`,
         );
 
         void queueConversationRejoin(conversationId.id, () => this.joinByExternalCommit(conversationId));

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -63,7 +63,7 @@ import {decryptAsset} from '../../cryptography/AssetCryptography';
 import {MLSService} from '../../messagingProtocols/mls';
 import {queueConversationRejoin} from '../../messagingProtocols/mls/conversationRejoinQueue';
 import {
-  isCoreCryptoMLSWelcomeMessageMissingKeyPackageError,
+  isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError,
   isCoreCryptoMLSWrongEpochError,
 } from '../../messagingProtocols/mls/MLSService/CoreCryptoMLSError';
 import {getConversationQualifiedMembers, ProteusService} from '../../messagingProtocols/proteus';
@@ -722,7 +722,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     try {
       return await this.mlsService.handleMLSWelcomeMessageEvent(event, this.apiClient.validatedClientId);
     } catch (error) {
-      if (isCoreCryptoMLSWelcomeMessageMissingKeyPackageError(error)) {
+      if (isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError(error)) {
         const {qualified_conversation: conversationId} = event;
 
         // Note that we don't care about a subconversation here, as the welcome message is always for the parent conversation.
@@ -733,7 +733,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
         }
 
         this.logger.info(
-          `Received welcome message with a key package that is no longer in the store, joining the conversation (${conversationId.id}) via external commit...`,
+          `Received welcome message with deleted key package, joining the conversation (${conversationId.id}) via external commit...`,
         );
 
         void queueConversationRejoin(conversationId.id, () => this.joinByExternalCommit(conversationId));

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -29,6 +29,8 @@ export const CoreCryptoMLSError = {
     DUPLICATE_MESSAGE: 'We already decrypted this message once',
   },
   CONVERSATION_ALREADY_EXISTS: 'Conversation already exists',
+  WELCOME_MESSAGE_DELETED_KEY_PACKAGE:
+    'Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit',
 } as const;
 
 export const isCoreCryptoMLSWrongEpochError = (error: unknown): boolean => {
@@ -37,6 +39,10 @@ export const isCoreCryptoMLSWrongEpochError = (error: unknown): boolean => {
 
 export const isCoreCryptoMLSConversationAlreadyExistsError = (error: unknown): boolean => {
   return error instanceof Error && error.message === CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS;
+};
+
+export const isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError = (error: unknown): boolean => {
+  return error instanceof Error && error.message === CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE;
 };
 
 const mlsDecryptionErrorsToIgnore: string[] = [

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -29,11 +29,8 @@ export const CoreCryptoMLSError = {
     DUPLICATE_MESSAGE: 'We already decrypted this message once',
   },
   CONVERSATION_ALREADY_EXISTS: 'Conversation already exists',
-  WELCOME_MESSAGE: {
-    DELETED_KEY_PACKAGE:
-      'Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit',
-    NO_MATCHING_ENCRYPTION_KEY: 'No matching encryption key was found in the key store.',
-  },
+  WELCOME_MESSAGE_DELETED_KEY_PACKAGE:
+    'Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit',
 } as const;
 
 export const isCoreCryptoMLSWrongEpochError = (error: unknown): boolean => {
@@ -44,12 +41,8 @@ export const isCoreCryptoMLSConversationAlreadyExistsError = (error: unknown): b
   return error instanceof Error && error.message === CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS;
 };
 
-const missingKeyPackageErrorMessages: string[] = [
-  CoreCryptoMLSError.WELCOME_MESSAGE.DELETED_KEY_PACKAGE,
-  CoreCryptoMLSError.WELCOME_MESSAGE.NO_MATCHING_ENCRYPTION_KEY,
-];
-export const isCoreCryptoMLSWelcomeMessageMissingKeyPackageError = (error: unknown): boolean => {
-  return error instanceof Error && missingKeyPackageErrorMessages.includes(error.message);
+export const isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError = (error: unknown): boolean => {
+  return error instanceof Error && error.message === CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE;
 };
 
 const mlsDecryptionErrorsToIgnore: string[] = [

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -29,7 +29,7 @@ export const CoreCryptoMLSError = {
     DUPLICATE_MESSAGE: 'We already decrypted this message once',
   },
   CONVERSATION_ALREADY_EXISTS: 'Conversation already exists',
-  WELCOME_MESSAGE_DELETED_KEY_PACKAGE:
+  ORPHAN_WELCOME_MESSAGE:
     'Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit',
 } as const;
 
@@ -41,8 +41,8 @@ export const isCoreCryptoMLSConversationAlreadyExistsError = (error: unknown): b
   return error instanceof Error && error.message === CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS;
 };
 
-export const isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError = (error: unknown): boolean => {
-  return error instanceof Error && error.message === CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE;
+export const isCoreCryptoMLSOrphanWelcomeMessageError = (error: unknown): boolean => {
+  return error instanceof Error && error.message === CoreCryptoMLSError.ORPHAN_WELCOME_MESSAGE;
 };
 
 const mlsDecryptionErrorsToIgnore: string[] = [

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -29,8 +29,11 @@ export const CoreCryptoMLSError = {
     DUPLICATE_MESSAGE: 'We already decrypted this message once',
   },
   CONVERSATION_ALREADY_EXISTS: 'Conversation already exists',
-  WELCOME_MESSAGE_DELETED_KEY_PACKAGE:
-    'Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit',
+  WELCOME_MESSAGE: {
+    DELETED_KEY_PACKAGE:
+      'Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit',
+    NO_MATCHING_ENCRYPTION_KEY: 'No matching encryption key was found in the key store.',
+  },
 } as const;
 
 export const isCoreCryptoMLSWrongEpochError = (error: unknown): boolean => {
@@ -41,8 +44,12 @@ export const isCoreCryptoMLSConversationAlreadyExistsError = (error: unknown): b
   return error instanceof Error && error.message === CoreCryptoMLSError.CONVERSATION_ALREADY_EXISTS;
 };
 
-export const isCoreCryptoMLSWelcomeMessageDeletedKeyPackageError = (error: unknown): boolean => {
-  return error instanceof Error && error.message === CoreCryptoMLSError.WELCOME_MESSAGE_DELETED_KEY_PACKAGE;
+const missingKeyPackageErrorMessages: string[] = [
+  CoreCryptoMLSError.WELCOME_MESSAGE.DELETED_KEY_PACKAGE,
+  CoreCryptoMLSError.WELCOME_MESSAGE.NO_MATCHING_ENCRYPTION_KEY,
+];
+export const isCoreCryptoMLSWelcomeMessageMissingKeyPackageError = (error: unknown): boolean => {
+  return error instanceof Error && missingKeyPackageErrorMessages.includes(error.message);
 };
 
 const mlsDecryptionErrorsToIgnore: string[] = [


### PR DESCRIPTION
When following corecrypto error is thrown, we should join the conversation with external commit:

`Although this Welcome seems valid, the local KeyPackage it references has already been deleted locally. Join this group with an external commit`

This is so called Orphan Welcome message, backend does not track claimed KeyPackages. Only way to recover is to rejoin with ext commit. 

This can happen when a client is being added to multiple mls groups at the same time.
<img width="717" alt="Screenshot 2024-03-07 at 15 47 52" src="https://github.com/wireapp/wire-web-packages/assets/45733298/7e1d7388-da23-48e4-b01a-860b53817f76">
