### PR TITLE
runfix(api-client/core): use conversation's qualified id to set conversation role [WPB-15024]

### DIFF
--- a/archive/bot-api/src/MessageHandler.ts
+++ b/archive/bot-api/src/MessageHandler.ts
@@ -85,7 +85,7 @@ export abstract class MessageHandler {
     }
   }
 
-  public async setAdminRole(conversationId: string, userId: QualifiedId): Promise<void> {
+  public async setAdminRole(conversationId: QualifiedId, userId: QualifiedId): Promise<void> {
     return this.account!.service!.conversation.setMemberConversationRole(
       conversationId,
       userId,
@@ -93,7 +93,7 @@ export abstract class MessageHandler {
     );
   }
 
-  public async setMemberRole(conversationId: string, userId: QualifiedId): Promise<void> {
+  public async setMemberRole(conversationId: QualifiedId, userId: QualifiedId): Promise<void> {
     return this.account!.service!.conversation.setMemberConversationRole(
       conversationId,
       userId,

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -879,14 +879,14 @@ export class ConversationAPI {
 
   /**
    * Update membership of the specified user in a certain conversation
-   * @param qualifiedId The user ID
-   * @param conversationId The conversation ID to change the user's membership in
+   * @param userId The user qualified ID
+   * @param conversationId The qualified ID of the conversation to change the user's membership in
    * @param memberUpdateData The new member data
    * @see https://staging-nginz-https.zinfra.io/swagger-ui/#!/conversations/updateOtherMember
    */
   public async putOtherMember(
-    qualifiedId: QualifiedId,
-    conversationId: string,
+    userId: QualifiedId,
+    conversationId: QualifiedId,
     memberUpdateData: ConversationOtherMemberUpdateData,
   ): Promise<void> {
     const config: AxiosRequestConfig = {
@@ -894,8 +894,8 @@ export class ConversationAPI {
       method: 'put',
       url:
         this.backendFeatures.version >= apiBreakpoint.version7
-          ? `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${qualifiedId.domain}/${qualifiedId.id}`
-          : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId}/${ConversationAPI.URL.MEMBERS}/${qualifiedId.id}`,
+          ? `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.domain}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${userId.domain}/${userId.id}`
+          : `/${ConversationAPI.URL.CONVERSATIONS}/${conversationId.id}/${ConversationAPI.URL.MEMBERS}/${userId.id}`,
     };
 
     await this.client.sendJSON<ConversationMemberJoinEvent>(config);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -251,7 +251,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
   }
 
   public setMemberConversationRole(
-    conversationId: string,
+    conversationId: QualifiedId,
     userId: QualifiedId,
     conversationRole: DefaultConversationRoleName | string,
   ): Promise<void> {


### PR DESCRIPTION
## Description

The new endpoint also requires the conversation's domain

https://staging-nginz-https.zinfra.io/v4/api/swagger-ui/#/default/update-other-member

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
