### PR TITLE
fix: Do not throw error when initClient is called without MLS config

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -366,10 +366,7 @@ export class Account extends TypedEventEmitter<Events> {
     await this.apiClient.transport.http.associateClientWithSession(client.id);
 
     await this.service.proteus.initClient(this.storeEngine, this.apiClient.context);
-    if (this.service.mls) {
-      if (!mlsConfig) {
-        throw new Error('trying to init MLS without config. Please provide a config to initClient method.');
-      }
+    if (this.service.mls && mlsConfig) {
       const {userId, domain = ''} = this.apiClient.context;
       await this.service.mls.initClient({id: userId, domain}, client, mlsConfig);
       // initialize schedulers for pending mls proposals once client is initialized


### PR DESCRIPTION
Since it's possible to init a non-MLS client in an MLS enabled env, there is no need to throw an error in case a client is init without an MLS configuration. 

Regression introduced with https://github.com/wireapp/wire-web-packages/pull/6168