### PR TITLE
feat(api-client/cells): add "offset" and "limit" configuration [WPB-15679]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -302,7 +302,6 @@ describe('CellsAPI', () => {
   describe('getAllFiles', () => {
     it('retrieves all files with the correct parameters', async () => {
       const mockCollection: Partial<RestNodeCollection> = {
-        // Use appropriate properties based on the actual RestNodeCollection interface
         Nodes: [
           {Path: '/file1.txt', Uuid: 'uuid1'},
           {Path: '/file2.txt', Uuid: 'uuid2'},
@@ -315,7 +314,55 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Locators: {Many: [{Path: `${TEST_FILE_PATH}/*`}]},
-        Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+      });
+      expect(result).toEqual(mockCollection);
+    });
+
+    it('uses default values when limit and offset are not provided', async () => {
+      const mockCollection: Partial<RestNodeCollection> = {
+        Nodes: [
+          {Path: '/file1.txt', Uuid: 'uuid1'},
+          {Path: '/file2.txt', Uuid: 'uuid2'},
+        ],
+      };
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockCollection as RestNodeCollection));
+
+      const result = await cellsAPI.getAllFiles({path: TEST_FILE_PATH});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Locators: {Many: [{Path: `${TEST_FILE_PATH}/*`}]},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+      });
+      expect(result).toEqual(mockCollection);
+    });
+
+    it('respects custom limit and offset parameters', async () => {
+      const mockCollection: Partial<RestNodeCollection> = {
+        Nodes: [
+          {Path: '/file1.txt', Uuid: 'uuid1'},
+          {Path: '/file2.txt', Uuid: 'uuid2'},
+        ],
+      };
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockCollection as RestNodeCollection));
+
+      const result = await cellsAPI.getAllFiles({
+        path: TEST_FILE_PATH,
+        limit: 5,
+        offset: 10,
+      });
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Locators: {Many: [{Path: `${TEST_FILE_PATH}/*`}]},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '5',
+        Offset: '10',
       });
       expect(result).toEqual(mockCollection);
     });
@@ -500,7 +547,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Locators: {Many: [{Path: filePath}]},
-        Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+        Flags: ['WithPreSignedURLs'],
       });
       expect(result).toEqual(mockNode);
     });
@@ -543,7 +590,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Locators: {Many: [{Uuid: fileUuid}]},
-        Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+        Flags: ['WithPreSignedURLs'],
       });
       expect(result).toEqual(mockNode);
     });
@@ -750,7 +797,69 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Query: {FileName: searchPhrase, Type: 'LEAF'},
-        Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('uses default values when limit and offset are not provided', async () => {
+      const searchPhrase = 'test';
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/test.txt',
+            Uuid: 'file-uuid-1',
+          },
+          {
+            Path: '/folder/test-file.txt',
+            Uuid: 'file-uuid-2',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchFiles({phrase: searchPhrase});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Query: {FileName: searchPhrase, Type: 'LEAF'},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('respects custom limit and offset parameters', async () => {
+      const searchPhrase = 'test';
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/test.txt',
+            Uuid: 'file-uuid-1',
+          },
+          {
+            Path: '/folder/test-file.txt',
+            Uuid: 'file-uuid-2',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchFiles({
+        phrase: searchPhrase,
+        limit: 5,
+        offset: 10,
+      });
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Query: {FileName: searchPhrase, Type: 'LEAF'},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '5',
+        Offset: '10',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -767,7 +876,9 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Query: {FileName: searchPhrase, Type: 'LEAF'},
-        Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -793,7 +904,9 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Query: {FileName: searchPhrase, Type: 'LEAF'},
-        Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
       });
       expect(result).toEqual(mockResponse);
     });

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -37,6 +37,8 @@ import {AccessTokenStore} from '../auth';
 import {HttpClient} from '../http';
 
 const CONFIGURATION_ERROR = 'CellsAPI is not initialized. Call initialize() before using any methods.';
+const DEFAULT_LIMIT = 10;
+const DEFAULT_OFFSET = 0;
 
 interface CellsConfig {
   pydio: {
@@ -171,7 +173,7 @@ export class CellsAPI {
 
     const result = await this.client.lookup({
       Locators: {Many: [{Path: path}]},
-      Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+      Flags: ['WithPreSignedURLs'],
     });
 
     const node = result.data.Nodes?.[0];
@@ -190,7 +192,7 @@ export class CellsAPI {
 
     const result = await this.client.lookup({
       Locators: {Many: [{Uuid: uuid}]},
-      Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+      Flags: ['WithPreSignedURLs'],
     });
 
     const node = result.data.Nodes?.[0];
@@ -222,27 +224,47 @@ export class CellsAPI {
     return result.data;
   }
 
-  async getAllFiles({path}: {path: string}): Promise<RestNodeCollection> {
+  async getAllFiles({
+    path,
+    limit = DEFAULT_LIMIT,
+    offset = DEFAULT_OFFSET,
+  }: {
+    path: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
 
     const result = await this.client.lookup({
       Locators: {Many: [{Path: `${path}/*`}]},
-      Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+      Flags: ['WithPreSignedURLs'],
+      Limit: `${limit}`,
+      Offset: `${offset}`,
     });
 
     return result.data;
   }
 
-  async searchFiles({phrase}: {phrase: string}): Promise<RestNodeCollection> {
+  async searchFiles({
+    phrase,
+    limit = DEFAULT_LIMIT,
+    offset = DEFAULT_OFFSET,
+  }: {
+    phrase: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
 
     const result = await this.client.lookup({
       Query: {FileName: phrase, Type: 'LEAF'},
-      Flags: ['WithVersionsAll', 'WithPreSignedURLs'],
+      Flags: ['WithPreSignedURLs'],
+      Limit: `${limit}`,
+      Offset: `${offset}`,
     });
 
     return result.data;


### PR DESCRIPTION
## Description

Adds configurable "limit" and "offset" options for the `searchFiles` and `getAllFiles` options. 

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
