### PR TITLE
fix(api-client/cells): single cells initialization

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -154,6 +154,7 @@ export class APIClient extends EventEmitter {
 
   // APIs
   public api: Apis;
+  private cellsApi: CellsAPI | null = null;
 
   // Configuration
   private readonly accessTokenStore: AccessTokenStore;
@@ -208,16 +209,21 @@ export class APIClient extends EventEmitter {
 
     const assetAPI = new AssetAPI(this.transport.http, backendFeatures);
 
+    // Prevents the CellsAPI from being initialized multiple times
+    if (!this.cellsApi) {
+      this.cellsApi = new CellsAPI({
+        httpClientConfig: this.config,
+        accessTokenStore: this.accessTokenStore,
+      });
+    }
+
     return {
       account: new AccountAPI(this.transport.http),
       asset: assetAPI,
       auth: new AuthAPI(this.transport.http),
       services: new ServicesAPI(this.transport.http, assetAPI),
       broadcast: new BroadcastAPI(this.transport.http),
-      cells: new CellsAPI({
-        httpClientConfig: this.config,
-        accessTokenStore: this.accessTokenStore,
-      }),
+      cells: this.cellsApi,
       client: new ClientAPI(this.transport.http),
       connection: new ConnectionAPI(this.transport.http),
       conversation: new ConversationAPI(this.transport.http, backendFeatures),

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -36,7 +36,7 @@ import {S3Service} from './CellsStorage/S3Service';
 import {AccessTokenStore} from '../auth';
 import {HttpClient} from '../http';
 
-const CONFIGURATION_ERROR = 'CellsAPI is not configured. Call configure() before using any methods.';
+const CONFIGURATION_ERROR = 'CellsAPI is not initialized. Call initialize() before using any methods.';
 
 interface CellsConfig {
   pydio: {


### PR DESCRIPTION
## Description

I have found that CellsApi is initialing multiple times which was causing configuration errors since we configure it not in the constructor, but via the function (https://github.com/wireapp/wire-web-packages/pull/6987)

To fix this issue, we have to make sure CellsApi is initialized only once.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
