### PR TITLE
fix(copy-config): make rimraf production dependency

### DIFF
--- a/packages/copy-config/package.json
+++ b/packages/copy-config/package.json
@@ -14,7 +14,8 @@
     "cosmiconfig": "9.0.0",
     "fs-extra": "11.1.0",
     "jszip": "3.10.1",
-    "logdown": "3.3.1"
+    "logdown": "3.3.1",
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "@swc/core": "^1.3.10",
@@ -25,7 +26,6 @@
     "@types/jest": "^29.2.0",
     "@types/rimraf": "^3.0.2",
     "jest": "^29.2.1",
-    "rimraf": "^3.0.2",
     "typescript": "^5.0.4"
   },
   "scripts": {


### PR DESCRIPTION
`rimraf` is directly used by the package when installed and used by the consumer. 
We need to define it as such 