### PR TITLE
runfix: start listening for new crl points on e2ei service init

### DIFF
--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -60,9 +60,6 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   ) {
     super();
     this.enrollmentStorage = createE2EIEnrollmentStorage(coreDatabase);
-    mlsService.on('newCrlDistributionPoints', distributionPoints =>
-      this.handleNewCrlDistributionPoints(distributionPoints),
-    );
   }
 
   // If we have a handle in the local storage, we are in the enrollment process (this handle is saved before oauth redirect)
@@ -207,6 +204,11 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
    */
   public async initialize(discoveryUrl: string): Promise<void> {
     this._acmeService = new AcmeService(discoveryUrl);
+
+    this.mlsService.on('newCrlDistributionPoints', distributionPoints =>
+      this.handleNewCrlDistributionPoints(distributionPoints),
+    );
+
     await this.registerServerCertificates();
     await this.initialiseCrlDistributionTimers();
   }


### PR DESCRIPTION
We should not listen for `newCrlDistributionPoints` event if e2ei feature is disabled. Instead of subscribing to an event when the service is initialised, we do that in the explicit `initialize` method call. 

We need the acme service to be initialised first anyway.

It will remove the unhandled console error:

![Screenshot 2024-05-10 at 14 55 02](https://github.com/wireapp/wire-web-packages/assets/45733298/4ae6bc51-e47e-4f2e-8a3d-a068568cfea8)
