### PR TITLE
fix: remove hardcoded fill color for CircleCloseIcon

### DIFF
--- a/packages/react-ui-kit/src/Icon/CircleCloseIcon.tsx
+++ b/packages/react-ui-kit/src/Icon/CircleCloseIcon.tsx
@@ -20,12 +20,11 @@
 import {SVGIcon, SVGIconProps} from './SVGIcon';
 
 export const CircleCloseIcon = (props: SVGIconProps) => (
-  <SVGIcon realWidth={16} realHeight={16} fill="none" {...props}>
+  <SVGIcon realWidth={16} realHeight={16} {...props}>
     <path
       fillRule="evenodd"
       clipRule="evenodd"
       d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16ZM8 9.41421L4.75736 12.6569L3.34315 11.2426L6.58579 8L3.34315 4.75736L4.75736 3.34315L8 6.58579L11.2426 3.34315L12.6569 4.75736L9.41421 8L12.6569 11.2426L11.2426 12.6569L8 9.41421Z"
-      fill="black"
     />
   </SVGIcon>
 );


### PR DESCRIPTION
The circle close icon has it's fill color hardcoded in a way it cannot be reassigned for dark mode.
After removing the hardcoded value, the component gets a correct value from its default `SVGIconProps` props that can be reassigned

before:
![image](https://github.com/wireapp/wire-web-packages/assets/78490891/c9f068fe-9de0-414b-bb08-816aa1139ade)

After:
![image](https://github.com/wireapp/wire-web-packages/assets/78490891/e542fb60-448d-4cbe-acfa-de3b8a105b13)
