### PR TITLE
fix: Replace `uuidjs` with `uuid` WPB-7240

### DIFF
--- a/archive/bot-api/package.json
+++ b/archive/bot-api/package.json
@@ -6,11 +6,12 @@
     "@wireapp/store-engine": "workspace:^",
     "file-type": "16.5.4",
     "logdown": "^3.3.1",
-    "uuidjs": "4.2.8"
+    "uuid": "9.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "3.8.2",
     "@types/readable-stream": "2.3.9",
+    "@types/uuid": "9.0.8",
     "cross-env": "7.0.3",
     "dotenv-defaults": "2.0.2",
     "jasmine": "3.8.0",

--- a/archive/bot-api/src/Bot.ts
+++ b/archive/bot-api/src/Bot.ts
@@ -31,7 +31,7 @@ import {Account} from '@wireapp/core';
 import {PayloadBundle, PayloadBundleType} from '@wireapp/core/lib/conversation/';
 import {CRUDEngine} from '@wireapp/store-engine';
 import logdown from 'logdown';
-import UUID from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 import {BotConfig, BotCredentials} from './Interfaces';
 import {MessageHandler} from './MessageHandler';
@@ -62,7 +62,7 @@ export class Bot extends MessageHandler {
   }
 
   public addHandler(handler: MessageHandler): void {
-    this.handlers.set(UUID.genV4().toString(), handler);
+    this.handlers.set(uuidv4(), handler);
   }
 
   public removeHandler(key: string): void {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "idb": "8.0.0",
     "logdown": "3.3.1",
     "long": "^5.2.0",
-    "uuidjs": "4.2.13",
+    "uuid": "9.0.1",
     "zod": "3.23.8"
   },
   "devDependencies": {
@@ -38,6 +38,7 @@
     "@types/long": "^5.0.0",
     "@types/rimraf": "4.0.5",
     "@types/tough-cookie": "4.0.5",
+    "@types/uuid": "9.0.8",
     "commander": "12.1.0",
     "cross-env": "7.0.3",
     "dotenv-defaults": "5.0.2",

--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -29,7 +29,7 @@ import {ReconnectingWebsocket} from '@wireapp/api-client/lib/tcp/ReconnectingWeb
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 import {WS} from 'jest-websocket-mock';
 import nock, {cleanAll} from 'nock';
-import {genV4} from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 import {APIClient} from '@wireapp/api-client';
 import {AccentColor, ValidationUtil} from '@wireapp/commons';
@@ -263,7 +263,7 @@ describe('Account', () => {
 
     const mockNotifications = (size: number) => {
       const notifications = Array.from(new Array(size)).map(() => ({
-        id: genV4().toString(),
+        id: uuidv4(),
         payload: [{}] as BackendEvent[],
       }));
       jest.spyOn(dependencies.apiClient.api.notification, 'getAllNotifications').mockResolvedValue({notifications});
@@ -369,7 +369,7 @@ describe('Account', () => {
               expect(onEvent).not.toHaveBeenCalledWith(expect.any(Object), NotificationSource.WEBSOCKET);
 
               onEvent.mockReset();
-              server.send(JSON.stringify({id: genV4().toString(), payload: [{}]}));
+              server.send(JSON.stringify({id: uuidv4(), payload: [{}]}));
               await waitFor(() => expect(onEvent).toHaveBeenCalledTimes(1));
               expect(onEvent).not.toHaveBeenCalledWith(expect.any(Object), NotificationSource.NOTIFICATION_STREAM);
               expect(onEvent).toHaveBeenCalledWith(expect.any(Object), NotificationSource.WEBSOCKET);
@@ -394,7 +394,7 @@ describe('Account', () => {
                 case ConnectionState.PROCESSING_NOTIFICATIONS:
                   // sending a message as soon as the notificaiton stream starts to process
                   // This message should only be forwarded once the notification stream is fully processed
-                  server.send(JSON.stringify({id: genV4().toString(), payload: [{}]}));
+                  server.send(JSON.stringify({id: uuidv4(), payload: [{}]}));
                   break;
                 case ConnectionState.LIVE:
                   expect(onNotificationStreamProgress).toHaveBeenCalledTimes(nbNotifications);
@@ -432,7 +432,7 @@ describe('Account', () => {
                 case ConnectionState.PROCESSING_NOTIFICATIONS:
                   // sending a message as soon as the notificaiton stream starts to process
                   // This message should only be forwarded once the notification stream is fully processed
-                  server.send(JSON.stringify({id: genV4().toString(), payload: [{}]}));
+                  server.send(JSON.stringify({id: uuidv4(), payload: [{}]}));
                   break;
                 case ConnectionState.LIVE:
                   reject(new Error());

--- a/packages/core/src/conversation/AssetService/AssetService.test.ts
+++ b/packages/core/src/conversation/AssetService/AssetService.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {genV4} from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 import {APIClient} from '@wireapp/api-client';
 
@@ -30,8 +30,8 @@ describe('AssetService', () => {
       const assetService = new AssetService(apiClient);
 
       const assetServerData = {
-        key: `3-2-${genV4().toString()}`,
-        token: genV4().toString(),
+        key: `3-2-${uuidv4()}`,
+        token: uuidv4(),
         expires: '',
       };
 

--- a/packages/core/src/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/conversation/message/MessageBuilder.ts
@@ -18,7 +18,7 @@
  */
 
 import {QualifiedId} from '@wireapp/api-client/lib/user';
-import {genV4} from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 import {
   IComposite,
@@ -65,7 +65,7 @@ import {GenericMessageType} from '../GenericMessageType';
 import {MessageToProtoMapper} from '../message/MessageToProtoMapper';
 
 export function createId() {
-  return genV4().toString();
+  return uuidv4();
 }
 
 export function buildButtonActionMessage(payloadBundle: ButtonActionMessage['content']): GenericMessage {

--- a/packages/core/src/conversation/message/MessageService.test.ts
+++ b/packages/core/src/conversation/message/MessageService.test.ts
@@ -24,7 +24,7 @@ import {
   QualifiedUserClients,
 } from '@wireapp/api-client/lib/conversation';
 import {StatusCodes} from 'http-status-codes';
-import {genV4} from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 import {APIClient} from '@wireapp/api-client';
 import {GenericMessage, Text} from '@wireapp/protocol-messaging';
@@ -44,12 +44,12 @@ const baseMessageSendingStatus: MessageSendingStatus = {
 
 type TestUser = {id: string; domain: string; clients: string[]};
 const user1: TestUser = {
-  id: genV4().toString(),
+  id: uuidv4(),
   domain: '1.wire.test',
   clients: ['client1.1', 'client1.2', 'client1.3', 'client1.4'],
 };
 const user2: TestUser = {
-  id: genV4().toString(),
+  id: uuidv4(),
   domain: '2.wire.test',
   clients: ['client2.1', 'client2.2', 'client2.3', 'client2.4'],
 };

--- a/packages/core/src/test/PayloadHelper.ts
+++ b/packages/core/src/test/PayloadHelper.ts
@@ -18,10 +18,10 @@
  */
 
 import {faker} from '@faker-js/faker';
-import {genV4} from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 export function getUUID(): string {
-  return genV4().toString();
+  return uuidv4();
 }
 
 export function getUrlParameter(url: string, parameter: string): string | string[] | null {

--- a/packages/store-engine-dexie/package.json
+++ b/packages/store-engine-dexie/package.json
@@ -19,6 +19,7 @@
     "@types/jest": "^29.2.0",
     "@types/node": "^20.1.0",
     "@types/rimraf": "4.0.5",
+    "@types/uuid": "9.0.8",
     "@wireapp/store-engine": "workspace:^",
     "core-js": "^3.36.0",
     "fake-indexeddb": "^5.0.2",
@@ -27,7 +28,7 @@
     "rimraf": "5.0.7",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
-    "uuidjs": "4.2.13"
+    "uuid": "9.0.1"
   },
   "scripts": {
     "build": "yarn clean && tsc",

--- a/packages/store-engine-dexie/src/index.test.ts
+++ b/packages/store-engine-dexie/src/index.test.ts
@@ -27,7 +27,7 @@ import {readSpec} from '@wireapp/store-engine/lib/test/readSpec';
 import {updateOrCreateSpec} from '@wireapp/store-engine/lib/test/updateOrCreateSpec';
 import {updateSpec} from '@wireapp/store-engine/lib/test/updateSpec';
 import Dexie from 'dexie';
-import {genV4} from 'uuidjs';
+import {v4 as uuidv4} from 'uuid';
 
 import {IndexedDBEngine} from './index';
 
@@ -42,7 +42,7 @@ describe('IndexedDBEngine', () => {
   ): Promise<IndexedDBEngine> {
     const storeEngine = shouldCreateNewEngine ? new IndexedDBEngine() : engine;
 
-    const db: Dexie = await storeEngine.init(`database-${genV4().toString()}`);
+    const db: Dexie = await storeEngine.init(`database-${uuidv4()}`);
     let schema = {
       'the-simpsons': ', firstName, lastName',
     };
@@ -67,7 +67,7 @@ describe('IndexedDBEngine', () => {
   describe('init', () => {
     it('resolves with the database instance to which the records will be saved.', async () => {
       const engine = new IndexedDBEngine();
-      const instance = await engine.init(`database-${genV4().toString()}`);
+      const instance = await engine.init(`database-${uuidv4()}`);
       expect(instance instanceof Dexie).toBe(true);
       await Dexie.delete(instance.name);
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4225,6 +4225,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:9.0.8":
+  version: 9.0.8
+  resolution: "@types/uuid@npm:9.0.8"
+  checksum: b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
+  languageName: node
+  linkType: hard
+
 "@types/vinyl@npm:*":
   version: 2.0.7
   resolution: "@types/vinyl@npm:2.0.7"
@@ -4809,6 +4816,7 @@ __metadata:
     "@types/long": ^5.0.0
     "@types/rimraf": 4.0.5
     "@types/tough-cookie": 4.0.5
+    "@types/uuid": 9.0.8
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
     "@wireapp/core-crypto": 1.0.0-rc.60
@@ -4834,7 +4842,7 @@ __metadata:
     nock: 13.5.4
     rimraf: 5.0.7
     typescript: ^5.0.4
-    uuidjs: 4.2.13
+    uuid: 9.0.1
     zod: 3.23.8
   languageName: unknown
   linkType: soft
@@ -5047,6 +5055,7 @@ __metadata:
     "@types/jest": ^29.2.0
     "@types/node": ^20.1.0
     "@types/rimraf": 4.0.5
+    "@types/uuid": 9.0.8
     "@wireapp/store-engine": "workspace:^"
     core-js: ^3.36.0
     dexie: ">3.2.0"
@@ -5056,7 +5065,7 @@ __metadata:
     rimraf: 5.0.7
     ts-node: ^10.9.1
     typescript: ^5.0.4
-    uuidjs: 4.2.13
+    uuid: 9.0.1
   peerDependencies:
     "@wireapp/store-engine": 5.x.x
   languageName: unknown
@@ -18398,6 +18407,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:9.0.1, uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^2.0.1":
   version: 2.0.3
   resolution: "uuid@npm:2.0.3"
@@ -18411,24 +18429,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
-  languageName: node
-  linkType: hard
-
-"uuidjs@npm:4.2.13":
-  version: 4.2.13
-  resolution: "uuidjs@npm:4.2.13"
-  bin:
-    uuidjs: bin/cli.js
-  checksum: 67d4a32f6abbe68f692d57d9524aa01e2959a30dadf6e47779a6f31807dc89da057da349e02a4ded08b8f53bbbe29bb3a46fb667a59d5ed9627d5eebef55a6ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Motivation: bump `uuidjs` from v 4.2.13 to v 5.1.0 causes problems with `jest` that are hard to resolve.
And since `uuid` has 103,276,467 weekly downloads vs `uuidjs` - 9,841, it makes sense to use `uuid`.

## Pull Request Checklist

- [x] My code is covered by tests
