### PR TITLE
feat(commons): Add support for plain text logging

### DIFF
--- a/packages/commons/src/LogFactory.ts
+++ b/packages/commons/src/LogFactory.ts
@@ -32,6 +32,7 @@ export interface LoggerOptions {
   logFilePath?: string;
   namespace?: string;
   separator?: string;
+  plaintext?: boolean;
 }
 
 export class LogFactory {
@@ -94,6 +95,7 @@ export class LogFactory {
       logFilePath: '',
       namespace: '',
       separator: '::',
+      plaintext: false,
     };
     const config: LoggerOptions = {...defaults, ...options};
 
@@ -106,6 +108,7 @@ export class LogFactory {
     const logger = logdown(loggerName, {
       logger: console,
       markdown: false,
+      plaintext: config.plaintext,
       prefixColor: config.color,
     });
 


### PR DESCRIPTION
## Description

Implementation of a feature a previous web team member of Wire, @ffflorian added to logdown library in https://github.com/caiogondim/logdown.js/pull/226 

This will help getting rid of [object object] and [object Event] in the log files for desktop