### PR TITLE
feat(api-client/cells): add createFilePublicLink method and refactor getFilePublicLink [WPB-15679]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -173,25 +173,19 @@ export class CellsAPI {
     return result.data;
   }
 
-  async getFilePublicLink({
-    uuid,
-    label,
-    alreadyShared,
-  }: {
-    uuid: string;
-    label: string;
-    alreadyShared: boolean;
-  }): Promise<RestShareLink> {
-    if (alreadyShared) {
-      await this.deleteFilePublicLink({uuid});
-    }
-
+  async createFilePublicLink({uuid, label}: {uuid: string; label?: string}): Promise<RestShareLink> {
     const result = await this.client.createPublicLink(uuid, {
       Link: {
         Label: label,
         Permissions: ['Preview', 'Download'],
       },
     });
+
+    return result.data;
+  }
+
+  async getFilePublicLink({uuid}: {uuid: string}): Promise<RestShareLink> {
+    const result = await this.client.getPublicLink(uuid);
 
     return result.data;
   }


### PR DESCRIPTION

## Description

- introduced the `getFilePublicLink` method to retrieve public links for files.
- updated createFilePublicLink to handle optional label and removed `alreadyShared` parameter.
- enhanced test cases for both methods, including error handling for invalid UUIDs

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
