### PR TITLE
runfix: root CA registered flag

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -31,7 +31,6 @@ import {createE2EIEnrollmentStorage} from './Storage/E2EIStorage';
 import {ClientService} from '../../../client';
 import {CoreDatabase} from '../../../storage/CoreDB';
 import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUtils';
-import {LocalStorageStore} from '../../../util/LocalStorageStore';
 import {LowPrecisionTaskScheduler} from '../../../util/LowPrecisionTaskScheduler';
 import {StringifiedQualifiedId, stringifyQualifiedId} from '../../../util/qualifiedIdUtil';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
@@ -260,13 +259,11 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
    * Both must be registered before the first enrollment.
    */
   private async registerServerCertificates(): Promise<void> {
-    const ROOT_CA_KEY = 'e2ei_root-registered';
-    const store = LocalStorageStore(this.coreDatabase.name);
+    const isRootRegistered = await this.coreCryptoClient.e2eiIsPKIEnvSetup();
 
     // Register root certificate if not already registered
-    if (!store.has(ROOT_CA_KEY)) {
+    if (!isRootRegistered) {
       await this.registerLocalCertificateRoot(this.acmeService);
-      store.add(ROOT_CA_KEY, 'true');
     }
 
     // Register intermediate certificate and update it every 24 hours

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -70,7 +70,7 @@ const createMLSService = async () => {
     delete: key => mockedDb.delete('recurringTasks', key),
     get: async key => (await mockedDb.get('recurringTasks', key))?.firingDate,
     set: async (key, timestamp) => {
-      await mockedDb.put('recurringTasks', {key, firingDate: timestamp});
+      await mockedDb.put('recurringTasks', {key, firingDate: timestamp}, key);
     },
   });
 


### PR DESCRIPTION
We were maintaining a boolean flag of whether the root CA was already registered or not. What could happen is: after the root cert is registered but before we've set the flag to true, the app crashes (or simply get closed). Then the client thinks that is still has not registered the root certificate, tries to do so, fails (CoreCrypto error is thrown) and the client is stuck on a loading screen.

The solution is to use CoreCrypto's `.e2eiIsPKIEnvSetup()` method that will return false if the root cert is not yet registered and rely on that. With a single source of truth (CoreCrypto) we're sure whether the root CA is registered (or not). 

## Pull Request Checklist

- [x] My code is covered by tests
- [x] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
