### PR TITLE
fix(telemetry): version

### DIFF
--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -13,7 +13,7 @@
       "default": "./lib/index.cjs"
     }
   },
-  "version": "0.2.0",
+  "version": "0.0.0",
   "devDependencies": {
     "@types/node": "^22.0.0",
     "rimraf": "6.0.1",


### PR DESCRIPTION
## Description

Due to failing first release of the telemetry package, changing the version to be `0.0.0`, maybe then the CI will know that there's no package like that in the registry yet.

https://github.com/wireapp/wire-web-packages/actions/runs/11797832352/job/32862666948

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ