### PR TITLE
fix: issue with stringifying very large objects

### DIFF
--- a/packages/commons/src/util/StringUtil.test.ts
+++ b/packages/commons/src/util/StringUtil.test.ts
@@ -86,38 +86,60 @@ describe('StringUtil', () => {
     });
   });
 
-  describe('serializeArgs - Memory and Circular Reference Handling', () => {
-    jest.setTimeout(60000); // Increase timeout to handle large cases
+  describe('serializeArgs - Browser Safe Tests', () => {
+    jest.setTimeout(30000);
 
-    test('should not throw an error for a circular object', () => {
+    test('should truncate a very large string', () => {
+      const largeString = 'a'.repeat(1_000_000); // 1MB string (should truncate)
+
+      const result = StringUtil.serializeArgs([largeString]);
+
+      expect(result[0].length).toBeLessThanOrEqual(10_010); // Should truncate
+      expect(result[0]).toContain('... [truncated]');
+    });
+
+    test('should handle circular references', () => {
       const circularObj: any = {};
-      circularObj.self = circularObj; // Create a circular reference
+      circularObj.self = circularObj; // Create circular reference
 
-      expect(() => {
-        const result = StringUtil.serializeArgs([circularObj]);
-        expect(result[0]).toContain('[Circular]');
-      }).not.toThrow();
+      const result = StringUtil.serializeArgs([circularObj]);
+
+      expect(result[0]).toContain('[Circular]'); // Should replace circular references
+      expect(() => JSON.parse(result[0])).not.toThrow(); // Should be valid JSON
     });
 
-    test('should not throw an error for a very large string', () => {
-      const largeString = 'a'.repeat(500_000_000); // 500MB string
-
-      expect(() => {
-        const result = StringUtil.serializeArgs([largeString]);
-        expect(result[0]).toContain('... [truncated]'); // Check if truncated
-      }).not.toThrow();
-    });
-
-    test('should correctly serialize a large but valid object', () => {
+    test('should serialize a large object safely', () => {
       const largeObject: any = {};
-      for (let i = 0; i < 1e5; i++) {
+      for (let i = 0; i < 100_000; i++) {
+        // 100k properties
         largeObject[`key${i}`] = 'value';
       }
 
-      expect(() => {
-        const result = StringUtil.serializeArgs([largeObject]);
-        expect(typeof result[0]).toBe('string'); // Ensure it's serialized
-      }).not.toThrow();
+      const result = StringUtil.serializeArgs([largeObject]);
+
+      expect(typeof result[0]).toBe('string'); // Should still be a valid JSON string
+      expect(result[0].length).toBeLessThanOrEqual(1_000_010); // Should be within the truncation limit
+    });
+
+    test('should serialize a normal object correctly', () => {
+      const obj = {a: 1, b: 'test', c: [1, 2, 3]};
+
+      const result = StringUtil.serializeArgs([obj]);
+
+      expect(() => JSON.parse(result[0])).not.toThrow(); // Should be valid JSON
+      expect(JSON.parse(result[0])).toEqual(obj); // Should match original object
+    });
+
+    test('should return "[Unserializable Object]" for unsupported values', () => {
+      const unserializable = {
+        toJSON: () => {
+          throw new Error('Cannot serialize');
+        },
+      };
+
+      const result = StringUtil.serializeArgs([unserializable]);
+
+      expect(result[0]).toBe('[Unserializable Object]'); // Should return error placeholder
     });
   });
 });

--- a/packages/commons/src/util/StringUtil.test.ts
+++ b/packages/commons/src/util/StringUtil.test.ts
@@ -85,4 +85,39 @@ describe('StringUtil', () => {
       expect(expected).toEqual(actual);
     });
   });
+
+  describe('serializeArgs - Memory and Circular Reference Handling', () => {
+    jest.setTimeout(60000); // Increase timeout to handle large cases
+
+    test('should not throw an error for a circular object', () => {
+      const circularObj: any = {};
+      circularObj.self = circularObj; // Create a circular reference
+
+      expect(() => {
+        const result = StringUtil.serializeArgs([circularObj]);
+        expect(result[0]).toContain('[Circular]');
+      }).not.toThrow();
+    });
+
+    test('should not throw an error for a very large string', () => {
+      const largeString = 'a'.repeat(500_000_000); // 500MB string
+
+      expect(() => {
+        const result = StringUtil.serializeArgs([largeString]);
+        expect(result[0]).toContain('... [truncated]'); // Check if truncated
+      }).not.toThrow();
+    });
+
+    test('should correctly serialize a large but valid object', () => {
+      const largeObject: any = {};
+      for (let i = 0; i < 1e5; i++) {
+        largeObject[`key${i}`] = 'value';
+      }
+
+      expect(() => {
+        const result = StringUtil.serializeArgs([largeObject]);
+        expect(typeof result[0]).toBe('string'); // Ensure it's serialized
+      }).not.toThrow();
+    });
+  });
 });

--- a/packages/commons/src/util/StringUtil.ts
+++ b/packages/commons/src/util/StringUtil.ts
@@ -39,7 +39,7 @@ const maxSize = 10_000;
 export function serializeArgs(args: any[]): any[] {
   return args.map(arg => {
     if (typeof arg === 'string') {
-      return arg.length > 10000 ? `${arg.slice(0, maxSize - 15)}... [truncated]` : arg;
+      return arg.length > maxSize ? `${arg.slice(0, maxSize - 15)}... [truncated]` : arg;
     }
 
     if (typeof arg === 'object' && arg !== null) {

--- a/packages/commons/src/util/StringUtil.ts
+++ b/packages/commons/src/util/StringUtil.ts
@@ -36,5 +36,33 @@ export function bytesToUUID(uuid: Buffer | Uint8Array): string {
 }
 
 export function serializeArgs(args: any[]): any[] {
-  return args.map(arg => (typeof arg === 'object' && arg !== null ? JSON.stringify(arg) : arg));
+  return args.map(arg => {
+    if (typeof arg === 'string') {
+      return arg.length > 10000 ? `${arg.slice(0, 10000)}... [truncated]` : arg;
+    }
+
+    if (typeof arg === 'object' && arg !== null) {
+      try {
+        return JSON.stringify(arg, getCircularReplacer());
+      } catch (e) {
+        return '[Unserializable Object]';
+      }
+    }
+
+    return arg;
+  });
+}
+
+// Helper function to prevent circular references
+function getCircularReplacer() {
+  const seen = new WeakSet();
+  return (_key: string, value: any) => {
+    if (typeof value === 'object' && value !== null) {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+    }
+    return value;
+  };
 }


### PR DESCRIPTION
## Description

JSON.stringify throws an Error while stringifying large objects due to memory constraints. 