### PR TITLE
feat: allow match media to support external window

### DIFF
--- a/packages/react-ui-kit/src/Layout/MatchMedia.tsx
+++ b/packages/react-ui-kit/src/Layout/MatchMedia.tsx
@@ -29,8 +29,9 @@ export interface MatchMediaProps extends React.HTMLProps<ReactFragment> {
   query: Query;
 }
 
-export const useMatchMedia = (query: Query) => {
-  const matchMedia = useMemo(() => window.matchMedia(`(${query})`), [query]);
+export const useMatchMedia = (query: Query, customWindowObj?: Window) => {
+  const windowObj = customWindowObj || window;
+  const matchMedia = useMemo(() => windowObj.matchMedia(`(${query})`), [query, windowObj]);
 
   const [isMatching, setIsMatching] = useState(matchMedia.matches);
 


### PR DESCRIPTION
Adds multi-window support for MatchMedia util. Useful when opening an external window (e.g. calling popout view).