### PR TITLE
fix(react-ui-kit): mls verified icon color based on theme [WPB-6888]

### DIFF
--- a/packages/react-ui-kit/src/Icon/MLSVerified.tsx
+++ b/packages/react-ui-kit/src/Icon/MLSVerified.tsx
@@ -19,13 +19,15 @@
 
 import {SVGIcon, SVGIconProps} from './SVGIcon';
 
+import {Theme} from '../Layout';
+
 export const MLSVerified = (props: SVGIconProps) => (
   <SVGIcon realWidth={16} realHeight={16} {...props}>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M15 8V1.87197L8 0L1 2V8C1 12 4.00718 15.0977 8 16C12.0344 15.0977 15 12 15 8ZM13 5.34572L6.85214 12L3 7.84605L4.23094 6.50033L6.85214 9.30856L11.7691 4L13 5.34572Z"
-      fill="#1D7833"
+      css={(theme: Theme) => ({fill: theme.general.successColor})}
     />
   </SVGIcon>
 );

--- a/packages/react-ui-kit/src/Theme/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/Theme/GlobalCssVariables.tsx
@@ -65,6 +65,7 @@ const light: () => CSSObject = () => ({
 
   // General
   '--danger-color': COLOR_V2.RED_LIGHT_500,
+  '--success-color': COLOR_V2.GREEN_LIGHT_500,
   '--app-bg': COLOR_V2.GRAY_10,
   '--main-color': COLOR.BLACK,
 });
@@ -113,6 +114,7 @@ const dark: () => CSSObject = () => ({
 
   // General
   '--danger-color': COLOR_V2.RED_DARK_500,
+  '--success-color': COLOR_V2.GREEN_DARK_500,
   '--app-bg': COLOR_V2.GRAY_95,
   '--main-color': COLOR.WHITE,
 });

--- a/packages/react-ui-kit/src/Theme/Theme.tsx
+++ b/packages/react-ui-kit/src/Theme/Theme.tsx
@@ -86,6 +86,7 @@ export interface Theme extends ETheme {
     color: string;
     contrastColor: string;
     dangerColor: string;
+    successColor: string;
     focusColor: string;
     primaryColor: string;
   };
@@ -184,6 +185,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
       backgroundColor: 'var(--app-bg)',
       color: 'var(--main-color)',
       dangerColor: 'var(--danger-color)',
+      successColor: 'var(--success-color)',
       primaryColor: 'var(--accent-color)',
       contrastColor: 'var(--text-input-background)',
       focusColor: 'var(--accent-color-focus)',
@@ -259,6 +261,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
       color: COLOR.TEXT,
       primaryColor: COLOR_V2.BLUE,
       dangerColor: COLOR_V2.RED,
+      successColor: COLOR_V2.GREEN_LIGHT_500,
       contrastColor: 'var(--text-input-background)',
       focusColor: 'var(--accent-color-focus)',
     },
@@ -333,6 +336,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
       color: COLOR.WHITE,
       primaryColor: COLOR_V2.BLUE,
       dangerColor: COLOR_V2.RED,
+      successColor: COLOR_V2.GREEN_DARK_500,
       contrastColor: 'var(--text-input-background)',
       focusColor: 'var(--accent-color-focus)',
     },


### PR DESCRIPTION
Use theme value and its new `successColor` for MLSVerified icon's green color so it respects theme changes.

Before
<img width="283" alt="Screenshot 2024-03-19 at 12 37 17" src="https://github.com/wireapp/wire-web-packages/assets/45733298/4cbecbc7-6598-496c-bb36-3678b966a06f">


After
<img width="265" alt="Screenshot 2024-03-19 at 12 36 07" src="https://github.com/wireapp/wire-web-packages/assets/45733298/03f0a22e-4de4-4f29-a4cb-f12029a9f813">


