### PR TITLE
feat(api-client): Update telemetry key name in webapp properties (WPB-9972)

### DIFF
--- a/packages/api-client/src/user/data/UserPropertiesSetData.ts
+++ b/packages/api-client/src/user/data/UserPropertiesSetData.ts
@@ -53,7 +53,7 @@ export interface WebappProperties {
     };
     privacy: {
       marketing_consent?: boolean;
-      telemetry_sharing?: boolean;
+      telemetry_data_sharing?: boolean;
     };
     sound: {
       alerts: AudioPreference;


### PR DESCRIPTION
### Description

Since we want to trigger the user data sharing consent modal once more for every user we need to update the key of `telemetry_sharing` to something else like `telemetry_data_sharing`. By changing this brand new value will be `undefined` for all of the users and it'll trigger the modal to ask for consent once more.