### PR TITLE
fix: do not create an RTC object for check

### DIFF
--- a/packages/commons/src/util/Runtime.ts
+++ b/packages/commons/src/util/Runtime.ts
@@ -165,9 +165,7 @@ export class Runtime {
     if (!Runtime.isSupportingRTCPeerConnection()) {
       return false;
     }
-
-    const peerConnection = new RTCPeerConnection(undefined);
-    return 'createDataChannel' in peerConnection;
+    return !!(window.RTCPeerConnection.prototype && window.RTCPeerConnection.prototype.createDataChannel);
   };
 
   public static isSupportingUserMedia = (): boolean => {


### PR DESCRIPTION
To check if `RTCDataChannel's` are offered we creating `RTCPeerConnection` objects
Creating `RTCPeerConnection` objects leads to too many unnecessary ghost objects in the background that are not cleared away. This can potentially lead to errors in the app.

<img width="807" alt="Bildschirmfoto 2024-06-19 um 17 16 39" src="https://github.com/wireapp/wire-web-packages/assets/1362436/643433ea-e537-4db8-a752-7e8815adc628">


<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
