### PR TITLE
runfix: fix credential type value

### DIFF
--- a/packages/core/__mocks__/@wireapp/core-crypto.ts
+++ b/packages/core/__mocks__/@wireapp/core-crypto.ts
@@ -25,6 +25,7 @@ export enum Ciphersuite {
 
 export enum CredentialType {
   Basic = 1,
+  X509 = 2,
 }
 
 export enum GroupInfoEncryptionType {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.test.ts
@@ -20,7 +20,7 @@
 import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 import axios from 'axios';
 
-import {CoreCrypto, WireIdentity} from '@wireapp/core-crypto';
+import {CoreCrypto, CredentialType, WireIdentity} from '@wireapp/core-crypto';
 
 import {E2EIServiceExternal} from './E2EIServiceExternal';
 
@@ -82,6 +82,7 @@ function generateCoreCryptoIdentity({
       '-----BEGIN CERTIFICATE-----\nMIICRTCCAeqgAwIBAgIQcpcbKbgHLM5qoB7xgxm6BTAKBggqhkjOPQQDAjAuMSww\nKgYDVQQDEyNlbG5hLndpcmUubGluayBFMkVJIEludGVybWVkaWF0ZSBDQTAeFw0y\nMzExMjIxMTIwMDVaFw0yMzExMjQxMTIwMDVaMDIxFzAVBgNVBAoTDmVsbmEud2ly\nZS5saW5rMRcwFQYDVQQDEw5BZHJpYW4gV2Vpc3MgMjAqMAUGAytlcAMhAMwP5B9X\nwanLL7JUmHEc1SJYAvHUvMnL1MS/D4CK3JaMo4IBEzCCAQ8wDgYDVR0PAQH/BAQD\nAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAdBgNVHQ4EFgQUrIPC\nem20zAl1ybZqXm2LkvD2U1swHwYDVR0jBBgwFoAU5bQTjX1Ps09suTYe4tzXUKgl\nN9YwdwYDVR0RBHAwboYpaW06d2lyZWFwcD0lNDBhZHJpYW5fd2lyZTJAZWxuYS53\naXJlLmxpbmuGQWltOndpcmVhcHA9U0tIRHNFc09TODJUcldUSE5Fc1ZOQS9lYjll\nMDM4NjE4MzllOWRhQGVsbmEud2lyZS5saW5rMCUGDCsGAQQBgqRkxihAAQQVMBMC\nAQYEDGRlZmF1bHR0ZWFtcwQAMAoGCCqGSM49BAMCA0kAMEYCIQCQQHVAd6wjp2A+\nVvKIXu4oVlCMZkAUATU5bXY4njvapwIhAO8rION7Mz5rSjixJsdEL8E+HHsNvCax\ndjrSL0FL9SM6\n-----END CERTIFICATE-----\n',
     status,
     thumbprint: 'mNyAo88vAF5s7v0UWBNxlQKxP3dfT91A-4PbuzEA5uQ',
+    credentialType: CredentialType.X509,
   } as unknown as WireIdentity;
 }
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -46,13 +46,26 @@ type Events = {
   crlChanged: {domain: string};
 };
 
-// TODO coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
+//TODO: coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
 function fixDeviceStatus(value: any): DeviceStatus {
   const fixedValue = DeviceStatus[value];
   if (!fixedValue) {
     throw new Error(`Invalid device status: ${value}`);
   }
   return fixedValue as unknown as DeviceStatus;
+}
+
+//TODO: coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
+function fixCredentialType(value: any): CredentialType {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const fixedValue = CredentialType[value];
+  if (!fixedValue) {
+    throw new Error(`Invalid credentialType value: ${value}`);
+  }
+  return fixedValue as unknown as CredentialType;
 }
 
 // TODO coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
@@ -155,6 +168,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
       const identities = (userIdentities.get(userId.id) || []).map(identity => ({
         ...identity,
         status: fixDeviceStatus(identity.status),
+        credentialType: fixCredentialType(identity.credentialType),
         deviceId: parseFullQualifiedClientId(identity.clientId).client,
         qualifiedUserId: userId,
       }));
@@ -202,6 +216,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     return deviceIdentities.map(identity => ({
       ...identity,
       deviceId: parseFullQualifiedClientId(identity.clientId).client,
+      credentialType: fixCredentialType(identity.credentialType),
       qualifiedUserId: userClientsMap[identity.clientId],
     }));
   }


### PR DESCRIPTION
Instead of an actual enum value, CoreCrypto returns us enum's key as a string for a `credentialType` value. Until the fix for that is included in the library, we are wrapping the value with a method that would map the received string to the actual enum value.