### PR TITLE
feat(mls): add mlsOtherError to error ignore list [WPB-16234]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -51,9 +51,20 @@ const mlsDecryptionErrorNamesToIgnore: string[] = [
   CORE_CRYPTO_ERROR_NAMES.MlsErrorDuplicateMessage,
   CORE_CRYPTO_ERROR_NAMES.MlsErrorBufferedFutureMessage,
   CORE_CRYPTO_ERROR_NAMES.MlsErrorUnmergedPendingGroup,
-  CORE_CRYPTO_ERROR_NAMES.MlsErrorOther,
 ];
 
+// This error is thrown when we receive a commit for which we have not yet received all the proposals.
+// This is a normal situation and we should ignore this error.
+// This error will get a proper name in the future.
+const isOtherErrorToIgnore = (error: Error): boolean => {
+  return (
+    error.name === CORE_CRYPTO_ERROR_NAMES.MlsErrorOther &&
+    error.message.startsWith('Incoming message is a commit for which we have not yet received all the proposals')
+  );
+};
+
 export const shouldMLSDecryptionErrorBeIgnored = (error: unknown): error is Error => {
-  return error instanceof Error && mlsDecryptionErrorNamesToIgnore.includes(error.name);
+  return (
+    error instanceof Error && (mlsDecryptionErrorNamesToIgnore.includes(error.name) || isOtherErrorToIgnore(error))
+  );
 };

--- a/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/CoreCryptoMLSError.ts
@@ -51,6 +51,7 @@ const mlsDecryptionErrorNamesToIgnore: string[] = [
   CORE_CRYPTO_ERROR_NAMES.MlsErrorDuplicateMessage,
   CORE_CRYPTO_ERROR_NAMES.MlsErrorBufferedFutureMessage,
   CORE_CRYPTO_ERROR_NAMES.MlsErrorUnmergedPendingGroup,
+  CORE_CRYPTO_ERROR_NAMES.MlsErrorOther,
 ];
 
 export const shouldMLSDecryptionErrorBeIgnored = (error: unknown): error is Error => {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -61,7 +61,6 @@ const createMLSService = async () => {
     mlsInit: jest.fn(),
     clientPublicKey: jest.fn(),
     processWelcomeMessage: jest.fn(),
-    decryptMessage: jest.fn(),
     conversationEpoch: jest.fn(),
     commitPendingProposals: jest.fn(),
     registerCallbacks: jest.fn(),
@@ -69,6 +68,7 @@ const createMLSService = async () => {
     clearPendingGroupFromExternalCommit: async () => {},
     clearPendingCommit: async () => {},
     commitAccepted: jest.fn(),
+    transaction: jest.fn(),
   } as unknown as CoreCrypto;
 
   const mockedDb = await openDB('core-test-db');
@@ -601,7 +601,7 @@ describe('MLSService', () => {
         proposals: [],
       };
 
-      jest.spyOn(mockCoreCrypto, 'decryptMessage').mockResolvedValueOnce(mockedDecryptoedMessage);
+      jest.spyOn(mockCoreCrypto, 'transaction').mockResolvedValueOnce(mockedDecryptoedMessage);
       jest.spyOn(mockCoreCrypto, 'conversationEpoch').mockResolvedValueOnce(mockedNewEpoch);
       jest.spyOn(mlsService, 'emit').mockImplementation(jest.fn());
 
@@ -615,7 +615,7 @@ describe('MLSService', () => {
       };
 
       await mlsService.handleMLSMessageAddEvent(mockedMLSWelcomeEvent, getGroupIdFromConversationId);
-      expect(mockCoreCrypto.decryptMessage).toHaveBeenCalled();
+      expect(mockCoreCrypto.transaction).toHaveBeenCalled();
       expect(mlsService.emit).toHaveBeenCalledWith('newEpoch', {epoch: mockedNewEpoch, groupId: mockGroupId});
     });
 
@@ -636,7 +636,7 @@ describe('MLSService', () => {
         commitDelay,
       };
 
-      jest.spyOn(mockCoreCrypto, 'decryptMessage').mockResolvedValueOnce(mockedDecryptoedMessage);
+      jest.spyOn(mockCoreCrypto, 'transaction').mockResolvedValueOnce(mockedDecryptoedMessage);
       jest.spyOn(mockCoreCrypto, 'conversationEpoch').mockResolvedValueOnce(mockedNewEpoch);
 
       jest.spyOn(mlsService, 'commitPendingProposals');
@@ -655,7 +655,7 @@ describe('MLSService', () => {
       expect(mockCoreCrypto.commitPendingProposals).not.toHaveBeenCalled();
 
       jest.advanceTimersByTime(commitDelay);
-      expect(mockCoreCrypto.decryptMessage).toHaveBeenCalled();
+      expect(mockCoreCrypto.transaction).toHaveBeenCalled();
       expect(mockCoreCrypto.commitPendingProposals).toHaveBeenCalled();
     });
   });

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -420,7 +420,9 @@ export class MLSService extends TypedEventEmitter<Events> {
 
   public async decryptMessage(conversationId: ConversationId, payload: Uint8Array): Promise<DecryptedMessage> {
     try {
-      const decryptedMessage = await this.coreCryptoClient.decryptMessage(conversationId, payload);
+      const decryptedMessage = await this.coreCryptoClient.transaction(cx =>
+        cx.decryptMessage(conversationId, payload),
+      );
       this.dispatchNewCrlDistributionPoints(decryptedMessage);
       return decryptedMessage;
     } catch (error) {


### PR DESCRIPTION
## Description

We need to swallow another CoreCrypto error, which currently throws an error.
