### PR TITLE
feat: update CC to new version

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no-install lint-staged
+yarn lint-staged

--- a/packages/copy-config/src/utils.ts
+++ b/packages/copy-config/src/utils.ts
@@ -44,7 +44,7 @@ export async function downloadFileAsync(url: string, baseDir: string): Promise<v
   const zipFile = path.join(baseDir, 'archive.zip');
   await ensureDir(baseDir);
 
-  await new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const writer = createWriteStream(zipFile).on('error', reject).on('finish', resolve);
 
     return axios

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "3.0.0",
+    "@wireapp/core-crypto": "3.0.1",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "workspace:^",
     "@wireapp/promise-queue": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5723,10 +5723,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@wireapp/core-crypto@npm:3.0.0"
-  checksum: 815d109a11137f1c777b9c7d4835d8c9ded246cb79a456c24cfad17ced231f3987a3e6a8d3d98fa348f92d07656ccd6767a9b57ef5a7ba38b6ebff8262d14988
+"@wireapp/core-crypto@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@wireapp/core-crypto@npm:3.0.1"
+  checksum: 1581debc8f7105dc84a2976980a18febd7d346f7533c1ea45c767e46883329e3e0824eaa61db7f06170ee73da0e745595642556c54bef09cb718c227382ec0ba
   languageName: node
   linkType: hard
 
@@ -5743,7 +5743,7 @@ __metadata:
     "@types/uuid": 9.0.8
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 3.0.0
+    "@wireapp/core-crypto": 3.0.1
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/priority-queue": "workspace:^"
     "@wireapp/promise-queue": "workspace:^"


### PR DESCRIPTION
- Update of CC to the latest version

- Fix for lint staged:
> I ran into an issue where lint-staged started with npx and got no access to my workspace, and the prettier + eslint commands that write files failed. Change to yarn (which we use anyways) fixed that.

- copy-config fix

> It had a type mismatch, which led to the package not being able to be built. 

