### PR TITLE
feat: add periodic keypackages check and logging [WPB-14727]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -754,10 +754,21 @@ export class MLSService extends TypedEventEmitter<Events> {
    * @param clientId id of the client
    */
   public schedulePeriodicKeyPackagesBackendSync(clientId: string) {
+    const task = async () => {
+      this.logger.log('Executed Periodic check for key packages');
+      await this.verifyRemoteMLSKeyPackagesAmount(clientId);
+    };
+
+    // If we're in a browser, we can use the focus event to check
+    if (window && window.addEventListener) {
+      // Do this check on focus, as we might have missed the task while the app was in the background
+      window.addEventListener('focus', task);
+    }
+    // Schedule the task to run every day
     return this.recurringTaskScheduler.registerTask({
       every: TimeUtil.TimeInMillis.DAY,
       key: 'try-key-packages-backend-sync',
-      task: () => this.verifyRemoteMLSKeyPackagesAmount(clientId),
+      task,
     });
   }
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -759,16 +759,12 @@ export class MLSService extends TypedEventEmitter<Events> {
       await this.verifyRemoteMLSKeyPackagesAmount(clientId);
     };
 
-    // If we're in a browser, we can use the focus event to check
-    if (window && window.addEventListener) {
-      // Do this check on focus, as we might have missed the task while the app was in the background
-      window.addEventListener('focus', task);
-    }
     // Schedule the task to run every day
     return this.recurringTaskScheduler.registerTask({
       every: TimeUtil.TimeInMillis.DAY,
       key: 'try-key-packages-backend-sync',
       task,
+      addTaskOnWindowFocusEvent: true,
     });
   }
 

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -28,7 +28,7 @@ interface RecurringTaskSchedulerStorage {
   delete: (key: string) => Promise<void>;
 }
 
-interface TaskParams {
+export interface TaskParams {
   every: number;
   task: () => Promise<unknown> | unknown;
   key: string;

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -32,12 +32,18 @@ interface TaskParams {
   every: number;
   task: () => Promise<unknown> | unknown;
   key: string;
+  addTaskOnWindowFocusEvent?: boolean;
 }
 
 export class RecurringTaskScheduler {
   constructor(private readonly storage: RecurringTaskSchedulerStorage) {}
 
-  public readonly registerTask = async ({every, task, key}: TaskParams): Promise<void> => {
+  public readonly registerTask = async ({
+    every,
+    task,
+    key,
+    addTaskOnWindowFocusEvent = false,
+  }: TaskParams): Promise<void> => {
     const firingDate = (await this.storage.get(key)) || Date.now() + every;
     await this.storage.set(key, firingDate);
 
@@ -60,6 +66,11 @@ export class RecurringTaskScheduler {
       LowPrecisionTaskScheduler.addTask({...taskConfig, intervalDelay: TimeUtil.TimeInMillis.MINUTE});
     } else {
       TaskScheduler.addTask(taskConfig);
+    }
+
+    // If the task should be added on window focus event, we add it here
+    if (window && window.addEventListener && addTaskOnWindowFocusEvent) {
+      window.addEventListener('focus', taskConfig.task);
     }
   };
 

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -70,7 +70,7 @@ export class RecurringTaskScheduler {
 
     // If the task should be added on window focus event, we add it here
 
-    if (addTaskOnWindowFocusEvent && typeof window !== 'undefined' && typeof window.addEventListener !== undefined) {
+    if (addTaskOnWindowFocusEvent && typeof window !== 'undefined') {
       window.addEventListener('focus', taskConfig.task);
     }
   };

--- a/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
+++ b/packages/core/src/util/RecurringTaskScheduler/RecurringTaskScheduler.ts
@@ -69,7 +69,8 @@ export class RecurringTaskScheduler {
     }
 
     // If the task should be added on window focus event, we add it here
-    if (window && window.addEventListener && addTaskOnWindowFocusEvent) {
+
+    if (addTaskOnWindowFocusEvent && typeof window !== 'undefined' && typeof window.addEventListener !== undefined) {
       window.addEventListener('focus', taskConfig.task);
     }
   };


### PR DESCRIPTION
## Description

We should check key packages not just every 24h, but also when the app comes back in focus. 

Since our key-packages are generalized and should not require a browser environment to be executed, this feature requires the "browser api" check and is only executed inside of a browser env.
