### PR TITLE
feat(api-client/cells): add path parameter for getAllFiles method

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -294,7 +294,7 @@ describe('CellsAPI', () => {
       const result = await cellsAPI.getAllFiles({path: TEST_FILE_PATH});
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
-        Locators: {Many: [{Path: '/*'}]},
+        Locators: {Many: [{Path: `${TEST_FILE_PATH}/*`}]},
         Flags: ['WithVersionsAll'],
       });
       expect(result).toEqual(mockCollection);

--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -114,7 +114,7 @@ describe('CellsAPI', () => {
       await cellsAPI.uploadFileDraft({
         uuid: MOCKED_UUID,
         versionId: MOCKED_UUID,
-        filePath: TEST_FILE_PATH,
+        path: TEST_FILE_PATH,
         file: testFile,
       });
 
@@ -124,7 +124,7 @@ describe('CellsAPI', () => {
       });
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
-        filePath: TEST_FILE_PATH,
+        path: TEST_FILE_PATH,
         file: testFile,
         metadata: {
           'Draft-Mode': 'true',
@@ -151,12 +151,12 @@ describe('CellsAPI', () => {
       await cellsAPI.uploadFileDraft({
         uuid: MOCKED_UUID,
         versionId: MOCKED_UUID,
-        filePath: TEST_FILE_PATH,
+        path: TEST_FILE_PATH,
         file: testFile,
       });
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
-        filePath: nextPath,
+        path: nextPath,
         file: testFile,
         metadata: {
           'Draft-Mode': 'true',
@@ -183,13 +183,13 @@ describe('CellsAPI', () => {
       await cellsAPI.uploadFileDraft({
         uuid: MOCKED_UUID,
         versionId: MOCKED_UUID,
-        filePath: TEST_FILE_PATH,
+        path: TEST_FILE_PATH,
         file: testFile,
         autoRename: false,
       });
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
-        filePath: TEST_FILE_PATH,
+        path: TEST_FILE_PATH,
         file: testFile,
         metadata: {
           'Draft-Mode': 'true',
@@ -204,7 +204,7 @@ describe('CellsAPI', () => {
       mockNodeServiceApi.createCheck.mockRejectedValueOnce(new Error(errorMessage));
 
       await expect(
-        cellsAPI.uploadFileDraft({uuid: MOCKED_UUID, versionId: MOCKED_UUID, filePath: TEST_FILE_PATH, file: testFile}),
+        cellsAPI.uploadFileDraft({uuid: MOCKED_UUID, versionId: MOCKED_UUID, path: TEST_FILE_PATH, file: testFile}),
       ).rejects.toThrow(errorMessage);
     });
 
@@ -223,7 +223,7 @@ describe('CellsAPI', () => {
       mockStorage.putObject.mockRejectedValueOnce(new Error(errorMessage));
 
       await expect(
-        cellsAPI.uploadFileDraft({uuid: MOCKED_UUID, versionId: MOCKED_UUID, filePath: TEST_FILE_PATH, file: testFile}),
+        cellsAPI.uploadFileDraft({uuid: MOCKED_UUID, versionId: MOCKED_UUID, path: TEST_FILE_PATH, file: testFile}),
       ).rejects.toThrow(errorMessage);
     });
 
@@ -238,7 +238,7 @@ describe('CellsAPI', () => {
         }),
       );
 
-      await cellsAPI.uploadFileDraft({uuid: MOCKED_UUID, versionId: MOCKED_UUID, filePath: '', file: testFile});
+      await cellsAPI.uploadFileDraft({uuid: MOCKED_UUID, versionId: MOCKED_UUID, path: '', file: testFile});
 
       expect(mockNodeServiceApi.createCheck).toHaveBeenCalledWith({
         Inputs: [{Type: 'LEAF', Locator: {Path: '', Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
@@ -257,7 +257,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.getByUuid.mockResolvedValueOnce(createMockResponse(mockNode as RestNode));
 
-      const result = await cellsAPI.getFile(fileId);
+      const result = await cellsAPI.getFile({id: fileId});
 
       expect(mockNodeServiceApi.getByUuid).toHaveBeenCalledWith(fileId);
       expect(result).toEqual(mockNode);
@@ -269,13 +269,13 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.getByUuid.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.getFile(fileId)).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.getFile({id: fileId})).rejects.toThrow(errorMessage);
     });
 
     it('handles empty ID', async () => {
       const emptyId = '';
 
-      await expect(cellsAPI.getFile(emptyId)).rejects.toThrow();
+      await expect(cellsAPI.getFile({id: emptyId})).rejects.toThrow();
     });
   });
 
@@ -291,7 +291,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockCollection as RestNodeCollection));
 
-      const result = await cellsAPI.getAllFiles();
+      const result = await cellsAPI.getAllFiles({path: TEST_FILE_PATH});
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Locators: {Many: [{Path: '/*'}]},
@@ -305,7 +305,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.getAllFiles()).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.getAllFiles({path: TEST_FILE_PATH})).rejects.toThrow(errorMessage);
     });
 
     it('returns empty collection when no files exist', async () => {
@@ -315,7 +315,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(emptyCollection as RestNodeCollection));
 
-      const result = await cellsAPI.getAllFiles();
+      const result = await cellsAPI.getAllFiles({path: TEST_FILE_PATH});
       expect(result).toEqual(emptyCollection);
     });
   });
@@ -326,7 +326,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.performAction.mockResolvedValueOnce(createMockResponse({}));
 
-      await cellsAPI.deleteFile(filePath);
+      await cellsAPI.deleteFile({path: filePath});
 
       expect(mockNodeServiceApi.performAction).toHaveBeenCalledWith('delete', {
         Nodes: [{Path: filePath}],
@@ -339,7 +339,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.deleteFile(filePath)).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.deleteFile({path: filePath})).rejects.toThrow(errorMessage);
     });
 
     it('handles attempts to delete non-existent paths', async () => {
@@ -348,7 +348,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.deleteFile(nonExistentPath)).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.deleteFile({path: nonExistentPath})).rejects.toThrow(errorMessage);
     });
   });
 
@@ -476,7 +476,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      const result = await cellsAPI.lookupFileByPath(filePath);
+      const result = await cellsAPI.lookupFileByPath({path: filePath});
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Locators: {Many: [{Path: filePath}]},
@@ -492,7 +492,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      await expect(cellsAPI.lookupFileByPath(filePath)).rejects.toThrow(`File not found: ${filePath}`);
+      await expect(cellsAPI.lookupFileByPath({path: filePath})).rejects.toThrow(`File not found: ${filePath}`);
     });
 
     it('propagates errors from the NodeServiceApi', async () => {
@@ -501,7 +501,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.lookupFileByPath(filePath)).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.lookupFileByPath({path: filePath})).rejects.toThrow(errorMessage);
     });
   });
 
@@ -518,7 +518,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      const result = await cellsAPI.lookupFileByUuid(fileUuid);
+      const result = await cellsAPI.lookupFileByUuid({uuid: fileUuid});
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Locators: {Many: [{Uuid: fileUuid}]},
@@ -534,7 +534,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      await expect(cellsAPI.lookupFileByUuid(fileUuid)).rejects.toThrow(`File not found: ${fileUuid}`);
+      await expect(cellsAPI.lookupFileByUuid({uuid: fileUuid})).rejects.toThrow(`File not found: ${fileUuid}`);
     });
 
     it('propagates errors from the NodeServiceApi', async () => {
@@ -543,7 +543,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.lookup.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.lookupFileByUuid(fileUuid)).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.lookupFileByUuid({uuid: fileUuid})).rejects.toThrow(errorMessage);
     });
   });
 
@@ -565,7 +565,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.nodeVersions = jest.fn().mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      const result = await cellsAPI.getFileVersions(fileUuid);
+      const result = await cellsAPI.getFileVersions({uuid: fileUuid});
 
       expect(mockNodeServiceApi.nodeVersions).toHaveBeenCalledWith(fileUuid, {FilterBy: 'VersionsAll'});
       expect(result).toEqual(mockVersions);
@@ -579,7 +579,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.nodeVersions = jest.fn().mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      const result = await cellsAPI.getFileVersions(fileUuid);
+      const result = await cellsAPI.getFileVersions({uuid: fileUuid});
 
       expect(mockNodeServiceApi.nodeVersions).toHaveBeenCalledWith(fileUuid, {FilterBy: 'VersionsAll'});
       expect(result).toBeUndefined();
@@ -591,7 +591,7 @@ describe('CellsAPI', () => {
 
       mockNodeServiceApi.nodeVersions = jest.fn().mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.getFileVersions(fileUuid)).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.getFileVersions({uuid: fileUuid})).rejects.toThrow(errorMessage);
     });
   });
 

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -84,7 +84,7 @@ export class CellsAPI {
       'Create-Version-Id': versionId,
     };
 
-    await this.storageService.putObject({filePath, file, metadata});
+    await this.storageService.putObject({path: filePath, file, metadata});
 
     return result.data;
   }

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -57,25 +57,25 @@ export class CellsAPI {
   async uploadFileDraft({
     uuid,
     versionId,
-    filePath,
+    path,
     file,
     autoRename = true,
   }: {
     uuid: string;
     versionId: string;
-    filePath: string;
+    path: string;
     file: File;
     autoRename?: boolean;
   }): Promise<RestCreateCheckResponse> {
-    let path = `${filePath}`.normalize('NFC');
+    let filePath = `${path}`.normalize('NFC');
 
     const result = await this.client.createCheck({
-      Inputs: [{Type: 'LEAF', Locator: {Path: path, Uuid: uuid}, VersionId: versionId}],
+      Inputs: [{Type: 'LEAF', Locator: {Path: filePath, Uuid: uuid}, VersionId: versionId}],
       FindAvailablePath: true,
     });
 
     if (autoRename && result.data.Results?.length && result.data.Results[0].Exists) {
-      path = result.data.Results[0].NextPath || path;
+      filePath = result.data.Results[0].NextPath || filePath;
     }
 
     const metadata = {
@@ -84,7 +84,7 @@ export class CellsAPI {
       'Create-Version-Id': versionId,
     };
 
-    await this.storageService.putObject({filePath: path, file, metadata});
+    await this.storageService.putObject({filePath, file, metadata});
 
     return result.data;
   }
@@ -101,13 +101,13 @@ export class CellsAPI {
     return result.data;
   }
 
-  async deleteFile(path: string): Promise<RestPerformActionResponse> {
+  async deleteFile({path}: {path: string}): Promise<RestPerformActionResponse> {
     const result = await this.client.performAction('delete', {Nodes: [{Path: path}]});
 
     return result.data;
   }
 
-  async lookupFileByPath(path: string): Promise<RestNode | undefined> {
+  async lookupFileByPath({path}: {path: string}): Promise<RestNode | undefined> {
     const result = await this.client.lookup({Locators: {Many: [{Path: path}]}});
 
     const node = result.data.Nodes?.[0];
@@ -119,7 +119,7 @@ export class CellsAPI {
     return node;
   }
 
-  async lookupFileByUuid(uuid: string): Promise<RestNode | undefined> {
+  async lookupFileByUuid({uuid}: {uuid: string}): Promise<RestNode | undefined> {
     const result = await this.client.lookup({Locators: {Many: [{Uuid: uuid}]}});
 
     const node = result.data.Nodes?.[0];
@@ -131,21 +131,21 @@ export class CellsAPI {
     return node;
   }
 
-  async getFileVersions(uuid: string): Promise<RestVersion[] | undefined> {
+  async getFileVersions({uuid}: {uuid: string}): Promise<RestVersion[] | undefined> {
     const result = await this.client.nodeVersions(uuid, {FilterBy: 'VersionsAll'});
 
     return result.data.Versions;
   }
 
-  async getFile(id: string): Promise<RestNode> {
+  async getFile({id}: {id: string}): Promise<RestNode> {
     const result = await this.client.getByUuid(id);
 
     return result.data;
   }
 
-  async getAllFiles(): Promise<RestNodeCollection> {
+  async getAllFiles({path}: {path: string}): Promise<RestNodeCollection> {
     const result = await this.client.lookup({
-      Locators: {Many: [{Path: `/*`}]},
+      Locators: {Many: [{Path: `${path}/*`}]},
       Flags: ['WithVersionsAll'],
     });
 

--- a/packages/api-client/src/cells/CellsStorage/CellsStorage.ts
+++ b/packages/api-client/src/cells/CellsStorage/CellsStorage.ts
@@ -18,15 +18,7 @@
  */
 
 export interface CellsStorage {
-  putObject({
-    filePath,
-    file,
-    metadata,
-  }: {
-    filePath: string;
-    file: File;
-    metadata?: Record<string, string>;
-  }): Promise<void>;
+  putObject({path, file, metadata}: {path: string; file: File; metadata?: Record<string, string>}): Promise<void>;
 }
 
 export class CellsStorageError extends Error {

--- a/packages/api-client/src/cells/CellsStorage/S3Service.test.ts
+++ b/packages/api-client/src/cells/CellsStorage/S3Service.test.ts
@@ -54,7 +54,7 @@ describe('S3Service', () => {
 
   describe('putObject', () => {
     it('creates a PutObjectCommand with the correct parameters', async () => {
-      await service.putObject({filePath: testFilePath, file: testFile});
+      await service.putObject({path: testFilePath, file: testFile});
 
       expect(PutObjectCommand).toHaveBeenCalledWith({
         Bucket: testConfig.bucket,
@@ -73,7 +73,7 @@ describe('S3Service', () => {
         'another-key': 'another-value',
       };
 
-      await service.putObject({filePath: testFilePath, file: testFile, metadata});
+      await service.putObject({path: testFilePath, file: testFile, metadata});
 
       expect(PutObjectCommand).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -87,12 +87,10 @@ describe('S3Service', () => {
 
       mockSend.mockRejectedValueOnce(error);
 
-      await expect(service.putObject({filePath: testFilePath, file: testFile})).rejects.toThrow(CellsStorageError);
+      await expect(service.putObject({path: testFilePath, file: testFile})).rejects.toThrow(CellsStorageError);
 
       mockSend.mockRejectedValueOnce(error);
-      await expect(service.putObject({filePath: testFilePath, file: testFile})).rejects.toThrow(
-        /The object was too large/,
-      );
+      await expect(service.putObject({path: testFilePath, file: testFile})).rejects.toThrow(/The object was too large/);
     });
 
     it('handles other S3ServiceExceptions with a generic error message', async () => {
@@ -102,10 +100,10 @@ describe('S3Service', () => {
 
       mockSend.mockRejectedValueOnce(error);
 
-      await expect(service.putObject({filePath: testFilePath, file: testFile})).rejects.toThrow(CellsStorageError);
+      await expect(service.putObject({path: testFilePath, file: testFile})).rejects.toThrow(CellsStorageError);
 
       mockSend.mockRejectedValueOnce(error);
-      await expect(service.putObject({filePath: testFilePath, file: testFile})).rejects.toThrow(
+      await expect(service.putObject({path: testFilePath, file: testFile})).rejects.toThrow(
         new RegExp(`Error from S3 while uploading object to.*${errorName}: ${errorMessage}`),
       );
     });
@@ -114,7 +112,7 @@ describe('S3Service', () => {
       const error = new Error('Unexpected error');
       mockSend.mockRejectedValueOnce(error);
 
-      await expect(service.putObject({filePath: testFilePath, file: testFile})).rejects.toBe(error);
+      await expect(service.putObject({path: testFilePath, file: testFile})).rejects.toBe(error);
     });
   });
 });

--- a/packages/api-client/src/cells/CellsStorage/S3Service.ts
+++ b/packages/api-client/src/cells/CellsStorage/S3Service.ts
@@ -48,18 +48,18 @@ export class S3Service implements CellsStorage {
   }
 
   async putObject({
-    filePath,
+    path,
     file,
     metadata,
   }: {
-    filePath: string;
+    path: string;
     file: File;
     metadata?: Record<string, string>;
   }): Promise<void> {
     const command = new PutObjectCommand({
       Bucket: this.bucket,
       Body: file,
-      Key: filePath,
+      Key: path,
       ContentType: file.type,
       ContentLength: file.size,
       Metadata: metadata,


### PR DESCRIPTION
## Description

Added the `path` parameter to the `getAllFiles` method in the cells API + rename parameters (`filePath` => `path`) and replace one param with an object.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
