### PR TITLE
fix: mls status dark theme icon colors [WPB-6888]

### DIFF
--- a/packages/react-ui-kit/src/Icon/CertificateExpired.tsx
+++ b/packages/react-ui-kit/src/Icon/CertificateExpired.tsx
@@ -19,16 +19,18 @@
 
 import {SVGIcon, SVGIconProps} from './SVGIcon';
 
+import {Theme} from '../Layout';
+
 export const CertificateExpiredIcon = (props: SVGIconProps) => (
   <SVGIcon realWidth={16} realHeight={16} {...props}>
     <path
       d="M8.00661 0.778123L14.25 2.44775V8C14.25 11.5269 11.6778 14.3426 8.00089 15.2298C4.35861 14.3417 1.75 11.5234 1.75 8V2.56573L8.00661 0.778123Z"
-      stroke="#C20013"
+      css={(theme: Theme) => ({stroke: theme.general.dangerColor})}
       strokeWidth="1.5"
       strokeMiterlimit="16"
       fill="transparent"
     />
-    <rect x="7" y="3.5" width="2" height="5" fill="#C20013" />
-    <rect x="7" y="9.5" width="2" height="2" fill="#C20013" />
+    <rect x="7" y="3.5" width="2" height="5" css={(theme: Theme) => ({fill: theme.general.dangerColor})} />
+    <rect x="7" y="9.5" width="2" height="2" css={(theme: Theme) => ({fill: theme.general.dangerColor})} />
   </SVGIcon>
 );

--- a/packages/react-ui-kit/src/Icon/CertificateRevoked.tsx
+++ b/packages/react-ui-kit/src/Icon/CertificateRevoked.tsx
@@ -19,13 +19,15 @@
 
 import {SVGIcon, SVGIconProps} from './SVGIcon';
 
+import {Theme} from '../Layout';
+
 export const CertificateRevoked = (props: SVGIconProps) => (
   <SVGIcon realWidth={16} realHeight={16} {...props}>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M15 8V1.87197L8 0L1 2V8C1 12 4.00718 15.0977 8 16C12.0344 15.0977 15 12 15 8ZM8 9.27467L5.27467 12L4 10.7253L6.72533 8L4 5.27467L5.27467 4L8 6.72533L10.7253 4L12 5.27467L9.27467 8L12 10.7253L10.7253 12L8 9.27467Z"
-      fill="#C20013"
+      css={(theme: Theme) => ({fill: theme.general.dangerColor})}
     />
   </SVGIcon>
 );

--- a/packages/react-ui-kit/src/Icon/ExpiresSoon.tsx
+++ b/packages/react-ui-kit/src/Icon/ExpiresSoon.tsx
@@ -19,13 +19,15 @@
 
 import {SVGIcon, SVGIconProps} from './SVGIcon';
 
+import {Theme} from '../Layout';
+
 export const ExpiresSoon = (props: SVGIconProps) => (
   <SVGIcon realWidth={17} realHeight={18} {...props}>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M15 2.87197V9C15 13 12.0344 16.0977 8 17C4.00718 16.0977 1 13 1 9V3L8 1L15 2.87197Z"
-      stroke="#1D7833"
+      css={(theme: Theme) => ({stroke: theme.general.successColor})}
       strokeWidth="1.5"
       strokeMiterlimit="3.62796"
       strokeDasharray="1 1"
@@ -35,7 +37,7 @@ export const ExpiresSoon = (props: SVGIconProps) => (
       fillRule="evenodd"
       clipRule="evenodd"
       d="M6.85214 13L13 6.34572L11.7691 5L6.85214 10.3086L4.23094 7.50033L3 8.84605L6.85214 13Z"
-      fill="#1D7833"
+      css={(theme: Theme) => ({fill: theme.general.successColor})}
     />
   </SVGIcon>
 );


### PR DESCRIPTION
Fixes mls verification status icons colors for dark theme. Basically a follow up to https://github.com/wireapp/wire-web-packages/pull/6084.