### PR TITLE
fix: use of Auth header to pass access-token instead of query param

### DIFF
--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -215,7 +215,7 @@ export class AssetAPI {
 
     const handleRequest = async (): Promise<AssetResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config, true);
+        const response = await this.client.sendRequest<ArrayBuffer>(config);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],
@@ -266,7 +266,7 @@ export class AssetAPI {
 
     const handleRequest = async (): Promise<AssetResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config, true);
+        const response = await this.client.sendRequest<ArrayBuffer>(config);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],

--- a/packages/api-client/src/team/member/MemberAPI.ts
+++ b/packages/api-client/src/team/member/MemberAPI.ts
@@ -160,7 +160,7 @@ export class MemberAPI {
 
     const handleRequest = async (): Promise<MemberCSVResponse> => {
       try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config, true);
+        const response = await this.client.sendRequest<ArrayBuffer>(config);
         return {
           buffer: response.data,
           mimeType: response.headers['content-type'],


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please check the following to make sure your contribution follows our guideline:
-->
[WPB-10469](https://wearezeta.atlassian.net/browse/WPB-10469)

Removed `access_token` from query param and passed it through `Authorization` header.

**Explanation:**

On the ticket there are 4 files mentioned that require changes:

- https://github.com/wireapp/wire-web-packages/blob/e875aa251d9da0df0b7caa7ba066279fecf1f4d7/packages/api-client/src/team/member/MemberAPI.ts#L163

- https://github.com/wireapp/wire-web-packages/blob/e875aa251d9da0df0b7caa7ba066279fecf1f4d7/packages/api-client/src/tcp/WebSocketClient.ts#L226 There is no other way of passing access_token. Additionally, we may not be seeing the URL in logs.

- https://github.com/wireapp/wire-webapp/blob/b89a390c78f4ba604d93b504b581104ac9adf548/src/script/assets/AssetService.ts#L30-L64
Already removed in this PR: https://github.com/wireapp/wire-webapp/pull/17842

- https://github.com/wireapp/wire-web-packages/blob/e875aa251d9da0df0b7caa7ba066279fecf1f4d7/packages/api-client/src/asset/AssetAPI.ts#L96 Asset token has completely different purpose, so didn't change anything related to it.

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes


[WPB-10469]: https://wearezeta.atlassian.net/browse/WPB-10469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ