### PR TITLE
feat: replace error_reporting with marketing_consent [WPB-10506]

### DIFF
--- a/packages/api-client/src/user/data/UserPropertiesSetData.ts
+++ b/packages/api-client/src/user/data/UserPropertiesSetData.ts
@@ -52,7 +52,7 @@ export interface WebappProperties {
       send: boolean;
     };
     privacy: {
-      report_errors?: boolean;
+      marketing_consent?: boolean;
       telemetry_sharing?: boolean;
     };
     sound: {


### PR DESCRIPTION
error_reporting is gone and should not be used anymore.

Added marketing_consent to have all privacy-related options, that a user has to give consent to, in one place.