### PR TITLE
feat: establish 1on1 mls conversation with new removal key [WPB-10744]

### DIFF
--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -19,6 +19,7 @@
 
 import {RECEIPT_MODE} from './data';
 
+import {MLSPublicKeyRecord} from '../client';
 import {QualifiedId} from '../user';
 
 import {ConversationMembers, ConversationProtocol} from './';
@@ -106,4 +107,10 @@ export interface MLSConversation extends Conversation {
   epoch: number;
   cipher_suite: number;
   protocol: ConversationProtocol.MLS;
+}
+
+export interface MLS1on1Conversation extends MLSConversation {
+  public_keys: {
+    removal: MLSPublicKeyRecord;
+  };
 }

--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -118,9 +118,9 @@ export interface MLS1to1Conversation {
 
 export function isMLS1to1Conversation(response: unknown): response is MLS1to1Conversation {
   if (typeof response === 'object' && response !== null) {
-    const conversation = response as MLS1to1Conversation;
+    const mls1to1Conversation = response as MLS1to1Conversation;
 
-    return !!conversation.conversation && !!conversation.public_keys;
+    return !!mls1to1Conversation.conversation && !!mls1to1Conversation.public_keys;
   }
 
   return false;

--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -120,7 +120,7 @@ export function isMLS1to1Conversation(response: unknown): response is MLS1to1Con
   if (typeof response === 'object' && response !== null) {
     const conversation = response as MLS1to1Conversation;
 
-    return !!conversation.conversation && !!conversation.public_keys
+    return !!conversation.conversation && !!conversation.public_keys;
   }
 
   return false;

--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -117,10 +117,8 @@ export interface MLS1to1Conversation {
 }
 
 export function isMLS1to1Conversation(response: unknown): response is MLS1to1Conversation {
-  if (typeof response === 'object' && response !== null) {
-    const mls1to1Conversation = response as MLS1to1Conversation;
-
-    return !!mls1to1Conversation.conversation && !!mls1to1Conversation.public_keys;
+  if (typeof response === 'object' && response !== null && 'conversation' in response && 'public_keys' in response) {
+    return true;
   }
 
   return false;

--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -115,3 +115,17 @@ export interface MLS1to1Conversation {
     removal: MLSPublicKeyRecord;
   };
 }
+
+export function isMLS1to1Conversation(response: unknown): response is MLS1to1Conversation {
+  if (typeof response === 'object' && response !== null) {
+    const conversation = response as MLS1to1Conversation;
+
+    if (!!conversation.conversation && !!conversation.public_keys) {
+      return true;
+    }
+
+    return false;
+  }
+
+  return false;
+}

--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -109,8 +109,9 @@ export interface MLSConversation extends Conversation {
   protocol: ConversationProtocol.MLS;
 }
 
-export interface MLS1on1Conversation extends MLSConversation {
-  public_keys: {
+export interface MLS1to1Conversation {
+  conversation: MLSConversation;
+  public_keys?: {
     removal: MLSPublicKeyRecord;
   };
 }

--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -120,11 +120,7 @@ export function isMLS1to1Conversation(response: unknown): response is MLS1to1Con
   if (typeof response === 'object' && response !== null) {
     const conversation = response as MLS1to1Conversation;
 
-    if (!!conversation.conversation && !!conversation.public_keys) {
-      return true;
-    }
-
-    return false;
+    return !!conversation.conversation && !!conversation.public_keys
   }
 
   return false;

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -31,7 +31,7 @@ import {
   JoinConversationByCodePayload,
   Member,
   MessageSendingStatus,
-  MLS1on1Conversation,
+  MLS1to1Conversation,
   MLSConversation,
   NewConversation,
   QualifiedConversationIds,
@@ -421,13 +421,13 @@ export class ConversationAPI {
    * Get a MLS 1:1-conversation with a given user.
    * @param userId - qualified user id
    */
-  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLS1on1Conversation> {
+  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLS1to1Conversation> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}/${domain}/${id}`,
     };
 
-    const response = await this.client.sendJSON<MLS1on1Conversation>(config);
+    const response = await this.client.sendJSON<MLS1to1Conversation>(config);
     return response.data;
   }
 

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -31,6 +31,7 @@ import {
   JoinConversationByCodePayload,
   Member,
   MessageSendingStatus,
+  MLS1on1Conversation,
   MLSConversation,
   NewConversation,
   QualifiedConversationIds,
@@ -420,13 +421,13 @@ export class ConversationAPI {
    * Get a MLS 1:1-conversation with a given user.
    * @param userId - qualified user id
    */
-  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLSConversation> {
+  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLS1on1Conversation> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}/${domain}/${id}`,
     };
 
-    const response = await this.client.sendJSON<MLSConversation>(config);
+    const response = await this.client.sendJSON<MLS1on1Conversation>(config);
     return response.data;
   }
 

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -421,13 +421,13 @@ export class ConversationAPI {
    * Get a MLS 1:1-conversation with a given user.
    * @param userId - qualified user id
    */
-  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLS1to1Conversation> {
+  public async getMLS1to1Conversation({domain, id}: QualifiedId): Promise<MLS1to1Conversation | MLSConversation> {
     const config: AxiosRequestConfig = {
       method: 'get',
       url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}/${domain}/${id}`,
     };
 
-    const response = await this.client.sendJSON<MLS1to1Conversation>(config);
+    const response = await this.client.sendJSON<MLS1to1Conversation | MLSConversation>(config);
     return response.data;
   }
 

--- a/packages/api-client/src/conversation/NewConversation.ts
+++ b/packages/api-client/src/conversation/NewConversation.ts
@@ -21,7 +21,6 @@ import {Conversation} from './Conversation';
 import {DefaultConversationRoleName} from './ConversationRole';
 import {RECEIPT_MODE} from './data/ConversationReceiptModeUpdateData';
 
-import {MLSPublicKeyRecord} from '../client';
 import {TeamInfo} from '../team/';
 import {QualifiedId} from '../user/';
 
@@ -39,7 +38,4 @@ export interface NewConversation
   protocol?: ConversationProtocol;
   team?: TeamInfo;
   users?: string[]; // users must be empty for creating MLS conversations
-  public_key?: {
-    removal: MLSPublicKeyRecord;
-  };
 }

--- a/packages/api-client/src/conversation/NewConversation.ts
+++ b/packages/api-client/src/conversation/NewConversation.ts
@@ -21,6 +21,7 @@ import {Conversation} from './Conversation';
 import {DefaultConversationRoleName} from './ConversationRole';
 import {RECEIPT_MODE} from './data/ConversationReceiptModeUpdateData';
 
+import {MLSPublicKeyRecord} from '../client';
 import {TeamInfo} from '../team/';
 import {QualifiedId} from '../user/';
 
@@ -38,4 +39,7 @@ export interface NewConversation
   protocol?: ConversationProtocol;
   team?: TeamInfo;
   users?: string[]; // users must be empty for creating MLS conversations
+  public_key?: {
+    removal: MLSPublicKeyRecord;
+  };
 }

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -436,7 +436,7 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(1);
-      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser, undefined);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });
@@ -474,10 +474,12 @@ describe('ConversationService', () => {
 
       // The 3rd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: updatedEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: updatedEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'register1to1Conversation').mockRejectedValueOnce(undefined);
@@ -491,7 +493,7 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(2);
-      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser, undefined);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -334,10 +334,12 @@ describe('ConversationService', () => {
       const remoteEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: remoteEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: remoteEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(true);
 
@@ -361,18 +363,22 @@ describe('ConversationService', () => {
       const updatedEpoch = 2;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: remoteEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: remoteEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make after joining the conversation with external commit
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: updatedEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: updatedEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(false);
@@ -402,18 +408,22 @@ describe('ConversationService', () => {
       const updatedEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: remoteEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: remoteEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: updatedEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: updatedEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'wipeConversation');
@@ -444,18 +454,22 @@ describe('ConversationService', () => {
       const updatedEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: remoteEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: remoteEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make when retrying to register the conversation
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        qualified_id: mockConversationId,
-        protocol: ConversationProtocol.MLS,
-        epoch: remoteEpoch,
-        group_id: mockGroupId,
+        conversation: {
+          qualified_id: mockConversationId,
+          protocol: ConversationProtocol.MLS,
+          epoch: remoteEpoch,
+          group_id: mockGroupId,
+        },
       } as unknown as MLS1to1Conversation);
 
       // The 3rd request we make after successfully registering a group

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -21,7 +21,7 @@ import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client';
 import {
   Conversation,
   ConversationProtocol,
-  MLS1to1Conversation,
+  MLSConversation,
   Subconversation,
   SUBCONVERSATION_ID,
 } from '@wireapp/api-client/lib/conversation';
@@ -338,7 +338,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(true);
 
       await conversationService.establishMLS1to1Conversation(mockGroupId, selfUser, otherUserId);
@@ -365,7 +365,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       // The 2nd request we make after joining the conversation with external commit
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -373,7 +373,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: updatedEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(false);
       jest.spyOn(mlsService, 'joinByExternalCommit').mockResolvedValueOnce({events: [], time: ''});
@@ -406,7 +406,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       // The 2nd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -414,7 +414,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: updatedEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       jest.spyOn(mlsService, 'wipeConversation');
 
@@ -448,7 +448,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       // The 2nd request we make when retrying to register the conversation
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -456,7 +456,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       // The 3rd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -464,7 +464,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: updatedEpoch,
         group_id: mockGroupId,
-      } as unknown as MLS1to1Conversation);
+      } as unknown as MLSConversation);
 
       jest.spyOn(mlsService, 'register1to1Conversation').mockRejectedValueOnce(undefined);
       jest.spyOn(mlsService, 'wipeConversation');

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -426,7 +426,7 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(1);
-      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser, undefined);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });
@@ -477,7 +477,7 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(2);
-      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser, undefined);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -21,7 +21,7 @@ import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client';
 import {
   Conversation,
   ConversationProtocol,
-  MLSConversation,
+  MLS1to1Conversation,
   Subconversation,
   SUBCONVERSATION_ID,
 } from '@wireapp/api-client/lib/conversation';
@@ -338,7 +338,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(true);
 
       await conversationService.establishMLS1to1Conversation(mockGroupId, selfUser, otherUserId);
@@ -365,7 +365,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make after joining the conversation with external commit
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -373,7 +373,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: updatedEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(false);
       jest.spyOn(mlsService, 'joinByExternalCommit').mockResolvedValueOnce({events: [], time: ''});
@@ -406,7 +406,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -414,7 +414,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: updatedEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'wipeConversation');
 
@@ -448,7 +448,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make when retrying to register the conversation
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -456,7 +456,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: remoteEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       // The 3rd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
@@ -464,7 +464,7 @@ describe('ConversationService', () => {
         protocol: ConversationProtocol.MLS,
         epoch: updatedEpoch,
         group_id: mockGroupId,
-      } as unknown as MLSConversation);
+      } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'register1to1Conversation').mockRejectedValueOnce(undefined);
       jest.spyOn(mlsService, 'wipeConversation');

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -334,12 +334,10 @@ describe('ConversationService', () => {
       const remoteEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: remoteEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(true);
 
@@ -363,22 +361,18 @@ describe('ConversationService', () => {
       const updatedEpoch = 2;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: remoteEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make after joining the conversation with external commit
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: updatedEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: updatedEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'isConversationEstablished').mockResolvedValueOnce(false);
@@ -408,22 +402,18 @@ describe('ConversationService', () => {
       const updatedEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: remoteEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: updatedEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: updatedEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'wipeConversation');
@@ -454,22 +444,18 @@ describe('ConversationService', () => {
       const updatedEpoch = 1;
 
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: remoteEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       // The 2nd request we make when retrying to register the conversation
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: remoteEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: remoteEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       // The 3rd request we make after successfully registering a group

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -436,7 +436,7 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(1);
-      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser, undefined);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });
@@ -474,12 +474,10 @@ describe('ConversationService', () => {
 
       // The 3rd request we make after successfully registering a group
       jest.spyOn(apiClient.api.conversation, 'getMLS1to1Conversation').mockResolvedValueOnce({
-        conversation: {
-          qualified_id: mockConversationId,
-          protocol: ConversationProtocol.MLS,
-          epoch: updatedEpoch,
-          group_id: mockGroupId,
-        },
+        qualified_id: mockConversationId,
+        protocol: ConversationProtocol.MLS,
+        epoch: updatedEpoch,
+        group_id: mockGroupId,
       } as unknown as MLS1to1Conversation);
 
       jest.spyOn(mlsService, 'register1to1Conversation').mockRejectedValueOnce(undefined);
@@ -493,7 +491,7 @@ describe('ConversationService', () => {
 
       expect(mlsService.wipeConversation).toHaveBeenCalledWith(mockGroupId);
       expect(mlsService.register1to1Conversation).toHaveBeenCalledTimes(2);
-      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser, undefined);
+      expect(mlsService.register1to1Conversation).toHaveBeenCalledWith(mockGroupId, otherUserId, selfUser);
       expect(conversationService.joinByExternalCommit).not.toHaveBeenCalled();
       expect(establishedConversation.epoch).toEqual(updatedEpoch);
     });

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -537,12 +537,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * @param userId - qualified user id
    */
   async getMLS1to1Conversation(userId: QualifiedId) {
-    const response = await this.apiClient.api.conversation.getMLS1to1Conversation(userId);
+    const conversation = await this.apiClient.api.conversation.getMLS1to1Conversation(userId);
 
     if (isMLS1to1Conversation(response)) {
-      return response;
+      return conversation;
     }
-    return {conversation: response};
+    return {conversation};
   }
 
   /**

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -29,6 +29,7 @@ import {
   MLSConversation,
   SUBCONVERSATION_ID,
   Subconversation,
+  isMLS1to1Conversation,
 } from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_TYPING, ConversationMemberUpdateData} from '@wireapp/api-client/lib/conversation/data';
 import {
@@ -536,7 +537,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * @param userId - qualified user id
    */
   async getMLS1to1Conversation(userId: QualifiedId) {
-    return this.apiClient.api.conversation.getMLS1to1Conversation(userId);
+    const response = await this.apiClient.api.conversation.getMLS1to1Conversation(userId);
+
+    if (isMLS1to1Conversation(response)) {
+      return response;
+    }
+    return {conversation: response};
   }
 
   /**

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -539,7 +539,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   async getMLS1to1Conversation(userId: QualifiedId) {
     const conversation = await this.apiClient.api.conversation.getMLS1to1Conversation(userId);
 
-    if (isMLS1to1Conversation(response)) {
+    if (isMLS1to1Conversation(conversation)) {
       return conversation;
     }
     return {conversation};

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -29,6 +29,7 @@ import {
   MLSConversation,
   SUBCONVERSATION_ID,
   Subconversation,
+  MLS1on1Conversation,
 } from '@wireapp/api-client/lib/conversation';
 import {CONVERSATION_TYPING, ConversationMemberUpdateData} from '@wireapp/api-client/lib/conversation/data';
 import {
@@ -552,7 +553,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
     selfUser: {user: QualifiedId; client: string},
     otherUserId: QualifiedId,
     shouldRetry = true,
-  ): Promise<MLSConversation> => {
+  ): Promise<MLS1on1Conversation> => {
     this.logger.debug(`Trying to establish a MLS 1:1 conversation with user ${otherUserId.id}...`);
 
     // Before trying to register a group, check if the group is already established o backend.
@@ -588,7 +589,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
     await this.mlsService.wipeConversation(groupId);
 
     try {
-      await this.mlsService.register1to1Conversation(groupId, otherUserId, selfUser);
+      await this.mlsService.register1to1Conversation(
+        groupId,
+        otherUserId,
+        selfUser,
+        mlsConversation.public_keys.removal,
+      );
 
       this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) established successfully.`);
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -587,7 +587,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
       );
 
       await this.joinByExternalCommit(mlsConversation.qualified_id);
-      return (await this.getMLS1to1Conversation(otherUserId)).conversation;
+      const {conversation: updatedMLSConversation} = await this.getMLS1to1Conversation(otherUserId);
+      return updatedMLSConversation;
     }
 
     // If group is not established on backend,
@@ -599,7 +600,8 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
       this.logger.info(`Conversation (id ${mlsConversation.qualified_id.id}) established successfully.`);
 
-      return (await this.getMLS1to1Conversation(otherUserId)).conversation;
+      const {conversation: updatedMLSConversation} = await this.getMLS1to1Conversation(otherUserId);
+      return updatedMLSConversation;
     } catch (error) {
       if (!shouldRetry) {
         this.logger.error(`Could not register MLS group with id ${groupId}: `, error);

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -151,46 +151,6 @@ export class SubconversationService extends TypedEventEmitter<Events> {
     await this.clearSubconversationGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
   }
 
-  /**
-   * Short term solution to an issues with 1:1 MLS call, see
-   * https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1314750477/2024-07-29+1+1+calls+over+SFT#Do-not-leave-the-subconversation
-   * Will delete a conference subconversation when hanging up on a 1:1 call instead of leaving.
-   *
-   * @param conversationId Id of the parent conversation which subconversation we want to leave
-   */
-  public async leave1on1ConferenceSubconversation(conversationId: QualifiedId): Promise<void> {
-    const subconversationGroupId = await this.getSubconversationGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
-
-    if (!subconversationGroupId) {
-      return;
-    }
-
-    const doesGroupExistLocally = await this.mlsService.conversationExists(subconversationGroupId);
-    if (!doesGroupExistLocally) {
-      // If the subconversation was known by a client but is does not exist locally, we can remove it from the store.
-      return this.clearSubconversationGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
-    }
-
-    try {
-      const epochInfo = await this.getSubconversationEpochInfo(conversationId, subconversationGroupId);
-
-      if (!epochInfo) {
-        throw new Error('Failed to get epoch info for conference subconversation');
-      }
-      await this.apiClient.api.conversation.deleteSubconversation(conversationId, SUBCONVERSATION_ID.CONFERENCE, {
-        groupId: subconversationGroupId,
-        epoch: epochInfo.epoch,
-      });
-    } catch (error) {
-      this.logger.error(`Failed to delete conference subconversation:`, error);
-    }
-
-    await this.mlsService.wipeConversation(subconversationGroupId);
-
-    // once we've deleted the subconversation, we can remove it from the store
-    await this.clearSubconversationGroupId(conversationId, SUBCONVERSATION_ID.CONFERENCE);
-  }
-
   public async leaveStaleConferenceSubconversations(): Promise<void> {
     const conversationIds = await this.getAllGroupIdsBySubconversationId(SUBCONVERSATION_ID.CONFERENCE);
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import type {ClaimedKeyPackages, RegisteredClient} from '@wireapp/api-client/lib/client';
+import type {ClaimedKeyPackages, MLSPublicKeyRecord, RegisteredClient} from '@wireapp/api-client/lib/client';
 import {PostMlsMessageResponse, SUBCONVERSATION_ID} from '@wireapp/api-client/lib/conversation';
 import {ConversationMLSMessageAddEvent, ConversationMLSWelcomeEvent} from '@wireapp/api-client/lib/event';
 import {BackendError, StatusCode} from '@wireapp/api-client/lib/http';
@@ -471,7 +471,11 @@ export class MLSService extends TypedEventEmitter<Events> {
    * @param groupId the id of the group to create inside of coreCrypto
    * @param parentGroupId in case the conversation is a subconversation, the id of the parent conversation
    */
-  public async registerEmptyConversation(groupId: string, parentGroupId?: string): Promise<void> {
+  public async registerEmptyConversation(
+    groupId: string,
+    parentGroupId?: string,
+    removalKeyFor1to1Signature?: MLSPublicKeyRecord,
+  ): Promise<void> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     let externalSenders: Uint8Array[] = [];
@@ -481,7 +485,9 @@ export class MLSService extends TypedEventEmitter<Events> {
     } else {
       const mlsKeys = (await this.apiClient.api.client.getPublicKeys()).removal;
       const ciphersuiteSignature = getSignatureAlgorithmForCiphersuite(this.config.defaultCiphersuite);
-      const removalKeyForSignature = mlsKeys[ciphersuiteSignature];
+      const removalKeyForSignature = removalKeyFor1to1Signature
+        ? removalKeyFor1to1Signature[ciphersuiteSignature]
+        : mlsKeys[ciphersuiteSignature];
       if (!removalKeyForSignature) {
         throw new Error(
           `Cannot create conversation: No backend removal key found for the signature ${ciphersuiteSignature}`,
@@ -559,9 +565,10 @@ export class MLSService extends TypedEventEmitter<Events> {
     groupId: string,
     userId: QualifiedId,
     selfUser: {user: QualifiedId; client: string},
+    removalKeyFor1to1Signature?: MLSPublicKeyRecord,
   ): Promise<PostMlsMessageResponse & {failures: AddUsersFailure[]}> {
     try {
-      await this.registerEmptyConversation(groupId);
+      await this.registerEmptyConversation(groupId, undefined, removalKeyFor1to1Signature);
 
       // We fist fetch key packages for the user we want to add
       const {keyPackages: otherUserKeyPackages, failures: otherUserKeysClaimingFailures} =

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -485,9 +485,8 @@ export class MLSService extends TypedEventEmitter<Events> {
     } else {
       const mlsKeys = (await this.apiClient.api.client.getPublicKeys()).removal;
       const ciphersuiteSignature = getSignatureAlgorithmForCiphersuite(this.config.defaultCiphersuite);
-      const removalKeyForSignature = removalKeyFor1to1Signature
-        ? removalKeyFor1to1Signature[ciphersuiteSignature]
-        : mlsKeys[ciphersuiteSignature];
+      const removalKeyForSignature =
+        removalKeyFor1to1Signature?.[ciphersuiteSignature] ?? mlsKeys[ciphersuiteSignature];
       if (!removalKeyForSignature) {
         throw new Error(
           `Cannot create conversation: No backend removal key found for the signature ${ciphersuiteSignature}`,


### PR DESCRIPTION
## Description

See https://wearezeta.atlassian.net/browse/WPB-10737 for a more in depth description of the issue.

In a nutshell, it's possible for a federated user to create a 1:1 conversation even if it's not hosted on their own backend, in which case it can introduce a host of issues because they're lacking the correct removal key.

to address that issue, the response from the endpoint `GET /conversations/one2one/{domain}/{userId}` was changed to include that removal key, from
```
{ <conversation metadata> }
```
to
```
{
  "conversation": { <conversation metadata> },
  "public_keys": {
    "removal": {
      "<sig-algo>": "string",
      ...
    }
  }
}
```

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ