### PR TITLE
feat: add flag for 1:1 sft calls

### DIFF
--- a/packages/api-client/src/team/feature/Feature.ts
+++ b/packages/api-client/src/team/feature/Feature.ts
@@ -84,9 +84,13 @@ export interface FeatureMLSMigrationConfig extends FeatureConfig {
   finaliseRegardlessAfter?: string;
 }
 
+export interface FeatureConferenceCallingConfig extends FeatureConfig {
+  useSFTForOneToOneCalls?: boolean;
+}
+
 export type FeatureAppLock = Feature<FeatureAppLockConfig>;
 export type FeatureClassifiedDomains = Feature<FeatureClassifiedDomainsConfig>;
-export type FeatureConferenceCalling = FeatureWithoutConfig;
+export type FeatureConferenceCalling = Feature<FeatureConferenceCallingConfig>;
 export type FeatureDigitalSignature = FeatureWithoutConfig;
 export type FeatureConversationGuestLink = FeatureWithoutConfig;
 export type FeatureFileSharing = FeatureWithoutConfig;


### PR DESCRIPTION
New conference calling setting that allows to use sft server for 1:1 calls instead of peer-to-peer connection.