### PR TITLE
fix(copy-config): allow configuring the log level

### DIFF
--- a/packages/copy-config/src/CopyConfigOptions.ts
+++ b/packages/copy-config/src/CopyConfigOptions.ts
@@ -52,4 +52,5 @@ export interface CopyConfigOptions {
    * @example `https://github.com/wireapp/wire-web-config-default#v0.7.1`
    */
   repositoryUrl: string;
+  logLevel?: 'verbose' | 'info' | 'silent';
 }

--- a/packages/copy-config/src/utils.ts
+++ b/packages/copy-config/src/utils.ts
@@ -86,6 +86,6 @@ export async function extractAsync(zipFile: string, destination: string): Promis
   );
 }
 
-export const isFile = (path: string) => /[^.\/\\]+\..+$/.test(path);
+export const isFile = (path: string) => /\w\.\w+$/.test(path);
 export const rimrafAsync = promisify(rimraf);
 export const execAsync = promisify(exec);


### PR DESCRIPTION
This will allow the consumer to limit the verbosity of the copyConfig CLI tool. 


### Before

```text
ℹ️  @wireapp/copy-config Found configuration file "/Users/atomrc/Workspace/wire-webapp/.copyconfigrc.js".
ℹ️  @wireapp/copy-config Cloning "https://github.com/wireapp/wire-web-config-wire" (branch "master") ...
ℹ️  @wireapp/copy-config Resolving "/Users/atomrc/Workspace/wire-webapp/config/wire-webapp/content/**"
ℹ️  @wireapp/copy-config/CopyConfig Copying "/call_drop.mp3" -> "/call_drop.mp3"
ℹ️  @wireapp/copy-config/CopyConfig Copying "/Users/atomrc/Workspace/wire-webapp/config/wire-webapp/content/audio/call_drop.mp3" -> "/Users/atomrc/Workspace/wire-webapp/resource/audio/call_drop.mp3"
ℹ️  @wireapp/copy-config/CopyConfig Copying "/Users/atomrc/Workspace/wire-webapp/config/wire-webapp/content/audio/camera.mp3" -> "/Users/atomrc/Workspace/wire-webapp/resource/audio/camera.mp3"

[...] 3000+ more lines

ℹ️  @wireapp/copy-config Copied 3747 files.
```

### After

```text
ℹ️  @wireapp/copy-config Found configuration file "/Users/atomrc/Workspace/wire-webapp/.copyconfigrc.js".
ℹ️  @wireapp/copy-config Cloning "https://github.com/wireapp/wire-web-config-wire" (branch "master") ...
ℹ️  @wireapp/copy-config Resolving "/Users/atomrc/Workspace/wire-webapp/config/wire-webapp/content/**"
ℹ️  @wireapp/copy-config Copied 3747 files.
```