### PR TITLE
runfix: remove slashes from conversation and user api constants

### DIFF
--- a/packages/api-client/src/APIClient.test.ts
+++ b/packages/api-client/src/APIClient.test.ts
@@ -247,13 +247,13 @@ describe('APIClient', () => {
     it('refreshes an access token when it becomes invalid', async () => {
       const queriedHandle = 'webappbot';
 
-      nock(baseUrl).get(UserAPI.URL.USERS).query({handles: queriedHandle}).once().reply(StatusCode.FORBIDDEN, {
+      nock(baseUrl).get(`/${UserAPI.URL.USERS}`).query({handles: queriedHandle}).once().reply(StatusCode.FORBIDDEN, {
         code: StatusCode.FORBIDDEN,
         label: BackendErrorLabel.INVALID_CREDENTIALS,
         message: 'Token expired',
       });
 
-      nock(baseUrl).get(UserAPI.URL.USERS).query({handles: queriedHandle}).reply(StatusCode.OK, userData);
+      nock(baseUrl).get(`/${UserAPI.URL.USERS}`).query({handles: queriedHandle}).reply(StatusCode.OK, userData);
 
       nock(baseUrl).post(AuthAPI.URL.ACCESS).reply(StatusCode.OK, accessTokenData);
 

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -160,7 +160,7 @@ export class ConversationAPI {
       method: 'delete',
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
-          ? `${ConversationAPI.URL.BOT}/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${serviceId}`
+          ? `/${ConversationAPI.URL.BOT}/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${serviceId}`
           : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.BOTS}/${serviceId}`,
     };
 
@@ -500,7 +500,7 @@ export class ConversationAPI {
       method: 'post',
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
-          ? `${ConversationAPI.URL.BOT}/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}`
+          ? `/${ConversationAPI.URL.BOT}/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}`
           : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.BOTS}}`,
     };
 

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -91,14 +91,14 @@ export class ConversationAPI {
     ACCESS: 'access',
     BOT: 'bot',
     BOTS: 'bots',
-    CLIENTS: '/clients',
+    CLIENTS: 'clients',
     CODE: 'code',
-    CODE_CHECK: '/code-check',
-    CONVERSATIONS: '/conversations',
+    CODE_CHECK: 'code-check',
+    CONVERSATIONS: 'conversations',
     SUBCONVERSATIONS: 'subconversations',
     GROUP_INFO: 'groupinfo',
-    MLS: '/mls',
-    JOIN: '/join',
+    MLS: 'mls',
+    JOIN: 'join',
     LIST: 'list',
     LIST_IDS: 'list-ids',
     MEMBERS: 'members',
@@ -124,8 +124,8 @@ export class ConversationAPI {
 
   private generateBaseConversationUrl(conversationId: QualifiedId, supportsQualifiedEndpoint: boolean = true): string {
     return supportsQualifiedEndpoint && conversationId.domain
-      ? `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}`
-      : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}`;
+      ? `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}`
+      : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}`;
   }
 
   /**
@@ -136,7 +136,7 @@ export class ConversationAPI {
   public async deleteConversationCode(conversationId: string): Promise<ConversationCodeDeleteEvent> {
     const config: AxiosRequestConfig = {
       method: 'delete',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
     };
 
     const response = await this.client.sendJSON<ConversationCodeDeleteEvent>(config);
@@ -161,7 +161,7 @@ export class ConversationAPI {
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
           ? `${ConversationAPI.URL.BOT}/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${serviceId}`
-          : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.BOTS}/${serviceId}`,
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.BOTS}/${serviceId}`,
     };
 
     await this.client.sendJSON(config);
@@ -174,7 +174,7 @@ export class ConversationAPI {
    * @see https://staging-nginz-https.zinfra.io/api/swagger-ui/#/default/delete_conversations__cnv_domain___cnv__members__usr_domain___usr_
    */
   public async deleteMember(conversationId: QualifiedId, userId: QualifiedId): Promise<ConversationMemberLeaveEvent> {
-    const url = `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${userId.domain}/${userId.id}`;
+    const url = `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${userId.domain}/${userId.id}`;
 
     const response = await this.client.sendJSON<ConversationMemberLeaveEvent>({
       method: 'delete',
@@ -191,7 +191,7 @@ export class ConversationAPI {
   public async getConversationCode(conversationId: string): Promise<ConversationCode> {
     const config: AxiosRequestConfig = {
       method: 'GET',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
     };
 
     const response = await this.client.sendJSON<ConversationCode>(config);
@@ -205,7 +205,7 @@ export class ConversationAPI {
   public async getConversationGuestLinkFeature(conversationId: string): Promise<ConversationGuestLinkStatus> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/features/conversationGuestLinks`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/features/conversationGuestLinks`,
     };
 
     const response = await this.client.sendJSON<ConversationGuestLinkStatus>(config);
@@ -225,7 +225,7 @@ export class ConversationAPI {
   public async getMLSSelfConversation(): Promise<MLSConversation> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.MLS_SELF}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.MLS_SELF}`,
     };
 
     const response = await this.client.sendJSON<MLSConversation>(config);
@@ -301,7 +301,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: {},
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.LIST_IDS}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.LIST_IDS}`,
     };
 
     if (limit > 0) {
@@ -343,8 +343,8 @@ export class ConversationAPI {
         method: 'post',
         url:
           this.backendFeatures.version >= apiBreakpoint.version2
-            ? `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.LIST}`
-            : `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.LIST}/${ConversationAPI.URL.V2}`,
+            ? `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.LIST}`
+            : `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.LIST}/${ConversationAPI.URL.V2}`,
       };
 
       const {data} = await this.client.sendJSON<RemoteConversations>(config);
@@ -390,7 +390,7 @@ export class ConversationAPI {
   public async getRoles(conversationId: string): Promise<ConversationRolesList> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.ROLES}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.ROLES}`,
     };
 
     const response = await this.client.sendJSON<ConversationRolesList>(config);
@@ -424,7 +424,7 @@ export class ConversationAPI {
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
           ? `${ConversationAPI.URL.ONE_2_ONE}-${ConversationAPI.URL.CONVERSATIONS}`
-          : `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}`,
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}`,
     };
 
     await this.client.sendJSON(config);
@@ -440,7 +440,7 @@ export class ConversationAPI {
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
           ? `${ConversationAPI.URL.ONE_2_ONE}-${ConversationAPI.URL.CONVERSATIONS}/${domain}/${id}`
-          : `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}/${domain}/${id}`,
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.ONE_2_ONE}/${domain}/${id}`,
     };
 
     const response = await this.client.sendJSON<MLS1to1Conversation | MLSConversation>(config);
@@ -457,7 +457,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: invitationData,
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}`,
     };
 
     try {
@@ -501,7 +501,7 @@ export class ConversationAPI {
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
           ? `${ConversationAPI.URL.BOT}/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}`
-          : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.BOTS}}`,
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.BOTS}}`,
     };
 
     const response = await this.client.sendJSON<ConversationMemberJoinEvent>(config);
@@ -547,7 +547,7 @@ export class ConversationAPI {
   ): Promise<ConversationCodeUpdateEvent> {
     const config: AxiosRequestConfig = {
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.CODE}`,
       data: {},
     };
 
@@ -568,7 +568,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: conversationCode,
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}${ConversationAPI.URL.CODE_CHECK}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.CODE_CHECK}`,
     };
 
     try {
@@ -593,7 +593,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: conversationCode,
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}${ConversationAPI.URL.JOIN}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.JOIN}`,
     };
 
     try {
@@ -624,7 +624,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       params: conversationCode,
       method: 'get',
-      url: `${ConversationAPI.URL.CONVERSATIONS}${ConversationAPI.URL.JOIN}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.JOIN}`,
     };
 
     try {
@@ -649,7 +649,7 @@ export class ConversationAPI {
   public async postJoin(conversationId: string): Promise<ConversationEvent> {
     const config: AxiosRequestConfig = {
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}`,
     };
 
     const response = await this.client.sendJSON<ConversationEvent>(config);
@@ -690,7 +690,7 @@ export class ConversationAPI {
        */
       data: ProtobufOTR.QualifiedNewOtrMessage.encode(messageData).finish().slice(),
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${domain}/${conversationId}/${ConversationAPI.URL.PROTEUS}/${ConversationAPI.URL.MESSAGES}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${domain}/${conversationId}/${ConversationAPI.URL.PROTEUS}/${ConversationAPI.URL.MESSAGES}`,
     };
 
     const response = await this.client.sendProtocolBuffer<MessageSendingStatus>(config, true);
@@ -707,7 +707,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: messageData,
       method: 'post',
-      url: `${ConversationAPI.URL.MLS}/${ConversationAPI.URL.MESSAGES}`,
+      url: `/${ConversationAPI.URL.MLS}/${ConversationAPI.URL.MESSAGES}`,
     };
 
     const response = await this.client.sendProtocolMls<PostMlsMessageResponse>(config, true);
@@ -724,7 +724,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: messageData,
       method: 'post',
-      url: `${ConversationAPI.URL.MLS}/commit-bundles`,
+      url: `/${ConversationAPI.URL.MLS}/commit-bundles`,
     };
 
     const response = await this.client.sendProtocolMls<PostMlsMessageResponse>(config, true);
@@ -738,7 +738,7 @@ export class ConversationAPI {
   public async postSelf(): Promise<Conversation> {
     const config: AxiosRequestConfig = {
       method: 'post',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.SELF}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${ConversationAPI.URL.SELF}`,
     };
 
     const response = await this.client.sendJSON<Conversation>(config);
@@ -795,7 +795,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: conversationNameData,
       method: 'put',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.NAME}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.NAME}`,
     };
 
     const response = await this.client.sendJSON<ConversationRenameEvent>(config);
@@ -815,7 +815,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: messageTimerData,
       method: 'put',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}/${ConversationAPI.URL.MESSAGE_TIMER}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}/${ConversationAPI.URL.MESSAGE_TIMER}`,
     };
 
     const response = await this.client.sendJSON<ConversationMessageTimerUpdateEvent>(config);
@@ -857,7 +857,7 @@ export class ConversationAPI {
       url:
         this.backendFeatures.version >= 2
           ? `${this.generateBaseConversationUrl(conversationId)}/${ConversationAPI.URL.MEMBERS}`
-          : `${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${ConversationAPI.URL.V2}`,
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${ConversationAPI.URL.V2}`,
     };
 
     try {
@@ -892,7 +892,7 @@ export class ConversationAPI {
     const config: AxiosRequestConfig = {
       data: memberUpdateData,
       method: 'put',
-      url: `${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${userId}`,
+      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${userId}`,
     };
 
     await this.client.sendJSON<ConversationMemberJoinEvent>(config);

--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -74,27 +74,27 @@ export class UserAPI {
   public static readonly DEFAULT_USERS_CHUNK_SIZE = 50;
   public static readonly DEFAULT_USERS_PREKEY_BUNDLE_CHUNK_SIZE = 128;
   public static readonly URL = {
-    ACTIVATE: '/activate',
+    ACTIVATE: 'activate',
     BY_HANDLE: 'by-handle',
-    CALLS: '/calls',
+    CALLS: 'calls',
     CLIENTS: 'clients',
     CONFIG: 'config',
     CONTACTS: 'contacts',
-    DELETE: '/delete',
+    DELETE: 'delete',
     EMAIL: 'email',
     HANDLES: 'handles',
     LIST_CLIENTS: 'list-clients',
     LIST_PREKEYS: 'list-prekeys',
-    LIST_USERS: '/list-users',
-    PASSWORD_RESET: '/password-reset',
+    LIST_USERS: 'list-users',
+    PASSWORD_RESET: 'password-reset',
     PRE_KEYS: 'prekeys',
-    PROPERTIES: '/properties',
+    PROPERTIES: 'properties',
     RICH_INFO: 'rich-info',
-    SEARCH: '/search',
+    SEARCH: 'search',
     SEND: 'send',
-    USERS: '/users',
+    USERS: 'users',
     V2: 'v2',
-    VERIFICATION: '/verification-code',
+    VERIFICATION: 'verification-code',
     SUPPORTED_PROTOCOLS: 'supported-protocols',
   };
 
@@ -110,7 +110,7 @@ export class UserAPI {
   public async deleteProperties(): Promise<void> {
     const config: AxiosRequestConfig = {
       method: 'delete',
-      url: UserAPI.URL.PROPERTIES,
+      url: `/${UserAPI.URL.PROPERTIES}`,
     };
 
     await this.client.sendJSON(config);
@@ -124,7 +124,7 @@ export class UserAPI {
   public async deleteProperty(propertyKey: string): Promise<void> {
     const config: AxiosRequestConfig = {
       method: 'delete',
-      url: `${UserAPI.URL.PROPERTIES}/${propertyKey}`,
+      url: `/${UserAPI.URL.PROPERTIES}/${propertyKey}`,
     };
 
     await this.client.sendJSON(config);
@@ -143,7 +143,7 @@ export class UserAPI {
         code: activationCode,
         key: activationKey,
       },
-      url: UserAPI.URL.ACTIVATE,
+      url: `/${UserAPI.URL.ACTIVATE}`,
     };
 
     const response = await this.client.sendJSON<ActivationResponse>(config);
@@ -157,7 +157,7 @@ export class UserAPI {
   public async getCallsConfiguration(): Promise<RTCConfiguration> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${UserAPI.URL.CALLS}/${UserAPI.URL.CONFIG}`,
+      url: `/${UserAPI.URL.CALLS}/${UserAPI.URL.CONFIG}`,
     };
 
     const response = await this.client.sendJSON<RTCConfiguration>(config);
@@ -171,7 +171,7 @@ export class UserAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getUserClient
    */
   public async getClient(userId: QualifiedId, clientId: string): Promise<PublicClient> {
-    const url = `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`;
+    const url = `//${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -190,7 +190,7 @@ export class UserAPI {
    */
   public async getClientPreKey(userId: QualifiedId, clientId: string): Promise<ClientPreKey> {
     const {id, domain} = userId;
-    const url = `${UserAPI.URL.USERS}/${domain}/${id}/${UserAPI.URL.PRE_KEYS}/${clientId}`;
+    const url = `//${UserAPI.URL.USERS}/${domain}/${id}/${UserAPI.URL.PRE_KEYS}/${clientId}`;
     const config: AxiosRequestConfig = {
       method: 'get',
       url,
@@ -206,7 +206,7 @@ export class UserAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getUserClients
    */
   public async getClients(userId: QualifiedId): Promise<PublicClient[]> {
-    const url = `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`;
+    const url = `//${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -226,7 +226,7 @@ export class UserAPI {
   public async getHandle(handle: string): Promise<HandleInfo> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${UserAPI.URL.USERS}/${UserAPI.URL.HANDLES}/${handle}`,
+      url: `/${UserAPI.URL.USERS}/${UserAPI.URL.HANDLES}/${handle}`,
     };
 
     const response = await this.client.sendJSON<HandleInfo>(config);
@@ -240,7 +240,7 @@ export class UserAPI {
   public async getProperties(): Promise<string[]> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: UserAPI.URL.PROPERTIES,
+      url: `/${UserAPI.URL.PROPERTIES}`,
     };
 
     const response = await this.client.sendJSON<string[]>(config);
@@ -255,7 +255,7 @@ export class UserAPI {
   public async getProperty<T>(propertyKey: string): Promise<T> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${UserAPI.URL.PROPERTIES}/${propertyKey}`,
+      url: `/${UserAPI.URL.PROPERTIES}/${propertyKey}`,
     };
 
     const response = await this.client.sendJSON<T>(config);
@@ -281,7 +281,7 @@ export class UserAPI {
       params: {
         q: query,
       },
-      url: `${UserAPI.URL.SEARCH}/${UserAPI.URL.CONTACTS}`,
+      url: `/${UserAPI.URL.SEARCH}/${UserAPI.URL.CONTACTS}`,
     };
 
     if (domain) {
@@ -318,8 +318,8 @@ export class UserAPI {
   public async getUser(userId: string | QualifiedId): Promise<User> {
     const url =
       typeof userId === 'string'
-        ? `${UserAPI.URL.USERS}/${userId}`
-        : `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}`;
+        ? `/${UserAPI.URL.USERS}/${userId}`
+        : `/${UserAPI.URL.USERS}/${userId.domain}/${userId.id}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -331,7 +331,7 @@ export class UserAPI {
   }
 
   public async getUserPreKeys(userId: QualifiedId): Promise<PreKeyBundle> {
-    const url = `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.PRE_KEYS}`;
+    const url = `/${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.PRE_KEYS}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -343,7 +343,7 @@ export class UserAPI {
   }
 
   public async getUserSupportedProtocols(userId: QualifiedId): Promise<ConversationProtocol[]> {
-    const url = `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.SUPPORTED_PROTOCOLS}`;
+    const url = `/${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.SUPPORTED_PROTOCOLS}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -415,8 +415,8 @@ export class UserAPI {
   public async headUsers(userId: string | QualifiedId): Promise<void> {
     const url =
       typeof userId === 'string'
-        ? `${UserAPI.URL.USERS}/${userId}`
-        : `${UserAPI.URL.USERS}/${userId.domain}/${userId.id}`;
+        ? `/${UserAPI.URL.USERS}/${userId}`
+        : `/${UserAPI.URL.USERS}/${userId.domain}/${userId.id}`;
 
     const config: AxiosRequestConfig = {
       method: 'head',
@@ -436,7 +436,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: activationData,
       method: 'post',
-      url: UserAPI.URL.ACTIVATE,
+      url: `/${UserAPI.URL.ACTIVATE}`,
     };
 
     const response = await this.client.sendJSON<ActivationResponse>(config);
@@ -452,7 +452,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: activationCodeData,
       method: 'post',
-      url: `${UserAPI.URL.ACTIVATE}/${UserAPI.URL.SEND}`,
+      url: `/${UserAPI.URL.ACTIVATE}/${UserAPI.URL.SEND}`,
     };
 
     await this.client.sendJSON(config);
@@ -467,7 +467,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: {email, action},
       method: 'post',
-      url: `${UserAPI.URL.VERIFICATION}/${UserAPI.URL.SEND}`,
+      url: `/${UserAPI.URL.VERIFICATION}/${UserAPI.URL.SEND}`,
     };
     await this.client.sendJSON(config);
   }
@@ -481,7 +481,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: verificationData,
       method: 'post',
-      url: UserAPI.URL.DELETE,
+      url: `/${UserAPI.URL.DELETE}`,
     };
 
     await this.client.sendJSON(config);
@@ -498,8 +498,8 @@ export class UserAPI {
       method: 'post',
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
-          ? `${UserAPI.URL.HANDLES}`
-          : `${UserAPI.URL.USERS}/${UserAPI.URL.HANDLES}`,
+          ? `/${UserAPI.URL.HANDLES}`
+          : `/${UserAPI.URL.USERS}/${UserAPI.URL.HANDLES}`,
     };
 
     const response = await this.client.sendJSON<string[]>(config);
@@ -516,8 +516,8 @@ export class UserAPI {
       method: 'head',
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
-          ? `${UserAPI.URL.HANDLES}/${handle}`
-          : `${UserAPI.URL.USERS}/${UserAPI.URL.HANDLES}/${handle}`,
+          ? `/${UserAPI.URL.HANDLES}/${handle}`
+          : `/${UserAPI.URL.USERS}/${UserAPI.URL.HANDLES}/${handle}`,
     };
 
     await this.client.sendJSON(config);
@@ -531,7 +531,7 @@ export class UserAPI {
   public async getUserByHandle(handle: QualifiedHandle): Promise<User> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${UserAPI.URL.USERS}/${UserAPI.URL.BY_HANDLE}/${handle.domain}/${handle.handle}`,
+      url: `/${UserAPI.URL.USERS}/${UserAPI.URL.BY_HANDLE}/${handle.domain}/${handle.handle}`,
     };
 
     const response = await this.client.sendJSON<User>(config);
@@ -542,7 +542,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: userClientMap,
       method: 'post',
-      url: `${UserAPI.URL.USERS}/${UserAPI.URL.LIST_PREKEYS}`,
+      url: `/${UserAPI.URL.USERS}/${UserAPI.URL.LIST_PREKEYS}`,
     };
 
     const response = await this.client.sendJSON<QualifiedUserPreKeyBundleMap | PrekeysResponse>(config, true);
@@ -559,7 +559,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: users,
       method: 'post',
-      url: UserAPI.URL.LIST_USERS,
+      url: `/${UserAPI.URL.LIST_USERS}`,
     };
     try {
       /**
@@ -592,7 +592,7 @@ export class UserAPI {
         const {data: sameBackendUserData} = await this.client.sendJSON<User[]>({
           data: {qualified_ids: sameBackendUsers},
           method: 'post',
-          url: UserAPI.URL.LIST_USERS,
+          url: `/${UserAPI.URL.LIST_USERS}`,
         });
         return {found: sameBackendUserData, failed: federatedUsers};
       }
@@ -609,8 +609,8 @@ export class UserAPI {
       method: 'post',
       url:
         this.backendFeatures.version >= apiBreakpoint.version2
-          ? `${UserAPI.URL.USERS}/${UserAPI.URL.LIST_CLIENTS}`
-          : `${UserAPI.URL.USERS}/${UserAPI.URL.LIST_CLIENTS}/${UserAPI.URL.V2}`,
+          ? `/${UserAPI.URL.USERS}/${UserAPI.URL.LIST_CLIENTS}`
+          : `/${UserAPI.URL.USERS}/${UserAPI.URL.LIST_CLIENTS}/${UserAPI.URL.V2}`,
     };
 
     const response = await this.client.sendJSON<QualifiedPublicClients>(config);
@@ -677,7 +677,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: resetData,
       method: 'post',
-      url: UserAPI.URL.PASSWORD_RESET,
+      url: `/${UserAPI.URL.PASSWORD_RESET}`,
     };
 
     await this.client.sendJSON(config);
@@ -693,7 +693,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: propertyData,
       method: 'put',
-      url: `${UserAPI.URL.PROPERTIES}/${propertyKey}`,
+      url: `/${UserAPI.URL.PROPERTIES}/${propertyKey}`,
     };
 
     await this.client.sendJSON(config);
@@ -707,7 +707,7 @@ export class UserAPI {
   public async getRichInfo(userId: string): Promise<RichInfo> {
     const config: AxiosRequestConfig = {
       method: 'get',
-      url: `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.RICH_INFO}`,
+      url: `/${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.RICH_INFO}`,
     };
 
     const response = await this.client.sendJSON<RichInfo>(config);
@@ -723,7 +723,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: {email},
       method: 'put',
-      url: `${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.EMAIL}`,
+      url: `//${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.EMAIL}`,
     };
     await this.client.sendJSON(config);
   }

--- a/packages/api-client/src/user/UserAPI.ts
+++ b/packages/api-client/src/user/UserAPI.ts
@@ -171,7 +171,7 @@ export class UserAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getUserClient
    */
   public async getClient(userId: QualifiedId, clientId: string): Promise<PublicClient> {
-    const url = `//${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`;
+    const url = `/${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}/${clientId}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -190,7 +190,7 @@ export class UserAPI {
    */
   public async getClientPreKey(userId: QualifiedId, clientId: string): Promise<ClientPreKey> {
     const {id, domain} = userId;
-    const url = `//${UserAPI.URL.USERS}/${domain}/${id}/${UserAPI.URL.PRE_KEYS}/${clientId}`;
+    const url = `/${UserAPI.URL.USERS}/${domain}/${id}/${UserAPI.URL.PRE_KEYS}/${clientId}`;
     const config: AxiosRequestConfig = {
       method: 'get',
       url,
@@ -206,7 +206,7 @@ export class UserAPI {
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/users/getUserClients
    */
   public async getClients(userId: QualifiedId): Promise<PublicClient[]> {
-    const url = `//${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`;
+    const url = `/${UserAPI.URL.USERS}/${userId.domain}/${userId.id}/${UserAPI.URL.CLIENTS}`;
 
     const config: AxiosRequestConfig = {
       method: 'get',
@@ -723,7 +723,7 @@ export class UserAPI {
     const config: AxiosRequestConfig = {
       data: {email},
       method: 'put',
-      url: `//${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.EMAIL}`,
+      url: `/${UserAPI.URL.USERS}/${userId}/${UserAPI.URL.EMAIL}`,
     };
     await this.client.sendJSON(config);
   }


### PR DESCRIPTION
## Description

Slashes are hardcoded into some of the url constants in the conversation and user api;

This remove those slashes, allowing us to use those constant where the API endpoints change the order around, as is the case for V&, see https://wearezeta.atlassian.net/wiki/spaces/ENGINEERIN/pages/1309868033/API+changes+v6+v7

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
