### PR TITLE
feat(privacy): streamline the structure of privacy related events

### DIFF
--- a/packages/webapp-events/src/index.ts
+++ b/packages/webapp-events/src/index.ts
@@ -199,9 +199,11 @@ export const WebAppEvents = {
       PREVIEWS: {
         SEND: 'wire.webapp.properties.update.previews.send',
       },
-      PRIVACY: 'wire.webapp.properties.update.privacy',
+      PRIVACY: {
+        TELEMETRY_SHARING: 'wire.webapp.properties.update.privacy.telemetry_sharing',
+        MARKETING_CONSENT: 'wire.webapp.properties.update.privacy.marketing_consent',
+      },
       SOUND_ALERTS: 'wire.webapp.properties.update.sound_alerts',
-      TELEMETRY_SHARING: 'wire.webapp.properties.update.telemetry_sharing',
     },
     UPDATED: 'wire.webapp.properties.updated',
   },


### PR DESCRIPTION
While checking the webapp code related to user consent for tracking and marketing  realized:

- 'wire.webapp.properties.update.privacy' is not used in the webapp anymore
- we should handle marketing_consent exactly the same as telemetry_sharing, instead of having different code structures for them

This package update will help streamline the code in our web application.