### PR TITLE
fix: use isGroup as a function and pass options

### DIFF
--- a/packages/react-ui-kit/src/Form/SelectComponents.tsx
+++ b/packages/react-ui-kit/src/Form/SelectComponents.tsx
@@ -71,12 +71,12 @@ export const CustomOption = (dataUieName: string) => (props: OptionProps<Option>
     <components.Option {...props}>
       <div
         css={{
-          ...((isMulti || isGroup) && {
+          ...((isMulti || isGroup(options)) && {
             display: 'grid',
             gridTemplateAreas: `"checkbox label"
                                 ". description"`,
             gridTemplateColumns: '22px 1fr',
-            columnGap: isGroup ? '5px' : '10px',
+            columnGap: isGroup(options) ? '5px' : '10px',
           }),
         }}
         {...(dataUieName && {


### PR DESCRIPTION
## Description

The function isGroup was used as a boolean, always returning true. Used it as a function and passed options

## Screenshots/Screencast (for UI changes)

### Before
![Screenshot 2025-03-06 at 14 03 10](https://github.com/user-attachments/assets/8fe7bdf9-9747-4c17-9167-17146c6119c5)

### After
![Screenshot 2025-03-06 at 14 02 43](https://github.com/user-attachments/assets/94d7d405-2a2d-4a34-9f6b-c3c0e79c616a)

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
