### PR TITLE
fix(mls): create specific error for trying to add proteus users [WPB-15301]

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -119,6 +119,7 @@ export enum AddUsersFailureReasons {
   NON_FEDERATING_BACKENDS = 'NON_FEDERATING_BACKENDS',
   UNREACHABLE_BACKENDS = 'UNREACHABLE_BACKENDS',
   OFFLINE_FOR_TOO_LONG = 'OFFLINE_FOR_TOO_LONG',
+  NOT_MLS_CAPABLE = 'NOT_MLS_CAPABLE',
 }
 
 /**
@@ -141,6 +142,10 @@ export type AddUsersFailure =
     }
   | {
       reason: AddUsersFailureReasons.OFFLINE_FOR_TOO_LONG;
+      users: QualifiedId[];
+    }
+  | {
+      reason: AddUsersFailureReasons.NOT_MLS_CAPABLE;
       users: QualifiedId[];
     };
 


### PR DESCRIPTION
## Description

When we tried to add users to an MLS conversation, there was no check if the user could be added (supporting the MLS protocol).
This PR ensures that every user we try to add to a conversation is capable of being added, and creates a new error type for users that need to be skipped.