### PR TITLE
fix(api-client): socket reconnect after coming back from sleep

### DIFF
--- a/packages/api-client/src/tcp/ReconnectingWebsocket.ts
+++ b/packages/api-client/src/tcp/ReconnectingWebsocket.ts
@@ -84,6 +84,12 @@ export class ReconnectingWebsocket {
 
     this.hasUnansweredPing = false;
 
+    /**
+     * According to https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine, navigator.onLine attribute and 'online' and 'offline' events are not reliable enough (especially when it's truthy).
+     * We won't receive the 'offline' event when the system goes to sleep (e.g. closing the lid of a laptop).
+     * In this case navigator.onLine will still return true, but the WebSocket connection could be closed.
+     * To handle this, we need a custom approach to detect when the system goes to sleep and when it wakes up.
+     * **/
     onBackFromSleep({
       callback: () => {
         if (this.socket) {

--- a/packages/api-client/src/tcp/ReconnectingWebsocket.ts
+++ b/packages/api-client/src/tcp/ReconnectingWebsocket.ts
@@ -48,7 +48,7 @@ export class ReconnectingWebsocket {
   private static readonly RECONNECTING_OPTIONS: Options = {
     WebSocket: WebSocketNode,
     connectionTimeout: TimeUtil.TimeInMillis.SECOND * 4,
-    debug: false,
+    debug: true,
     maxReconnectionDelay: TimeUtil.TimeInMillis.SECOND * 10,
     maxRetries: Infinity,
     minReconnectionDelay: TimeUtil.TimeInMillis.SECOND * 4,
@@ -173,16 +173,10 @@ export class ReconnectingWebsocket {
     return this.socket ? this.socket.readyState : WEBSOCKET_STATE.CLOSED;
   }
 
-  public disconnect(reason = 'Closed by client', keepClosed = true): void {
+  public disconnect(reason = 'Closed by client'): void {
     if (this.socket) {
       this.logger.info(`Disconnecting from WebSocket (reason: "${reason}")`);
-      // TODO: 'any' can be removed once this issue is resolved:
-      // https://github.com/pladaria/reconnecting-websocket/issues/44
-      (this.socket as any).close(CloseEventCode.NORMAL_CLOSURE, reason, {
-        delay: 0,
-        fastClose: true,
-        keepClosed,
-      });
+      this.socket.close(CloseEventCode.NORMAL_CLOSURE, reason);
     }
   }
 

--- a/packages/api-client/src/tcp/ReconnectingWebsocket.ts
+++ b/packages/api-client/src/tcp/ReconnectingWebsocket.ts
@@ -24,6 +24,7 @@ import {TimeUtil} from '@wireapp/commons';
 
 import * as buffer from '../shims/node/buffer';
 import {WebSocketNode} from '../shims/node/websocket';
+import {onBackFromSleep} from '../utils/BackFromSleepHandler';
 
 export enum CloseEventCode {
   NORMAL_CLOSURE = 1000,
@@ -82,6 +83,16 @@ export class ReconnectingWebsocket {
     }
 
     this.hasUnansweredPing = false;
+
+    onBackFromSleep({
+      callback: () => {
+        if (this.socket) {
+          this.logger.debug('Back from sleep, reconnecting WebSocket');
+          this.socket?.reconnect();
+        }
+      },
+      isDisconnected: () => this.getState() === WEBSOCKET_STATE.CLOSED,
+    });
   }
 
   private readonly internalOnError = (error: ErrorEvent) => {

--- a/packages/api-client/src/tcp/ReconnectingWebsocket.ts
+++ b/packages/api-client/src/tcp/ReconnectingWebsocket.ts
@@ -49,7 +49,7 @@ export class ReconnectingWebsocket {
   private static readonly RECONNECTING_OPTIONS: Options = {
     WebSocket: WebSocketNode,
     connectionTimeout: TimeUtil.TimeInMillis.SECOND * 4,
-    debug: true,
+    debug: false,
     maxReconnectionDelay: TimeUtil.TimeInMillis.SECOND * 10,
     maxRetries: Infinity,
     minReconnectionDelay: TimeUtil.TimeInMillis.SECOND * 4,

--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -182,9 +182,9 @@ export class WebSocketClient extends EventEmitter {
     }
   }
 
-  public disconnect(reason?: string, keepClosed = true): void {
+  public disconnect(reason?: string): void {
     if (this.socket) {
-      this.socket.disconnect(reason, keepClosed);
+      this.socket.disconnect(reason);
     }
   }
 

--- a/packages/api-client/src/utils/BackFromSleepHandler/BackFromSleepHandler.test.ts
+++ b/packages/api-client/src/utils/BackFromSleepHandler/BackFromSleepHandler.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {onBackFromSleep} from './BackFromSleepHandler';
+
+const CHECK_INTERVAL = 2000;
+const TOLERANCE = CHECK_INTERVAL * 2;
+
+jest.useFakeTimers();
+
+describe('onBackFromSleep', () => {
+  let originalDateNow: () => number;
+  let now: number;
+
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    now = Date.now();
+    jest.spyOn(global, 'Date').mockImplementation(
+      () =>
+        ({
+          getTime: () => now,
+        }) as unknown as Date,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    global.Date.now = originalDateNow;
+  });
+
+  it('should call the callback when system wakes up from sleep', () => {
+    const callback = jest.fn();
+    onBackFromSleep({callback});
+
+    // Simulate system sleep
+    now += TOLERANCE + 1;
+    jest.advanceTimersByTime(CHECK_INTERVAL);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call the callback for small delays', () => {
+    const callback = jest.fn();
+    onBackFromSleep({callback});
+
+    // Simulate small delay
+    now += TOLERANCE - 1;
+    jest.advanceTimersByTime(CHECK_INTERVAL);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should call the callback if disconnected during sleep', () => {
+    const callback = jest.fn();
+    const isDisconnected = jest.fn().mockReturnValue(true);
+
+    onBackFromSleep({callback, isDisconnected});
+
+    // Simulate system sleep
+    now += TOLERANCE + 1;
+    jest.advanceTimersByTime(CHECK_INTERVAL);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call the callback if not disconnected during sleep', () => {
+    const callback = jest.fn();
+    const isDisconnected = jest.fn().mockReturnValue(false);
+
+    onBackFromSleep({callback, isDisconnected});
+
+    // Simulate system sleep
+    now += TOLERANCE + 1;
+    jest.advanceTimersByTime(CHECK_INTERVAL);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should call the callback only once after sleep', () => {
+    const callback = jest.fn();
+    onBackFromSleep({callback});
+
+    // Simulate system sleep and wake up
+    now += TOLERANCE + 1;
+    jest.advanceTimersByTime(CHECK_INTERVAL);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Simulate more intervals
+    jest.advanceTimersByTime(CHECK_INTERVAL * 10);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stop checking when returned function is called', () => {
+    const callback = jest.fn();
+    const stop = onBackFromSleep({callback});
+
+    // Stop the interval
+    stop();
+
+    // Simulate system sleep
+    now += TOLERANCE + 1;
+    jest.advanceTimersByTime(CHECK_INTERVAL);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api-client/src/utils/BackFromSleepHandler/BackFromSleepHandler.ts
+++ b/packages/api-client/src/utils/BackFromSleepHandler/BackFromSleepHandler.ts
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+const CHECK_INTERVAL = 2000;
+const TOLERANCE = CHECK_INTERVAL * 2;
+
+/**
+ * This function will call the callback when the system has very likely woken up from sleep.
+ * It will ignore small delays and will only call the callback if the system was disconnected during sleep.
+ * @param callback - the function to call when the system wakes up
+ * @param isDisconnected - (optional) a function to make sure the connection was lost, to reduce the chance of false positives
+ * @returns a function to stop the interval
+ * @example
+ * ```typescript
+ * const stop = onBackFromSleep({
+ *  callback: () => {
+ *   console.log('Woke up from sleep');
+ * },
+ * isDisconnected: () => {
+ *  return !navigator.onLine;
+ * }
+ * });
+ * ```
+ */
+export const onBackFromSleep = ({
+  callback,
+  isDisconnected: isDisconnectedCallback,
+}: {
+  callback: () => void;
+  isDisconnected?: () => boolean;
+}) => {
+  let lastTime = new Date().getTime();
+  let wasDisconnected = false;
+
+  const tid = setInterval(() => {
+    const currentTime = new Date().getTime();
+
+    // The interval did not run for a while, so we assume the system was sleeping
+    const wasAsleep = currentTime > lastTime + TOLERANCE;
+
+    lastTime = currentTime;
+
+    if (isDisconnectedCallback && isDisconnectedCallback()) {
+      wasDisconnected = true;
+    }
+
+    if (wasAsleep) {
+      if (!isDisconnectedCallback || wasDisconnected) {
+        wasDisconnected = false;
+        callback();
+      }
+    }
+  }, CHECK_INTERVAL);
+
+  return () => clearInterval(tid);
+};

--- a/packages/api-client/src/utils/BackFromSleepHandler/index.ts
+++ b/packages/api-client/src/utils/BackFromSleepHandler/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2024 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './BackFromSleepHandler';


### PR DESCRIPTION
Once we've realised that the app was (**probably**) sleeping and during the possible "sleep time" the socket was disconnected, we will immediately reconnect. This should fix the bug where after coming back from sleep mode, messages are not synced immediately.