### PR TITLE
fix(api-client/cells): change leavePartsOnError to false in S3Service [WPB-16843]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -143,7 +143,7 @@ describe('CellsAPI', () => {
           Inputs: [{Type: 'LEAF', Locator: {Path: TEST_FILE_PATH, Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
           FindAvailablePath: true,
         },
-        {signal: undefined},
+        {abortController: undefined},
       );
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
@@ -154,7 +154,7 @@ describe('CellsAPI', () => {
           'Create-Resource-Uuid': MOCKED_UUID,
           'Create-Version-Id': MOCKED_UUID,
         },
-        signal: undefined,
+        abortController: undefined,
       });
     });
 
@@ -269,7 +269,7 @@ describe('CellsAPI', () => {
           Inputs: [{Type: 'LEAF', Locator: {Path: '', Uuid: MOCKED_UUID}, VersionId: MOCKED_UUID}],
           FindAvailablePath: true,
         },
-        {signal: undefined},
+        {abortControllerntroller: undefined},
       );
 
       expect(mockStorage.putObject).toHaveBeenCalledWith({
@@ -280,7 +280,7 @@ describe('CellsAPI', () => {
           'Create-Resource-Uuid': MOCKED_UUID,
           'Create-Version-Id': MOCKED_UUID,
         },
-        signal: undefined,
+        abortController: undefined,
       });
     });
   });

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -104,7 +104,7 @@ export class CellsAPI {
     file,
     autoRename = true,
     progressCallback,
-    signal,
+    abortController,
   }: {
     uuid: string;
     versionId: string;
@@ -112,7 +112,7 @@ export class CellsAPI {
     file: File;
     autoRename?: boolean;
     progressCallback?: (progress: number) => void;
-    signal?: AbortSignal;
+    abortController?: AbortController;
   }): Promise<RestCreateCheckResponse> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
@@ -125,7 +125,7 @@ export class CellsAPI {
         Inputs: [{Type: 'LEAF', Locator: {Path: filePath, Uuid: uuid}, VersionId: versionId}],
         FindAvailablePath: true,
       },
-      {signal},
+      {signal: abortController?.signal},
     );
 
     if (autoRename && result.data.Results?.length && result.data.Results[0].Exists) {
@@ -138,7 +138,7 @@ export class CellsAPI {
       'Create-Version-Id': versionId,
     };
 
-    await this.storageService.putObject({path: filePath, file, metadata, progressCallback});
+    await this.storageService.putObject({path: filePath, file, metadata, progressCallback, abortController});
 
     return result.data;
   }

--- a/packages/api-client/src/cells/CellsStorage/CellsStorage.ts
+++ b/packages/api-client/src/cells/CellsStorage/CellsStorage.ts
@@ -23,11 +23,13 @@ export interface CellsStorage {
     file,
     metadata,
     progressCallback,
+    abortController,
   }: {
     path: string;
     file: File;
     metadata?: Record<string, string>;
     progressCallback?: (progress: number) => void;
+    abortController?: AbortController;
   }): Promise<void>;
 }
 

--- a/packages/api-client/src/cells/CellsStorage/S3Service.test.ts
+++ b/packages/api-client/src/cells/CellsStorage/S3Service.test.ts
@@ -71,7 +71,7 @@ describe('S3Service', () => {
         }),
         partSize: PART_SIZE,
         queueSize: MAX_QUEUE_SIZE,
-        leavePartsOnError: true,
+        leavePartsOnError: false,
         params: {
           Bucket: testConfig.bucket,
           Body: testFile,
@@ -80,6 +80,7 @@ describe('S3Service', () => {
           ContentLength: testFile.size,
           Metadata: undefined,
         },
+        abortController: undefined,
       });
     });
 

--- a/packages/api-client/src/cells/CellsStorage/S3Service.ts
+++ b/packages/api-client/src/cells/CellsStorage/S3Service.ts
@@ -66,7 +66,7 @@ export class S3Service implements CellsStorage {
       client: this.client,
       partSize: PART_SIZE,
       queueSize: MAX_QUEUE_SIZE,
-      leavePartsOnError: true,
+      leavePartsOnError: false,
       params: {
         Bucket: this.bucket,
         Body: file,

--- a/packages/api-client/src/cells/CellsStorage/S3Service.ts
+++ b/packages/api-client/src/cells/CellsStorage/S3Service.ts
@@ -56,11 +56,13 @@ export class S3Service implements CellsStorage {
     file,
     metadata,
     progressCallback,
+    abortController,
   }: {
     path: string;
     file: File;
     metadata?: Record<string, string>;
     progressCallback?: (progress: number) => void;
+    abortController?: AbortController;
   }): Promise<void> {
     const upload = new Upload({
       client: this.client,
@@ -75,6 +77,7 @@ export class S3Service implements CellsStorage {
         ContentLength: file.size,
         Metadata: metadata,
       },
+      abortController,
     });
 
     if (progressCallback) {


### PR DESCRIPTION
## Description

Change the AWS `leavePartsOnError` setting to `false` + switch `signal` to the abort controller.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
