### PR TITLE
fix: add ciphersuites param when replacing keys [WPB-10236]

### DIFF
--- a/packages/api-client/src/client/ClientAPI.ts
+++ b/packages/api-client/src/client/ClientAPI.ts
@@ -62,7 +62,7 @@ export class ClientAPI {
     PUBLIC_KEYS: 'public-keys',
     NONCE: 'nonce',
     ACCESS_TOKEN: 'access-token',
-  };
+  } as const;
 
   public async postClient(newClient: CreateClientPayload): Promise<RegisteredClient> {
     const config: AxiosRequestConfig = {
@@ -157,11 +157,14 @@ export class ClientAPI {
    * @param {string} clientId The client to upload the key packages for
    * @param {string[]} keyPackages The key packages to upload
    */
-  public async replaceMLSKeyPackages(clientId: string, keyPackages: string[]) {
+  public async replaceMLSKeyPackages(clientId: string, keyPackages: string[], ciphersuites: string) {
     const config: AxiosRequestConfig = {
       data: {key_packages: keyPackages},
       method: 'PUT',
       url: `/${ClientAPI.URL.MLS_CLIENTS}/${ClientAPI.URL.MLS_KEY_PACKAGES}/self/${clientId}`,
+      params: {
+        ciphersuites,
+      },
     };
 
     await this.client.sendJSON<PreKeyBundle>(config, true);

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -808,6 +808,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     return this.apiClient.api.client.replaceMLSKeyPackages(
       clientId,
       keyPackages.map(keyPackage => btoa(Converter.arrayBufferViewToBaselineString(keyPackage))),
+      numberToHex(this.config.defaultCiphersuite),
     );
   }
 


### PR DESCRIPTION
Backend requires a comma-separated ciphersuites as a query param when replacing mls key packages during the enrollment.
