### PR TITLE
fix(react-ui-kit): input autocomplete background color [WPB-9764]

### DIFF
--- a/packages/react-ui-kit/src/Form/Input.md
+++ b/packages/react-ui-kit/src/Form/Input.md
@@ -9,7 +9,6 @@ const [value, setValue] = useState('');
 <>
   <form>
     <Input
-      id="modal_pswd"
       type="password"
       label="Password"
       autocomplete="on"

--- a/packages/react-ui-kit/src/Form/Input.md
+++ b/packages/react-ui-kit/src/Form/Input.md
@@ -1,0 +1,21 @@
+Demo:
+
+```js
+import {Input} from '@wireapp/react-ui-kit';
+import {useState} from 'react';
+
+const [value, setValue] = useState('');
+
+<>
+  <form>
+    <Input
+      id="modal_pswd"
+      type="password"
+      label="Password"
+      autocomplete="on"
+      value={value}
+      onChange={event => setValue(event.currentTarget.value)}
+    />
+  </form>
+</>;
+```

--- a/packages/react-ui-kit/src/Form/Input.tsx
+++ b/packages/react-ui-kit/src/Form/Input.tsx
@@ -52,6 +52,13 @@ export const inputStyle: <T>(theme: Theme, props: InputProps<T>, hasError?: bool
     textTransform: placeholderTextTransform,
   };
 
+  const defaultBoxShadow = `0 0 0 1px ${theme.Select.borderColor}`;
+  const hoverBoxShadow = `0 0 0 1px ${theme.Input.borderHover}`;
+  const activeBoxShadow = `0 0 0 1px ${theme.general.primaryColor}`;
+  // The autocomplete box shadow is used as a workaround for the autofill background color
+  // The value (24px) is hardcoded to match the input background
+  const autocompleteBoxShadow = `0 0 0 24px ${theme.Input.backgroundAutocomplete} inset`;
+
   return {
     '&::-moz-placeholder': {
       ...placeholderStyle,
@@ -64,20 +71,35 @@ export const inputStyle: <T>(theme: Theme, props: InputProps<T>, hasError?: bool
       ...placeholderStyle,
     },
     '&:hover': {
-      boxShadow: !disabled && `0 0 0 1px ${theme.Input.borderHover}`,
+      boxShadow: !disabled && hoverBoxShadow,
     },
     '&:focus-visible, &:focus, &:active': {
-      boxShadow: `0 0 0 1px ${theme.general.primaryColor}`,
+      boxShadow: activeBoxShadow,
     },
     '&:invalid:not(:focus, :hover)': !markInvalid
       ? {
-          boxShadow: `0 0 0 1px ${theme.Select.borderColor}`,
+          boxShadow: defaultBoxShadow,
         }
       : {},
+    '&:-webkit-autofill': {
+      boxShadow: `${defaultBoxShadow}, ${autocompleteBoxShadow}`,
+      '-webkit-text-fill-color': theme.general.color,
+      '&:hover': {
+        boxShadow: !disabled && `${hoverBoxShadow}, ${autocompleteBoxShadow}`,
+      },
+      '&:focus-visible, &:focus, &:active': {
+        boxShadow: `${activeBoxShadow}, ${autocompleteBoxShadow}`,
+      },
+      '&:invalid:not(:focus, :hover)': !markInvalid
+        ? {
+            boxShadow: `${defaultBoxShadow}, ${autocompleteBoxShadow}`,
+          }
+        : {},
+    },
     background: disabled ? theme.Input.backgroundColorDisabled : theme.Input.backgroundColor,
     border: 'none',
     borderRadius: '12px',
-    boxShadow: markInvalid ? `0 0 0 1px ${theme.general.dangerColor}` : `0 0 0 1px ${theme.Select.borderColor}`,
+    boxShadow: markInvalid ? `0 0 0 1px ${theme.general.dangerColor}` : defaultBoxShadow,
     caretColor: theme.general.primaryColor,
     color: theme.general.color,
     fontWeight: 400,

--- a/packages/react-ui-kit/src/Form/__snapshots__/Input.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Input.test.tsx.snap
@@ -68,6 +68,25 @@ exports[`"Input" renders 1`] = `
   box-shadow: 0 0 0 1px #dce0e3;
 }
 
+.emotion-3:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-3:-webkit-autofill:hover {
+  box-shadow: 0 0 0 1px var(--text-input-border-hover),0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-3:-webkit-autofill:focus-visible,
+.emotion-3:-webkit-autofill:focus,
+.emotion-3:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-3:-webkit-autofill:invalid:not(:focus, :hover) {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+}
+
 <div
   className="emotion-0"
 >
@@ -147,6 +166,21 @@ exports[`"Input" renders as disabled 1`] = `
 
 .emotion-3:invalid:not(:focus, :hover) {
   box-shadow: 0 0 0 1px #dce0e3;
+}
+
+.emotion-3:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-3:-webkit-autofill:focus-visible,
+.emotion-3:-webkit-autofill:focus,
+.emotion-3:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-3:-webkit-autofill:invalid:not(:focus, :hover) {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
 }
 
 <div
@@ -229,6 +263,21 @@ exports[`"Input" renders as invalid 1`] = `
 .emotion-3:focus,
 .emotion-3:active {
   box-shadow: 0 0 0 1px #0667c8;
+}
+
+.emotion-3:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-3:-webkit-autofill:hover {
+  box-shadow: 0 0 0 1px var(--text-input-border-hover),0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-3:-webkit-autofill:focus-visible,
+.emotion-3:-webkit-autofill:focus,
+.emotion-3:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
 }
 
 <div
@@ -314,6 +363,25 @@ exports[`"Input" renders with placeholderTextTransform 1`] = `
 
 .emotion-3:invalid:not(:focus, :hover) {
   box-shadow: 0 0 0 1px #dce0e3;
+}
+
+.emotion-3:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-3:-webkit-autofill:hover {
+  box-shadow: 0 0 0 1px var(--text-input-border-hover),0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-3:-webkit-autofill:focus-visible,
+.emotion-3:-webkit-autofill:focus,
+.emotion-3:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-3:-webkit-autofill:invalid:not(:focus, :hover) {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
 }
 
 <div

--- a/packages/react-ui-kit/src/Form/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-ui-kit/src/Form/__snapshots__/Select.test.tsx.snap
@@ -66,6 +66,25 @@ exports[`"Select" renders 1`] = `
   box-shadow: 0 0 0 1px #dce0e3;
 }
 
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:hover {
+  box-shadow: 0 0 0 1px var(--text-input-border-hover),0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:focus-visible,
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:focus,
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:invalid:not(:focus, :hover) {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+}
+
 .emotion-2>div>div[class$="-Control"]:focus:visible,
 .emotion-2>div>div[class$="-Control"] active {
   box-shadow: 0 0 0 1px #0667c8;
@@ -359,6 +378,21 @@ exports[`"Select" renders as disabled 1`] = `
   box-shadow: 0 0 0 1px #dce0e3;
 }
 
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:focus-visible,
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:focus,
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:invalid:not(:focus, :hover) {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+}
+
 .emotion-2>div {
   padding: 0;
   height: auto;
@@ -650,6 +684,21 @@ exports[`"Select" renders as invalid 1`] = `
 .emotion-2>div>div[class$="-Control"]:focus,
 .emotion-2>div>div[class$="-Control"]:active {
   box-shadow: 0 0 0 1px #0667c8;
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill {
+  box-shadow: 0 0 0 1px #dce0e3,0 0 0 24px #e7f0fa inset;
+  -webkit-text-fill-color: rgb(29, 30, 31);
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:hover {
+  box-shadow: 0 0 0 1px var(--text-input-border-hover),0 0 0 24px #e7f0fa inset;
+}
+
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:focus-visible,
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:focus,
+.emotion-2>div>div[class$="-Control"]:-webkit-autofill:active {
+  box-shadow: 0 0 0 1px #0667c8,0 0 0 24px #e7f0fa inset;
 }
 
 .emotion-2>div>div[class$="-Control"]:focus:visible,

--- a/packages/react-ui-kit/src/Theme/GlobalCssVariables.tsx
+++ b/packages/react-ui-kit/src/Theme/GlobalCssVariables.tsx
@@ -55,6 +55,7 @@ const light: () => CSSObject = () => ({
   '--text-input-placeholder': COLOR_V2.GRAY_70,
   '--text-input-disabled': COLOR_V2.GRAY_20,
   '--text-input-label': COLOR_V2.GRAY_80,
+  '--text-input-autocomplete-background': COLOR_V2.BLUE_LIGHT_50,
 
   // Select
   '--select-focused-description': COLOR_V2.WHITE,
@@ -104,6 +105,7 @@ const dark: () => CSSObject = () => ({
   '--text-input-placeholder': COLOR_V2.GRAY_60,
   '--text-input-disabled': COLOR_V2.GRAY_100,
   '--text-input-label': COLOR_V2.GRAY_40,
+  '--text-input-autocomplete-background': COLOR_V2.BLUE_LIGHT_900,
 
   // Select
   '--select-focused-description': COLOR_V2.GRAY_40,

--- a/packages/react-ui-kit/src/Theme/Theme.tsx
+++ b/packages/react-ui-kit/src/Theme/Theme.tsx
@@ -101,6 +101,7 @@ export interface Theme extends ETheme {
   Input: {
     backgroundColor: string;
     backgroundColorDisabled: string;
+    backgroundAutocomplete: string;
     placeholderColor: string;
     labelColor: string;
     borderHover: string;
@@ -165,6 +166,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
     Input: {
       backgroundColor: 'var(--text-input-background)',
       backgroundColorDisabled: 'var(--text-input-disabled)',
+      backgroundAutocomplete: 'var(--text-input-autocomplete-background)',
       labelColor: 'var(--text-input-label)',
       placeholderColor: 'var(--text-input-placeholder)',
       borderHover: 'var(--text-input-border-hover)',
@@ -240,6 +242,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
     Input: {
       backgroundColor: COLOR.WHITE,
       backgroundColorDisabled: COLOR_V2.GRAY_20,
+      backgroundAutocomplete: COLOR_V2.BLUE_LIGHT_50,
       placeholderColor: COLOR.GRAY_DARKEN_24,
       labelColor: COLOR_V2.GRAY_80,
       borderHover: 'var(--text-input-border-hover)',
@@ -315,6 +318,7 @@ export const themes: {[themeId in THEME_ID]: Theme} = {
     Input: {
       backgroundColor: COLOR.BLACK_LIGHTEN_24,
       backgroundColorDisabled: COLOR.GRAY_100,
+      backgroundAutocomplete: COLOR_V2.BLUE_LIGHT_900,
       placeholderColor: COLOR.GRAY_LIGHTEN_88,
       labelColor: COLOR_V2.GRAY_40,
       borderHover: 'var(--text-input-border-hover)',

--- a/packages/react-ui-kit/styleguide.config.js
+++ b/packages/react-ui-kit/styleguide.config.js
@@ -33,7 +33,6 @@ module.exports = {
       components: 'src/Form/**/*.tsx',
       ignore: [
         'src/Form/ShakeBox.tsx',
-        'src/Form/Input.tsx',
         'src/Form/InputBlock.tsx',
         'src/Form/RoundIconButton.tsx',
         'src/Form/InputSubmitCombo.tsx',


### PR DESCRIPTION
## Description

https://wearezeta.atlassian.net/browse/WPB-9764

We have a problem with autocomplete styles. In the task there's an example of it:

![image](https://github.com/user-attachments/assets/5e454ab2-ec13-41d6-b686-c1b32b316e66)

On the screen above, you almost can't see the "show password" (eye icon) button. This is because the browser injects its own styles for the autocomplete (in this case, a yellow background).

The yellow background isn't always there, e.g. I have a nice blue color in my Chrome browser:

<img width="450" alt="Screenshot 2024-10-09 at 12 25 33" src="https://github.com/user-attachments/assets/2e4b1e43-1a68-4702-9215-a5e74103417c">

But it doesn't look good in the dark mode:

<img width="432" alt="Screenshot 2024-10-09 at 12 34 40" src="https://github.com/user-attachments/assets/014cc2c0-9463-4adf-9aa1-08849ce33499">

---

To unify the experience, we could set our background when the user uses the autocomplete browser feature. I did exactly this in this PR. 


Light mode:

https://github.com/user-attachments/assets/5aa057be-8ba8-47d4-9886-5333567c41de

Dark mode:


https://github.com/user-attachments/assets/981fe061-b24e-4ece-9859-f99fdcb4289d


I've tested it in Chrome, Firefox, and Safari - it works well everywhere.


## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ