### PR TITLE
fix(react-ui-kit): fix content inside tooltip [WPB-11596]

### DIFF
--- a/packages/react-ui-kit/src/Form/Tooltip.tsx
+++ b/packages/react-ui-kit/src/Form/Tooltip.tsx
@@ -60,6 +60,7 @@ const tooltipStyle: (theme: Theme) => CSSObject = theme => ({
     fontWeight: 400,
     padding: `${paddingDistance}px 8px`,
     textAlign: 'center',
+    overflowWrap: 'break-word',
   },
 
   '.tooltip-arrow': {


### PR DESCRIPTION
## Description
Long words in the tooltip should break onto new lines

## Screenshots/Screencast (for UI changes)
![Screenshot 2024-11-13 at 09 52 28](https://github.com/user-attachments/assets/666132a5-2640-43bd-baa6-a06d9617400b)

## Checklist
- [x] mentions the JIRA issue in the PR name (Ex. [WPB-423])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->


[WPB-423]: https://wearezeta.atlassian.net/browse/WPB-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ