### PR TITLE
fix: Revert "chore: Publish [skip ci]"

### DIFF
--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [27.3.2](https://github.com/wireapp/wire-web-packages/compare/@wireapp/api-client@27.3.1...@wireapp/api-client@27.3.2) (2024-08-12)
-
-**Note:** Version bump only for package @wireapp/api-client
-
 ## [27.3.1](https://github.com/wireapp/wire-web-packages/compare/@wireapp/api-client@27.3.0...@wireapp/api-client@27.3.1) (2024-07-31)
 
 **Note:** Version bump only for package @wireapp/api-client

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -66,6 +66,6 @@
     "watch": "webpack serve --config webpack.browser.js",
     "prepare": "yarn dist"
   },
-  "version": "27.3.2",
+  "version": "27.3.1",
   "gitHead": "5339f01fe01ef0871da8c8bc8662fbe9e604754a"
 }

--- a/packages/copy-config/CHANGELOG.md
+++ b/packages/copy-config/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [2.2.4](https://github.com/wireapp/wire-web-packages/compare/@wireapp/copy-config@2.2.3...@wireapp/copy-config@2.2.4) (2024-08-12)
-
-**Note:** Version bump only for package @wireapp/copy-config
-
 ## [2.2.3](https://github.com/wireapp/wire-web-packages/compare/@wireapp/copy-config@2.2.2...@wireapp/copy-config@2.2.3) (2024-07-16)
 
 **Note:** Version bump only for package @wireapp/copy-config

--- a/packages/copy-config/package.json
+++ b/packages/copy-config/package.json
@@ -35,5 +35,5 @@
     "test": "jest",
     "test:coverage": "jest --coverage"
   },
-  "version": "2.2.4"
+  "version": "2.2.3"
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,12 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [46.2.3](https://github.com/wireapp/wire-web-packages/compare/@wireapp/core@46.2.2...@wireapp/core@46.2.3) (2024-08-12)
-
-### Bug Fixes
-
-* handle leaving a 1:1 call over SFT [WPB-7151] ([#6434](https://github.com/wireapp/wire-web-packages/issues/6434)) ([5ace70c](https://github.com/wireapp/wire-web-packages/commit/5ace70c59a81dc0c07b6c9c7cf32df1f0f8274b2))
-
 ## [46.2.2](https://github.com/wireapp/wire-web-packages/compare/@wireapp/core@46.2.1...@wireapp/core@46.2.2) (2024-07-31)
 
 **Note:** Version bump only for package @wireapp/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,6 @@
     "test:coverage": "jest --coverage",
     "watch": "tsc --watch"
   },
-  "version": "46.2.3",
+  "version": "46.2.2",
   "gitHead": "5339f01fe01ef0871da8c8bc8662fbe9e604754a"
 }

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.0.18](https://github.com/wireapp/wire-web-packages/compare/@wireapp/eslint-config@3.0.17...@wireapp/eslint-config@3.0.18) (2024-08-12)
-
-**Note:** Version bump only for package @wireapp/eslint-config
-
 ## [3.0.17](https://github.com/wireapp/wire-web-packages/compare/@wireapp/eslint-config@3.0.16...@wireapp/eslint-config@3.0.17) (2024-07-31)
 
 **Note:** Version bump only for package @wireapp/eslint-config

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,7 +4,7 @@
   "description": "Wire ESLint config",
   "repository": "https://github.com/wireapp/wire-web-packages/tree/main/packages/eslint-config",
   "main": "eslintrc.js",
-  "version": "3.0.18",
+  "version": "3.0.17",
   "peerDependencies": {
     "eslint": "^8",
     "prettier": "^3"

--- a/packages/react-ui-kit/CHANGELOG.md
+++ b/packages/react-ui-kit/CHANGELOG.md
@@ -3,10 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [9.23.1](https://github.com/wireapp/wire-web-packages/compare/@wireapp/react-ui-kit@9.23.0...@wireapp/react-ui-kit@9.23.1) (2024-08-12)
-
-**Note:** Version bump only for package @wireapp/react-ui-kit
-
 # [9.23.0](https://github.com/wireapp/wire-web-packages/compare/@wireapp/react-ui-kit@9.22.0...@wireapp/react-ui-kit@9.23.0) (2024-08-01)
 
 ### Features

--- a/packages/react-ui-kit/package.json
+++ b/packages/react-ui-kit/package.json
@@ -70,5 +70,5 @@
     "test:watch": "jest --watch",
     "test:update": "jest --updateSnapshot"
   },
-  "version": "9.23.1"
+  "version": "9.23.0"
 }


### PR DESCRIPTION
This reverts commit dcbe8d6811804d1d0aa145633b5e760de5d8109d.

The latest publish commit didn't result in the packages actually being deployed on npm.

Using `fix` as the commit identifier will make sure the pipeline will publish the packages correctly (`chore` commits do not get published)