### PR TITLE
feat(api-client/cells): replace path with uuid in the deleteFile method

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -321,34 +321,34 @@ describe('CellsAPI', () => {
   });
 
   describe('deleteFile', () => {
-    it('deletes a file with the correct path', async () => {
-      const filePath = `/${TEST_FILE_PATH}`;
+    it('deletes a file with the correct uuid', async () => {
+      const uuid = 'file-uuid';
 
       mockNodeServiceApi.performAction.mockResolvedValueOnce(createMockResponse({}));
 
-      await cellsAPI.deleteFile({path: filePath});
+      await cellsAPI.deleteFile({uuid});
 
       expect(mockNodeServiceApi.performAction).toHaveBeenCalledWith('delete', {
-        Nodes: [{Path: filePath}],
+        Nodes: [{Uuid: uuid}],
       });
     });
 
     it('propagates errors when deletion fails', async () => {
-      const filePath = `/${TEST_FILE_PATH}`;
+      const uuid = 'file-uuid';
       const errorMessage = 'Delete failed';
 
       mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.deleteFile({path: filePath})).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.deleteFile({uuid})).rejects.toThrow(errorMessage);
     });
 
-    it('handles attempts to delete non-existent paths', async () => {
-      const nonExistentPath = '/does/not/exist.txt';
-      const errorMessage = 'Path not found';
+    it('handles attempts to delete with invalid uuid', async () => {
+      const invalidUuid = '';
+      const errorMessage = 'Invalid UUID';
 
       mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
 
-      await expect(cellsAPI.deleteFile({path: nonExistentPath})).rejects.toThrow(errorMessage);
+      await expect(cellsAPI.deleteFile({uuid: invalidUuid})).rejects.toThrow(errorMessage);
     });
   });
 

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -101,8 +101,8 @@ export class CellsAPI {
     return result.data;
   }
 
-  async deleteFile({path}: {path: string}): Promise<RestPerformActionResponse> {
-    const result = await this.client.performAction('delete', {Nodes: [{Path: path}]});
+  async deleteFile({uuid}: {uuid: string}): Promise<RestPerformActionResponse> {
+    const result = await this.client.performAction('delete', {Nodes: [{Uuid: uuid}]});
 
     return result.data;
   }


### PR DESCRIPTION
## Description

Replaces the `path` parameter with the `uuid` for the `deleteFile` cells method.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
