### PR TITLE
runfix: separate method for registering mls 1:1 conversation

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -124,6 +124,7 @@ describe('ConversationService', () => {
       getEpoch: () => Promise.resolve(),
       joinByExternalCommit: jest.fn(),
       registerConversation: jest.fn(),
+      register1to1Conversation: jest.fn(),
       wipeConversation: jest.fn(),
       handleMLSMessageAddEvent: jest.fn(),
       conversationExists: jest.fn(),
@@ -424,10 +425,8 @@ describe('ConversationService', () => {
       );
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
-      expect(mlsService.registerConversation).toHaveBeenCalledTimes(1);
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], {
-        creator: selfUser,
-      });
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(1);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });
@@ -467,7 +466,7 @@ describe('ConversationService', () => {
         group_id: mockGroupId,
       } as unknown as MLSConversation);
 
-      jest.spyOn(mlsService, 'registerConversation').mockRejectedValueOnce(undefined);
+      jest.spyOn(mlsService, 'register1to1Conversation').mockRejectedValueOnce(undefined);
       jest.spyOn(mlsService, 'wipeConversation');
 
       const establishedConversation = await conversationService.establishMLS1to1Conversation(
@@ -477,10 +476,8 @@ describe('ConversationService', () => {
       );
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
-      expect(mlsService.registerConversation).toHaveBeenCalledTimes(2);
-      expect(mlsService.registerConversation).toHaveBeenCalledWith(mockGroupId, [otherUserId, selfUser.user], {
-        creator: selfUser,
-      });
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(2);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -588,7 +588,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
     await this.mlsService.wipeConversation(groupId);
 
     try {
-      await this.mlsService.registerConversation(groupId, [otherUserId, selfUser.user], {creator: selfUser});
+      await this.mlsService.register1to1Conversation(groupId, otherUserId, selfUser);
+
       this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) established successfully.`);
 
       return this.getMLS1to1Conversation(otherUserId);

--- a/packages/core/src/messagingProtocols/mls/MLSService/ClientMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/ClientMLSError.ts
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2022 Wire Swiss GmbH
+ * Copyright (C) 2024 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,5 +17,16 @@
  *
  */
 
-export * from './MLSService';
-export * from './ClientMLSError';
+export enum ClientMLSErrorLabel {
+  NO_KEY_PACKAGES_AVAILABLE = 'no-key-packages-available',
+}
+
+export class ClientMLSError extends Error {
+  label: ClientMLSErrorLabel;
+
+  constructor(label: ClientMLSErrorLabel) {
+    super();
+    this.label = label;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}


### PR DESCRIPTION
Adds a separate method for registering a 1:1 conversation with a given user. When no keys of the user we want to create a 1:1 conversation with are available, we will throw an error which then can be handled by a consumer. For group conversations we keep the behaviour of creating an empty group by sending an empty commit (key packages update) if no keys are available, we don't want to do that for 1:1 conversations - backend requires a first commit sent in a MLS 1:1 conversation to add exactly one other user.

## Pull Request Checklist

- [ ] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
