### PR TITLE
runfix: mls default config

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -24,6 +24,7 @@ import {
   ConversationMLSWelcomeEvent,
 } from '@wireapp/api-client/lib/event';
 import {BackendError, BackendErrorLabel, StatusCode} from '@wireapp/api-client/lib/http';
+import {TimeInMillis} from '@wireapp/commons/lib/util/TimeUtil';
 
 import {randomUUID} from 'crypto';
 
@@ -357,6 +358,62 @@ describe('MLSService', () => {
   });
 
   describe('initClient', () => {
+    it('uses the default config if config is not provided by the consumer', async () => {
+      const [mlsService, {apiClient, coreCrypto}] = await createMLSService();
+
+      const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
+      const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {}, id: mockClientId} as unknown as RegisteredClient;
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientPublicKey = new Uint8Array();
+
+      jest.spyOn(coreCrypto, 'clientPublicKey').mockResolvedValueOnce(mockedClientPublicKey);
+      jest.spyOn(apiClient.api.client, 'putClient').mockResolvedValueOnce(undefined);
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
+
+      const config = {...defaultMLSInitConfig};
+
+      await mlsService.initClient(mockUserId, mockClient, config);
+
+      expect(coreCrypto.mlsInit).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        [Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
+        100,
+      );
+
+      expect(mlsService.config.nbKeyPackages).toEqual(100);
+    });
+
+    it('uses the config provided by the consumer', async () => {
+      const [mlsService, {apiClient, coreCrypto}] = await createMLSService();
+
+      const mockUserId = {id: 'user-1', domain: 'local.zinfra.io'};
+      const mockClientId = 'client-1';
+      const mockClient = {mls_public_keys: {}, id: mockClientId} as unknown as RegisteredClient;
+
+      apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
+
+      const mockedClientPublicKey = new Uint8Array();
+
+      jest.spyOn(coreCrypto, 'clientPublicKey').mockResolvedValueOnce(mockedClientPublicKey);
+      jest.spyOn(apiClient.api.client, 'putClient').mockResolvedValueOnce(undefined);
+      jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
+
+      const config = {...defaultMLSInitConfig, nbKeyPackages: 40, keyingMaterialUpdateThreshold: TimeInMillis.DAY};
+
+      await mlsService.initClient(mockUserId, mockClient, config);
+
+      expect(coreCrypto.mlsInit).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        [Ciphersuite.MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519],
+        config.nbKeyPackages,
+      );
+
+      expect(mlsService.config).toEqual(config);
+    });
+
     it('uploads public key only if it was not yet defined on client entity', async () => {
       const [mlsService, {apiClient, coreCrypto}] = await createMLSService();
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -152,9 +152,10 @@ export class MLSService extends TypedEventEmitter<Events> {
     {skipInitIdentity, ...mlsConfig}: InitClientOptions,
   ) {
     this._config = {
-      ...mlsConfig,
       ...defaultConfig,
+      ...mlsConfig,
     };
+
     await this.coreCryptoClient.mlsInit(
       generateMLSDeviceId(userId, client.id),
       this.config.ciphersuites,

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -151,9 +151,14 @@ export class MLSService extends TypedEventEmitter<Events> {
     client: RegisteredClient,
     {skipInitIdentity, ...mlsConfig}: InitClientOptions,
   ) {
+    // filter out undefined values from mlsConfig
+    const filteredMLSConfig = Object.fromEntries(
+      Object.entries(mlsConfig).filter(([_, value]) => value !== undefined),
+    ) as typeof mlsConfig;
+
     this._config = {
       ...defaultConfig,
-      ...mlsConfig,
+      ...filteredMLSConfig,
     };
 
     await this.coreCryptoClient.mlsInit(


### PR DESCRIPTION
We should not overwrite the consumer-provided MLS configuration by the default config, but rather use this config on top of the default config. This PR addresses that. We also make sure we filter out undefined values, in this case the default value will be used (consumer might want to set a value to `undefined` explicitly to make sure the default will be used).