### PR TITLE
fix(ui:select): make searchable and fix scroll behaviour

### DIFF
--- a/packages/react-ui-kit/src/Form/Select.md
+++ b/packages/react-ui-kit/src/Form/Select.md
@@ -132,5 +132,34 @@ const [isOpen, setIsOpen] = React.useState(false);
       />
     </Column>
   </Columns>
+
+  <Columns>
+    <Column>Select with many items</Column>
+
+    <Column>
+      <Select
+        label="Many items select"
+        required
+        id="manyItemsSelect"
+        options={[...selectOptions, ...selectOptions, ...selectOptions, ...selectOptions]}
+        dataUieName="required-select"
+      />
+    </Column>
+  </Columns>
+
+  <Columns>
+    <Column>Searcheable Select</Column>
+
+    <Column>
+      <Select
+        label="Searchable select"
+        required
+        id="searchableSelect"
+        options={[...selectOptions]}
+        dataUieName="required-select"
+        isSearchable
+      />
+    </Column>
+  </Columns>
 </Container>;
 ```

--- a/packages/react-ui-kit/src/Form/Select.tsx
+++ b/packages/react-ui-kit/src/Form/Select.tsx
@@ -58,6 +58,7 @@ interface SelectProps<IsMulti extends boolean, Group extends GroupBase<Option>>
   markInvalid?: boolean;
   required?: boolean;
   isMulti?: IsMulti;
+  isSearchable?: boolean;
 }
 
 export const Select = <IsMulti extends boolean = false, Group extends GroupBase<Option> = GroupBase<Option>>({
@@ -72,6 +73,7 @@ export const Select = <IsMulti extends boolean = false, Group extends GroupBase<
   wrapperCSS = {},
   markInvalid = false,
   required = false,
+  isSearchable = false,
   ...props
 }: SelectProps<IsMulti, Group>) => {
   const theme = useTheme();
@@ -111,7 +113,7 @@ export const Select = <IsMulti extends boolean = false, Group extends GroupBase<
         tabIndex={TabIndex.UNFOCUSABLE}
         isDisabled={disabled}
         hideSelectedOptions={false}
-        isSearchable={false}
+        isSearchable={isSearchable}
         isClearable={false}
         closeMenuOnSelect={!isMulti}
         isMulti={isMulti}

--- a/packages/react-ui-kit/src/Form/SelectStyles.tsx
+++ b/packages/react-ui-kit/src/Form/SelectStyles.tsx
@@ -121,7 +121,7 @@ export const customStyles = (theme: Theme, markInvalid = false) => ({
     borderRadius: 12,
     paddingBottom: 0,
     paddingTop: 0,
-    maxHeight: 'fit-content',
+    maxHeight: 400,
   }),
   option: (provided, {isMulti, isDisabled, isFocused, isSelected, options, data}) => ({
     ...provided,


### PR DESCRIPTION
There was an Issue where the selects is not able to being scrolled with very long lists.
Additionally it was also not being searchable.

This PR fixes both behaviours trough:
- setting a max height for the option-list to 400px
- add a parameter to activate the search feature, disabled by default