### PR TITLE
fix: Improve database key generation

### DIFF
--- a/packages/core/src/secretStore/secretKeyGenerator.ts
+++ b/packages/core/src/secretStore/secretKeyGenerator.ts
@@ -55,8 +55,16 @@ export async function generateSecretKey({
       throw new CorruptedKeyError('Invalid key');
     }
     if (!key) {
-      key = crypto.getRandomValues(new Uint8Array(keySize));
-      await secretsDb.saveSecretValue(keyId, key);
+      key = await crypto.subtle.generateKey(
+        {
+          name: 'AES-GCM',
+          length: 256,
+        },
+        true,
+        ['encrypt', 'decrypt'],
+      );
+      key = await crypto.subtle.exportKey('raw', key);
+      await secretsDb.saveSecretValue(keyId, new Uint8Array(key));
     }
     return {key, deleteKey: () => secretsDb.deleteSecretValue(keyId)};
   } catch (error) {

--- a/packages/core/src/secretStore/secretKeyGenerator.ts
+++ b/packages/core/src/secretStore/secretKeyGenerator.ts
@@ -58,13 +58,13 @@ export async function generateSecretKey({
       key = await crypto.subtle.generateKey(
         {
           name: 'AES-GCM',
-          length: 256,
+          length: keySize * 8,
         },
         true,
         ['encrypt', 'decrypt'],
       );
-      key = await crypto.subtle.exportKey('raw', key);
-      await secretsDb.saveSecretValue(keyId, new Uint8Array(key));
+      key = new Uint8Array(await crypto.subtle.exportKey('raw', key));
+      await secretsDb.saveSecretValue(keyId, key);
     }
     return {key, deleteKey: () => secretsDb.deleteSecretValue(keyId)};
   } catch (error) {


### PR DESCRIPTION
## Description

This will use `crypto.subtle.generateKey` instead of `crypto.randomBytes`

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
