### PR TITLE
fix(react-ui-kit): Adjust the behavior of eye icon on password input (WPB-15930)

### DIFF
--- a/packages/react-ui-kit/src/Form/Input.tsx
+++ b/packages/react-ui-kit/src/Form/Input.tsx
@@ -196,7 +196,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps<HTMLInputElem
               aria-controls={props.id}
               aria-expanded={togglePassword}
             >
-              {togglePassword ? <HideIcon /> : <ShowIcon />}
+              {togglePassword ? <ShowIcon /> : <HideIcon />}
             </button>
           )}
         </div>


### PR DESCRIPTION
## Description

eye icon for passwords should work vice verse the current behavior.

![Screen Recording 2025-02-03 at 3 09 49 PM](https://github.com/user-attachments/assets/242ed82a-1cc4-4f23-85dd-f7daf442931e)
