### PR TITLE
runfix: use fixed corecrypto enums

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "1.0.0-rc.56",
+    "@wireapp/core-crypto": "1.0.0-rc.57",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "workspace:^",
     "@wireapp/promise-queue": "workspace:^",

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -46,37 +46,6 @@ type Events = {
   crlChanged: {domain: string};
 };
 
-//TODO: coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
-function fixDeviceStatus(value: any): DeviceStatus {
-  const fixedValue = DeviceStatus[value];
-  if (!fixedValue) {
-    throw new Error(`Invalid device status: ${value}`);
-  }
-  return fixedValue as unknown as DeviceStatus;
-}
-
-//TODO: coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
-function fixCredentialType(value: any): CredentialType {
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  const fixedValue = CredentialType[value];
-  if (!fixedValue) {
-    throw new Error(`Invalid credentialType value: ${value}`);
-  }
-  return fixedValue as unknown as CredentialType;
-}
-
-// TODO coreCrypto types are wrong here. They return a string (the key of the enum) instead of the enum value
-function fixConversationState(value: any): E2eiConversationState {
-  const fixedValue = E2eiConversationState[value];
-  if (!fixedValue) {
-    throw new Error(`Invalid conversation status: ${value}`);
-  }
-  return fixedValue as unknown as E2eiConversationState;
-}
-
 // This export is meant to be accessible from the outside (e.g the Webapp / UI)
 export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   private _acmeService?: AcmeService;
@@ -107,8 +76,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   }
 
   public async getConversationState(conversationId: Uint8Array): Promise<E2eiConversationState> {
-    const state = await this.coreCryptoClient.e2eiConversationState(conversationId);
-    return fixConversationState(state);
+    return this.coreCryptoClient.e2eiConversationState(conversationId);
   }
 
   public isE2EIEnabled(): Promise<boolean> {
@@ -167,8 +135,6 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     for (const userId of userIds) {
       const identities = (userIdentities.get(userId.id) || []).map(identity => ({
         ...identity,
-        status: fixDeviceStatus(identity.status),
-        credentialType: fixCredentialType(identity.credentialType),
         deviceId: parseFullQualifiedClientId(identity.clientId).client,
         qualifiedUserId: userId,
       }));
@@ -216,7 +182,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
     return deviceIdentities.map(identity => ({
       ...identity,
       deviceId: parseFullQualifiedClientId(identity.clientId).client,
-      credentialType: fixCredentialType(identity.credentialType),
+      credentialType: identity.credentialType,
       qualifiedUserId: userClientsMap[identity.clientId],
     }));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4789,10 +4789,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:1.0.0-rc.56":
-  version: 1.0.0-rc.56
-  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.56"
-  checksum: c45ac583764bca6e27add33d49b35e7709fe3b2e1136802fe1c9a06e46b1318e97d2a055f777c7f5276fe8b6e9166c1a3e79ce2496d8cc103b563bdfa3ae402f
+"@wireapp/core-crypto@npm:1.0.0-rc.57":
+  version: 1.0.0-rc.57
+  resolution: "@wireapp/core-crypto@npm:1.0.0-rc.57"
+  checksum: 412f95a5a175dccffc3f489f4cad64bee600daef718282a42c8448f3f5571b37898935e8426f358c01a51fd3a011c04e0ca03370b9afdff11890c610142965c6
   languageName: node
   linkType: hard
 
@@ -4809,7 +4809,7 @@ __metadata:
     "@types/tough-cookie": 4.0.5
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 1.0.0-rc.56
+    "@wireapp/core-crypto": 1.0.0-rc.57
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/priority-queue": "workspace:^"
     "@wireapp/promise-queue": "workspace:^"


### PR DESCRIPTION
CoreCrypto has fixed enums, so we can use the raw returned value, without need to map enum's key to an enum value.