### PR TITLE
fix: Pass the correct ciphersuite when starting the e2ei enrollment process

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -60,7 +60,7 @@ export class E2EIServiceInternal {
    * @param getOAuthToken function called when the process needs an oauth token
    * @param refresh should the process refresh the current certificate or get a new one
    */
-  public async generateCertificate(getOAuthToken: getTokenCallback, refresh: boolean) {
+  public async generateCertificate(getOAuthToken: getTokenCallback, refresh: boolean, ciphersuite: Ciphersuite) {
     const stashedEnrollmentData = await this.enrollmentStorage.getPendingEnrollmentData();
 
     if (stashedEnrollmentData) {
@@ -73,7 +73,7 @@ export class E2EIServiceInternal {
     }
 
     // We first get the challenges needed to validate the user identity
-    const identity = await this.initIdentity(refresh);
+    const identity = await this.initIdentity(refresh, ciphersuite);
     const enrollmentChallenges = await this.getEnrollmentChallenges(identity);
     const {keyauth, oidcChallenge} = enrollmentChallenges.authorization;
     const challengeData = {challenge: oidcChallenge, keyAuth: keyauth};
@@ -102,11 +102,8 @@ export class E2EIServiceInternal {
 
   // ############ Internal Functions ############
 
-  private async initIdentity(hasActiveCertificate: boolean) {
+  private async initIdentity(hasActiveCertificate: boolean, ciphersuite: Ciphersuite) {
     const {user} = this.initialData;
-
-    // How long the issued certificate should be maximal valid
-    const ciphersuite = Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
     return hasActiveCertificate
       ? this.coreCryptoClient.e2eiNewRotateEnrollment(

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
@@ -55,8 +55,12 @@ const ciphersuiteSignatureAlgorithmMap: Record<Ciphersuite, MLSPublicKeyAlgorith
   [Ciphersuite.MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519]: MLSPublicKeyAlgorithmKeys.ED25519,
 };
 
+export const getSignatureAlgorithmForCiphersuite = (ciphersuite: Ciphersuite): MLSPublicKeyAlgorithmKeys => {
+  return ciphersuiteSignatureAlgorithmMap[ciphersuite];
+};
+
 export const isMLSDevice = ({mls_public_keys}: RegisteredClient, ciphersuite: Ciphersuite) => {
-  const signatureAlogrithm = ciphersuiteSignatureAlgorithmMap[ciphersuite];
+  const signatureAlogrithm = getSignatureAlgorithmForCiphersuite(ciphersuite);
   const signature = mls_public_keys[signatureAlogrithm];
   return typeof signature === 'string' && signature.length > 0;
 };

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts
@@ -21,7 +21,7 @@ import {PreKey} from '@wireapp/api-client/lib/auth';
 import {Encoder} from 'bazinga64';
 import {deleteDB} from 'idb';
 
-import {Ciphersuite, CoreCrypto} from '@wireapp/core-crypto';
+import {CoreCrypto} from '@wireapp/core-crypto';
 import type {CRUDEngine} from '@wireapp/store-engine';
 
 import {PrekeyTracker} from './PrekeysTracker';
@@ -62,7 +62,7 @@ export async function buildClient(
     databaseName: coreCryptoDbName,
     key: Encoder.toBase64(key.key).asString,
     wasmFilePath,
-    ciphersuites: [Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
+    ciphersuites: [],
   });
   return new CoreCryptoWrapper(coreCrypto, {nbPrekeys, onNewPrekeys, onWipe: key.deleteKey});
 }


### PR DESCRIPTION
Previous PR enabling dynamic ciphersuite selection missed one hardcoded ciphersuite when enrolling to the e2ei process