### PR TITLE
fix: force logout when zuid cookie is missing [WPB-10717]

### DIFF
--- a/packages/api-client/src/auth/AuthenticationError.ts
+++ b/packages/api-client/src/auth/AuthenticationError.ts
@@ -90,3 +90,11 @@ export class PasswordExistsError extends AuthenticationError {
     this.name = 'PasswordExistsError';
   }
 }
+
+export class MissingCookieAndTokenError extends AuthenticationError {
+  constructor(message: string, label = BackendErrorLabel.INVALID_CREDENTIALS, code = StatusCode.FORBIDDEN) {
+    super(message, label, code);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = 'MissingCookieAndTokenError';
+  }
+}

--- a/packages/api-client/src/http/BackendErrorMapper.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.ts
@@ -22,6 +22,7 @@ import {
   InvalidCredentialsError,
   InvalidTokenError,
   LoginTooFrequentError,
+  MissingCookieAndTokenError,
   MissingCookieError,
   SuspendedAccountError,
   TokenExpiredError,
@@ -55,6 +56,9 @@ export class BackendErrorMapper {
           'Invalid token': new InvalidTokenError('Authentication failed because the token is invalid.'),
           'Missing cookie': new MissingCookieError('Authentication failed because the cookie is missing.'),
           'Token expired': new TokenExpiredError('Authentication failed because the token is expired.'),
+          'Missing cookie and token': new MissingCookieAndTokenError(
+            'Authentication failed because the cookie and token is missing.',
+          ),
         },
         [BackendErrorLabel.NOT_CONNECTED]: {
           'Users are not connected': new UnconnectedUserError('Users are not connected.'),

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -32,6 +32,7 @@ import {
   AccessTokenStore,
   AuthAPI,
   InvalidTokenError,
+  MissingCookieAndTokenError,
   MissingCookieError,
   TokenExpiredError,
 } from '../auth/';
@@ -181,7 +182,11 @@ export class HttpClient extends EventEmitter {
           return retryWithTokenRefresh();
         }
 
-        if (mappedError instanceof InvalidTokenError || mappedError instanceof MissingCookieError) {
+        if (
+          mappedError instanceof InvalidTokenError ||
+          mappedError instanceof MissingCookieError ||
+          mappedError instanceof MissingCookieAndTokenError
+        ) {
           // On invalid cookie the application is supposed to logout.
           this.logger.warn(
             `Cannot renew access token for "${config.method}" request to "${config.url}" because cookie/token is invalid: ${mappedError.message}`,

--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -24,7 +24,7 @@ import {EventEmitter} from 'events';
 
 import {ReconnectingWebsocket, WEBSOCKET_STATE} from './ReconnectingWebsocket';
 
-import {InvalidTokenError, MissingCookieError} from '../auth/';
+import {InvalidTokenError, MissingCookieAndTokenError, MissingCookieError} from '../auth/';
 import {HttpClient, NetworkError} from '../http/';
 import {Notification} from '../notification/';
 
@@ -167,7 +167,11 @@ export class WebSocketClient extends EventEmitter {
     } catch (error) {
       if (error instanceof NetworkError) {
         this.logger.warn(error);
-      } else if (error instanceof InvalidTokenError || error instanceof MissingCookieError) {
+      } else if (
+        error instanceof InvalidTokenError ||
+        error instanceof MissingCookieError ||
+        error instanceof MissingCookieAndTokenError
+      ) {
         // On invalid cookie the application is supposed to logout.
         this.logger.warn(
           `[WebSocket] Cannot renew access token because cookie/token is invalid: ${error.message}`,


### PR DESCRIPTION
Fixed zuid missing error on HttpClient level.

https://github.com/wireapp/wire-webapp/pull/17932

## Pull Request Checklist

- [ ] My code is covered by tests
- [ ] I will [merge the PR as breaking change](https://github.com/wireapp/wire-web-packages/wiki/Releases#create-major-release), if the API contract changes
