### PR TITLE
feat(api-client/core): use v7 endpoint for setting member conversation roles [WPB-15024]

### DIFF
--- a/archive/bot-api/src/MessageHandler.ts
+++ b/archive/bot-api/src/MessageHandler.ts
@@ -85,7 +85,7 @@ export abstract class MessageHandler {
     }
   }
 
-  public async setAdminRole(conversationId: string, userId: string): Promise<void> {
+  public async setAdminRole(conversationId: string, userId: QualifiedId): Promise<void> {
     return this.account!.service!.conversation.setMemberConversationRole(
       conversationId,
       userId,
@@ -93,7 +93,7 @@ export abstract class MessageHandler {
     );
   }
 
-  public async setMemberRole(conversationId: string, userId: string): Promise<void> {
+  public async setMemberRole(conversationId: string, userId: QualifiedId): Promise<void> {
     return this.account!.service!.conversation.setMemberConversationRole(
       conversationId,
       userId,

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -879,20 +879,23 @@ export class ConversationAPI {
 
   /**
    * Update membership of the specified user in a certain conversation
-   * @param userId The user ID
+   * @param qualifiedId The user ID
    * @param conversationId The conversation ID to change the user's membership in
    * @param memberUpdateData The new member data
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateOtherMember
    */
   public async putOtherMember(
-    userId: string,
+    qualifiedId: QualifiedId,
     conversationId: string,
     memberUpdateData: ConversationOtherMemberUpdateData,
   ): Promise<void> {
     const config: AxiosRequestConfig = {
       data: memberUpdateData,
       method: 'put',
-      url: `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${userId}`,
+      url:
+        this.backendFeatures.version >= apiBreakpoint.version7
+          ? `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${qualifiedId.domain}/${qualifiedId.id}`
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${qualifiedId.id}`,
     };
 
     await this.client.sendJSON<ConversationMemberJoinEvent>(config);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -252,7 +252,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
 
   public setMemberConversationRole(
     conversationId: string,
-    userId: string,
+    userId: QualifiedId,
     conversationRole: DefaultConversationRoleName | string,
   ): Promise<void> {
     return this.apiClient.api.conversation.putOtherMember(userId, conversationId, {


### PR DESCRIPTION
## Description

The endpoint using a `string` as user id is deprecated in v7 and replaced by an endpoint that accepts `QualifiedId` only, see https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/#/default/update-other-member

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
