### PR TITLE
feat(team-inv-info): add created_by_email in TeamInvitation type [WPB-12142]

### DIFF
--- a/packages/api-client/src/team/invitation/TeamInvitation.ts
+++ b/packages/api-client/src/team/invitation/TeamInvitation.ts
@@ -22,6 +22,7 @@ import {Role} from '../member';
 export interface TeamInvitation {
   created_at: string;
   created_by: string;
+  created_by_email: string;
   email: string;
   id: string;
   name?: string;


### PR DESCRIPTION
## Description

Added property created_by_email in TeamInvitation (info) type.
BE PR refferrence: https://github.com/wireapp/wire-server/pull/4332

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ