### PR TITLE
feat: @pydio/protocol-messaging to @wireapp/protocol-messaging [WPB-16845]

### DIFF
--- a/archive/bot-api/package.json
+++ b/archive/bot-api/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/core": "workspace:^",
-    "@pydio/protocol-messaging": "1.49.0",
+    "@wireapp/protocol-messaging": "1.52.0",
     "@wireapp/store-engine": "workspace:^",
     "file-type": "16.5.4",
     "logdown": "^3.3.1",

--- a/archive/bot-api/src/MessageHandler.ts
+++ b/archive/bot-api/src/MessageHandler.ts
@@ -36,7 +36,7 @@ import {
   MentionContent,
 } from '@wireapp/core/lib/conversation/content/';
 import {QuotableMessage} from '@wireapp/core/lib/conversation/message/OtrMessage';
-import {Asset, Confirmation} from '@pydio/protocol-messaging';
+import {Asset, Confirmation} from '@wireapp/protocol-messaging';
 import FileType = require('file-type');
 
 import fs from 'fs';

--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **core:** @wireapp/protocol-messaging to @wireapp/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
+* **core:** @wireapp/protocol-messaging to @pydio/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
 
 # [27.25.0](https://github.com/wireapp/wire-web-packages/compare/@wireapp/api-client@27.24.0...@wireapp/api-client@27.25.0) (2025-03-12)
 
@@ -2070,7 +2070,7 @@ changed the types of conversation and user ids in @wireapp/bot-api MessageHandle
 
 ### BREAKING CHANGES
 
-* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by
+* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by 
 ```
 const {cancel, response} = await account.service.asset.uploadAsset(...);
 cancel() // This is how you cancel the upload
@@ -2217,7 +2217,7 @@ await response// This will contain the uploaded asset once the upload is done
 
 ### BREAKING CHANGES
 
-* **api-client:** - `getListConversations` is now renamed `getConversationsByQualifiedIds`
+* **api-client:** - `getListConversations` is now renamed `getConversationsByQualifiedIds` 
 - `getRemoteConversations` is now renamed `getConversationList`
 
 ## [13.9.2](https://github.com/wireapp/wire-web-packages/tree/main/packages/api-client/compare/@wireapp/api-client@13.9.1...@wireapp/api-client@13.9.2) (2021-09-29)

--- a/packages/api-client/CHANGELOG.md
+++ b/packages/api-client/CHANGELOG.md
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **core:** @wireapp/protocol-messaging to @pydio/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
+* **core:** @wireapp/protocol-messaging to @wireapp/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
 
 # [27.25.0](https://github.com/wireapp/wire-web-packages/compare/@wireapp/api-client@27.24.0...@wireapp/api-client@27.25.0) (2025-03-12)
 
@@ -2070,7 +2070,7 @@ changed the types of conversation and user ids in @wireapp/bot-api MessageHandle
 
 ### BREAKING CHANGES
 
-* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by 
+* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by
 ```
 const {cancel, response} = await account.service.asset.uploadAsset(...);
 cancel() // This is how you cancel the upload
@@ -2217,7 +2217,7 @@ await response// This will contain the uploaded asset once the upload is done
 
 ### BREAKING CHANGES
 
-* **api-client:** - `getListConversations` is now renamed `getConversationsByQualifiedIds` 
+* **api-client:** - `getListConversations` is now renamed `getConversationsByQualifiedIds`
 - `getRemoteConversations` is now renamed `getConversationList`
 
 ## [13.9.2](https://github.com/wireapp/wire-web-packages/tree/main/packages/api-client/compare/@wireapp/api-client@13.9.1...@wireapp/api-client@13.9.2) (2021-09-29)

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/lib-storage": "3.779.0",
     "@wireapp/commons": "workspace:^",
     "@wireapp/priority-queue": "workspace:^",
-    "@wireapp/protocol-messaging": "y1.52.0",
+    "@wireapp/protocol-messaging": "1.52.0",
     "axios": "1.7.9",
     "axios-retry": "4.5.0",
     "cells-sdk-ts": "https://github.com/pydio/cells-sdk-ts#v0.1.1-alpha07",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.750.0",
     "@aws-sdk/lib-storage": "3.779.0",
-    "@pydio/protocol-messaging": "1.51.0",
     "@wireapp/commons": "workspace:^",
     "@wireapp/priority-queue": "workspace:^",
+    "@wireapp/protocol-messaging": "y1.52.0",
     "axios": "1.7.9",
     "axios-retry": "4.5.0",
     "cells-sdk-ts": "https://github.com/pydio/cells-sdk-ts#v0.1.1-alpha07",

--- a/packages/api-client/src/broadcast/BroadcastAPI.ts
+++ b/packages/api-client/src/broadcast/BroadcastAPI.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {proteus as ProtobufOTR} from '@pydio/protocol-messaging/web/otr';
+import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
 import {AxiosRequestConfig} from 'axios';
 
 import {MessageSendingStatus} from '../conversation/';

--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -17,8 +17,8 @@
  *
  */
 
-import {proteus as ProtobufOTR} from '@pydio/protocol-messaging/web/otr';
 import {chunk} from '@wireapp/commons/lib/util/ArrayUtil';
+import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
 import {AxiosRequestConfig, isAxiosError} from 'axios';
 
 import {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **core:** @wireapp/protocol-messaging to @wireapp/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
+* **core:** @wireapp/protocol-messaging to @pydio/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
 
 ## [46.19.12](https://github.com/wireapp/wire-web-packages/compare/@wireapp/core@46.19.11...@wireapp/core@46.19.12) (2025-03-12)
 
@@ -3026,7 +3026,7 @@ changed the types of conversation and user ids in @wireapp/bot-api MessageHandle
 
 ### BREAKING CHANGES
 
-* To send `lastRead` and `countly` as protobuf message, you now need to provide a `MessageSendingOptions` object as last parameter.
+* To send `lastRead` and `countly` as protobuf message, you now need to provide a `MessageSendingOptions` object as last parameter. 
 
 ```js
 core.service.conversation.sendLastRead(conversation, timestamp, true);
@@ -3078,13 +3078,13 @@ If you were doing
 const account = new Account(apiClient, createStoreEngine);
 ```
 
-Now you need to do
+Now you need to do 
 
 ```js
 const account = new Account(apiClient, {createStore: createStoreEngine});
 ```
 
-- The `login` and `init` function do not take a storage engine parameter anymore. You now need to give a `createStore` function to the constructor in order to give a custom storage engine to the core.
+- The `login` and `init` function do not take a storage engine parameter anymore. You now need to give a `createStore` function to the constructor in order to give a custom storage engine to the core. 
 
 BEFORE
 
@@ -3394,7 +3394,7 @@ Replace `MessageBuilder.createImage({..., imageAsset: asset})` with `MessageBuil
 
 ### BREAKING CHANGES
 
-* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by
+* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by 
 ```
 const {cancel, response} = await account.service.asset.uploadAsset(...);
 cancel() // This is how you cancel the upload
@@ -7222,7 +7222,7 @@ await account.service.conversation.send(textPayload);
 
 ### BREAKING CHANGES
 
-* **core:** createText() now returns a TextContentBuilder.
+* **core:** createText() now returns a TextContentBuilder. 
 
 <a name="5.9.25"></a>
 ## [5.9.25](https://github.com/wireapp/wire-web-packages/tree/main/packages/core/compare/@wireapp/core@5.9.24...@wireapp/core@5.9.25) (2018-09-12)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* **core:** @wireapp/protocol-messaging to @pydio/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
+* **core:** @wireapp/protocol-messaging to @wireapp/protocol-messaging [WPB-16433] ([#6978](https://github.com/wireapp/wire-web-packages/issues/6978)) ([c06b24b](https://github.com/wireapp/wire-web-packages/commit/c06b24b19e69ba04d95884cabbb129dc447437ca))
 
 ## [46.19.12](https://github.com/wireapp/wire-web-packages/compare/@wireapp/core@46.19.11...@wireapp/core@46.19.12) (2025-03-12)
 
@@ -3026,7 +3026,7 @@ changed the types of conversation and user ids in @wireapp/bot-api MessageHandle
 
 ### BREAKING CHANGES
 
-* To send `lastRead` and `countly` as protobuf message, you now need to provide a `MessageSendingOptions` object as last parameter. 
+* To send `lastRead` and `countly` as protobuf message, you now need to provide a `MessageSendingOptions` object as last parameter.
 
 ```js
 core.service.conversation.sendLastRead(conversation, timestamp, true);
@@ -3078,13 +3078,13 @@ If you were doing
 const account = new Account(apiClient, createStoreEngine);
 ```
 
-Now you need to do 
+Now you need to do
 
 ```js
 const account = new Account(apiClient, {createStore: createStoreEngine});
 ```
 
-- The `login` and `init` function do not take a storage engine parameter anymore. You now need to give a `createStore` function to the constructor in order to give a custom storage engine to the core. 
+- The `login` and `init` function do not take a storage engine parameter anymore. You now need to give a `createStore` function to the constructor in order to give a custom storage engine to the core.
 
 BEFORE
 
@@ -3394,7 +3394,7 @@ Replace `MessageBuilder.createImage({..., imageAsset: asset})` with `MessageBuil
 
 ### BREAKING CHANGES
 
-* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by 
+* **core:** Uploading an asset now return a structure that allow cancelling the upload. Thus instances of `await account.service.asset.uploadAsset(...)` must be replaced by
 ```
 const {cancel, response} = await account.service.asset.uploadAsset(...);
 cancel() // This is how you cancel the upload
@@ -7222,7 +7222,7 @@ await account.service.conversation.send(textPayload);
 
 ### BREAKING CHANGES
 
-* **core:** createText() now returns a TextContentBuilder. 
+* **core:** createText() now returns a TextContentBuilder.
 
 <a name="5.9.25"></a>
 ## [5.9.25](https://github.com/wireapp/wire-web-packages/tree/main/packages/core/compare/@wireapp/core@5.9.24...@wireapp/core@5.9.25) (2018-09-12)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,13 +11,13 @@
     "./lib/cryptography/AssetCryptography/crypto.node": "./lib/cryptography/AssetCryptography/crypto.browser.js"
   },
   "dependencies": {
-    "@pydio/protocol-messaging": "^1.51.0",
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
     "@wireapp/core-crypto": "3.1.0",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "workspace:^",
     "@wireapp/promise-queue": "workspace:^",
+    "@wireapp/protocol-messaging": "1.52.0",
     "@wireapp/store-engine": "workspace:*",
     "axios": "1.7.9",
     "bazinga64": "workspace:^",

--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {GenericMessage, Text} from '@pydio/protocol-messaging';
 import {AuthAPI} from '@wireapp/api-client/lib/auth';
 import {ClientAPI, ClientClassification, ClientType, RegisteredClient} from '@wireapp/api-client/lib/client';
 import {ConversationAPI} from '@wireapp/api-client/lib/conversation';
@@ -34,6 +33,7 @@ import {v4 as uuidv4} from 'uuid';
 
 import {APIClient} from '@wireapp/api-client';
 import {AccentColor, ValidationUtil} from '@wireapp/commons';
+import {GenericMessage, Text} from '@wireapp/protocol-messaging';
 
 import {Account, ConnectionState} from './Account';
 import {NotificationSource} from './notification';

--- a/packages/core/src/broadcast/AvailabilityType.ts
+++ b/packages/core/src/broadcast/AvailabilityType.ts
@@ -17,6 +17,6 @@
  *
  */
 
-import {Availability} from '@pydio/protocol-messaging';
+import {Availability} from '@wireapp/protocol-messaging';
 
 export type AvailabilityType = Availability.Type;

--- a/packages/core/src/broadcast/BroadcastService.ts
+++ b/packages/core/src/broadcast/BroadcastService.ts
@@ -17,10 +17,10 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {MessageSendingStatus, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 
 import {APIClient} from '@wireapp/api-client';
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {sendMessage} from '../conversation/message/messageSender';
 import {MessageService} from '../conversation/message/MessageService';

--- a/packages/core/src/conversation/AbortReason.ts
+++ b/packages/core/src/conversation/AbortReason.ts
@@ -17,6 +17,6 @@
  *
  */
 
-import {Asset} from '@pydio/protocol-messaging';
+import {Asset} from '@wireapp/protocol-messaging';
 
 export type AbortReason = Asset.NotUploaded;

--- a/packages/core/src/conversation/ClientActionType.ts
+++ b/packages/core/src/conversation/ClientActionType.ts
@@ -17,4 +17,4 @@
  *
  */
 
-export {ClientAction as ClientActionType} from '@pydio/protocol-messaging';
+export {ClientAction as ClientActionType} from '@wireapp/protocol-messaging';

--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {ClientClassification, ClientType} from '@wireapp/api-client/lib/client';
 import {
   Conversation,
@@ -36,6 +35,7 @@ import {QualifiedId} from '@wireapp/api-client/lib/user';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';
 
 import {APIClient} from '@wireapp/api-client';
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {AddUsersFailure, AddUsersFailureReasons, ConversationService, MessageSendingState} from '..';
 import {MLSService} from '../../messagingProtocols/mls';

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {
   Conversation,
   DefaultConversationRoleName,
@@ -48,6 +47,7 @@ import {Decoder} from 'bazinga64';
 
 import {APIClient} from '@wireapp/api-client';
 import {LogFactory, TypedEventEmitter} from '@wireapp/commons';
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {
   AddUsersFailure,
@@ -271,7 +271,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
    * Will create a conversation on backend and register it to CoreCrypto once created
    * @param conversationData
    */
-  public async createMLSConversation(
+  public async createMLSConvcersation(
     conversationData: NewConversation,
     selfUserId: QualifiedId,
     selfClientId: string,

--- a/packages/core/src/conversation/ConversationService/ConversationService.types.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.types.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {
   QualifiedUserClients,
   ConversationProtocol,
@@ -26,6 +25,8 @@ import {
 } from '@wireapp/api-client/lib/conversation';
 import {ConversationEvent, ConversationMemberJoinEvent} from '@wireapp/api-client/lib/event';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {MessageSendingState} from '..';
 

--- a/packages/core/src/conversation/content/AssetContent.ts
+++ b/packages/core/src/conversation/content/AssetContent.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Asset} from '@pydio/protocol-messaging';
+import {Asset} from '@wireapp/protocol-messaging';
 
 import {AbortReason, AssetTransferState} from '..';
 import {EncryptedAssetUploaded} from '../../cryptography';

--- a/packages/core/src/conversation/content/ButtonActionConfirmationContent.ts
+++ b/packages/core/src/conversation/content/ButtonActionConfirmationContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IButtonActionConfirmation} from '@pydio/protocol-messaging';
+import {IButtonActionConfirmation} from '@wireapp/protocol-messaging';
 export {IButtonActionConfirmation as ButtonActionConfirmationContent};

--- a/packages/core/src/conversation/content/ButtonActionContent.ts
+++ b/packages/core/src/conversation/content/ButtonActionContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IButtonAction} from '@pydio/protocol-messaging';
+import {IButtonAction} from '@wireapp/protocol-messaging';
 export {IButtonAction as ButtonActionContent};

--- a/packages/core/src/conversation/content/ClearedContent.ts
+++ b/packages/core/src/conversation/content/ClearedContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {ICleared} from '@pydio/protocol-messaging';
+import {ICleared} from '@wireapp/protocol-messaging';
 export {ICleared as ClearedContent};

--- a/packages/core/src/conversation/content/ClientActionContent.ts
+++ b/packages/core/src/conversation/content/ClientActionContent.ts
@@ -17,6 +17,6 @@
  *
  */
 
-import {IGenericMessage} from '@pydio/protocol-messaging';
+import {IGenericMessage} from '@wireapp/protocol-messaging';
 
 export type ClientActionContent = Required<Pick<IGenericMessage, 'clientAction'>>;

--- a/packages/core/src/conversation/content/CompositeContent.ts
+++ b/packages/core/src/conversation/content/CompositeContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IComposite} from '@pydio/protocol-messaging';
+import {IComposite} from '@wireapp/protocol-messaging';
 export {IComposite as CompositeContent};

--- a/packages/core/src/conversation/content/ConfirmationContent.ts
+++ b/packages/core/src/conversation/content/ConfirmationContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IConfirmation} from '@pydio/protocol-messaging';
+import {IConfirmation} from '@wireapp/protocol-messaging';
 export {IConfirmation as ConfirmationContent};

--- a/packages/core/src/conversation/content/DeletedContent.ts
+++ b/packages/core/src/conversation/content/DeletedContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IMessageDelete} from '@pydio/protocol-messaging';
+import {IMessageDelete} from '@wireapp/protocol-messaging';
 export {IMessageDelete as DeletedContent};

--- a/packages/core/src/conversation/content/HiddenContent.ts
+++ b/packages/core/src/conversation/content/HiddenContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IMessageHide} from '@pydio/protocol-messaging';
+import {IMessageHide} from '@wireapp/protocol-messaging';
 export {IMessageHide as HiddenContent};

--- a/packages/core/src/conversation/content/KnockContent.ts
+++ b/packages/core/src/conversation/content/KnockContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IKnock} from '@pydio/protocol-messaging';
+import {IKnock} from '@wireapp/protocol-messaging';
 export {IKnock as KnockContent};

--- a/packages/core/src/conversation/content/LinkPreviewContent.ts
+++ b/packages/core/src/conversation/content/LinkPreviewContent.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {ILinkPreview} from '@pydio/protocol-messaging';
+import {ILinkPreview} from '@wireapp/protocol-messaging';
 
 import {ImageAssetContent, ImageContent, LegalHoldStatus} from '.';
 

--- a/packages/core/src/conversation/content/MentionContent.ts
+++ b/packages/core/src/conversation/content/MentionContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {IMention} from '@pydio/protocol-messaging';
+import {IMention} from '@wireapp/protocol-messaging';
 export {IMention as MentionContent};

--- a/packages/core/src/conversation/content/MultipartContent.ts
+++ b/packages/core/src/conversation/content/MultipartContent.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {IMultipart, IAttachment, ICellAsset, IAsset} from '@pydio/protocol-messaging';
+import {IMultipart, IAttachment, ICellAsset, IAsset} from '@wireapp/protocol-messaging';
 export {IMultipart as MultiPartContent};
 export {IAttachment as MultiPartAttachment};
 export {ICellAsset as MultiPartCellAsset};

--- a/packages/core/src/conversation/content/QuoteContent.ts
+++ b/packages/core/src/conversation/content/QuoteContent.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {IQuote} from '@pydio/protocol-messaging';
+import {IQuote} from '@wireapp/protocol-messaging';
 
 import {AssetContent, LocationContent, MultiPartContent, TextContent} from '.';
 

--- a/packages/core/src/conversation/content/TweetContent.ts
+++ b/packages/core/src/conversation/content/TweetContent.ts
@@ -17,5 +17,5 @@
  *
  */
 
-import {ITweet} from '@pydio/protocol-messaging';
+import {ITweet} from '@wireapp/protocol-messaging';
 export {ITweet as TweetContent};

--- a/packages/core/src/conversation/content/index.ts
+++ b/packages/core/src/conversation/content/index.ts
@@ -17,7 +17,7 @@
  *
  */
 
-export {LegalHoldStatus} from '@pydio/protocol-messaging';
+export {LegalHoldStatus} from '@wireapp/protocol-messaging';
 export {Connection as ConnectionContent} from '@wireapp/api-client/lib/connection/';
 
 import * as ContentType from './ContentType.guards';

--- a/packages/core/src/conversation/message/MessageBuilder.ts
+++ b/packages/core/src/conversation/message/MessageBuilder.ts
@@ -17,6 +17,9 @@
  *
  */
 
+import {QualifiedId} from '@wireapp/api-client/lib/user';
+import {v4 as uuidv4} from 'uuid';
+
 import {
   IComposite,
   Asset,
@@ -40,9 +43,7 @@ import {
   Cleared,
   ICalling,
   InCallHandRaise,
-} from '@pydio/protocol-messaging';
-import {QualifiedId} from '@wireapp/api-client/lib/user';
-import {v4 as uuidv4} from 'uuid';
+} from '@wireapp/protocol-messaging';
 
 import {
   ButtonActionConfirmationMessage,

--- a/packages/core/src/conversation/message/MessageService.test.ts
+++ b/packages/core/src/conversation/message/MessageService.test.ts
@@ -17,7 +17,6 @@
  *
  */
 
-import {GenericMessage, Text} from '@pydio/protocol-messaging';
 import {
   MessageSendingStatus,
   OTRRecipients,
@@ -28,6 +27,7 @@ import {StatusCodes} from 'http-status-codes';
 import {v4 as uuidv4} from 'uuid';
 
 import {APIClient} from '@wireapp/api-client';
+import {GenericMessage, Text} from '@wireapp/protocol-messaging';
 
 import {MessageService} from './MessageService';
 

--- a/packages/core/src/conversation/message/MessageService.ts
+++ b/packages/core/src/conversation/message/MessageService.ts
@@ -17,10 +17,10 @@
  *
  */
 
-import {proteus as ProtobufOTR} from '@pydio/protocol-messaging/web/otr';
 import {MessageSendingStatus, QualifiedOTRRecipients, QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId, QualifiedUserPreKeyBundleMap} from '@wireapp/api-client/lib/user';
 import {uuidToBytes} from '@wireapp/commons/lib/util/StringUtil';
+import {proteus as ProtobufOTR} from '@wireapp/protocol-messaging/web/otr';
 import {AxiosError} from 'axios';
 import {deepmerge} from 'deepmerge-ts';
 import {StatusCodes as HTTP_STATUS} from 'http-status-codes';

--- a/packages/core/src/conversation/message/MessageToProtoMapper.ts
+++ b/packages/core/src/conversation/message/MessageToProtoMapper.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {Article, Asset, LinkPreview, Mention, Quote, Text, Tweet} from '@pydio/protocol-messaging';
+import {Article, Asset, LinkPreview, Mention, Quote, Text, Tweet} from '@wireapp/protocol-messaging';
 
 import {EditedTextContent, LinkPreviewUploadedContent, TextContent} from '../content';
 import {GenericMessageType} from '../GenericMessageType';

--- a/packages/core/src/demo/echo.ts
+++ b/packages/core/src/demo/echo.ts
@@ -26,7 +26,7 @@ import {WebSocketClient} from '@wireapp/api-client/lib/tcp/';
 import {ClientType} from '@wireapp/api-client/lib/client/ClientType';
 import {ConnectionStatus} from '@wireapp/api-client/lib/connection/';
 import {CONVERSATION_TYPING} from '@wireapp/api-client/lib/conversation/data/';
-import {LegalHoldStatus, Confirmation} from '@pydio/protocol-messaging';
+import {LegalHoldStatus, Confirmation} from '@wireapp/protocol-messaging';
 import {AssetContent} from '../main/conversation/content/AssetContent';
 import {LinkPreviewUploadedContent} from '../main/conversation/content';
 import {MessageBuilder} from '../main/conversation/message/MessageBuilder';

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
@@ -17,9 +17,10 @@
  *
  */
 
-import {GenericMessage, Text} from '@pydio/protocol-messaging';
 import {CONVERSATION_EVENT, ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
 import {QualifiedId} from '@wireapp/api-client/lib/user';
+
+import {GenericMessage, Text} from '@wireapp/protocol-messaging';
 
 import {handleMLSMessageAdd} from './messageAdd';
 

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
@@ -17,9 +17,10 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {ConversationMLSMessageAddEvent} from '@wireapp/api-client/lib/event';
 import {Decoder} from 'bazinga64';
+
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {HandledEventPayload} from '../../../../../notification';
 import {MLSService, optionalToUint8Array} from '../../../MLSService/MLSService';

--- a/packages/core/src/messagingProtocols/mls/MLSService/commitBundleUtil.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/commitBundleUtil.test.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {mls} from '@pydio/protocol-messaging/web/mls';
+import {mls} from '@wireapp/protocol-messaging/web/mls';
 import {Encoder} from 'bazinga64';
 
 import {CommitBundle, RatchetTreeType, GroupInfoEncryptionType} from '@wireapp/core-crypto';

--- a/packages/core/src/messagingProtocols/mls/MLSService/commitBundleUtil.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/commitBundleUtil.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import {mls} from '@pydio/protocol-messaging/web/mls';
+import {mls} from '@wireapp/protocol-messaging/web/mls';
 
 import {CommitBundle, GroupInfoEncryptionType, RatchetTreeType} from '@wireapp/core-crypto';
 

--- a/packages/core/src/messagingProtocols/proteus/EventHandler/events/otrMessageAdd/otrMessageAdd.ts
+++ b/packages/core/src/messagingProtocols/proteus/EventHandler/events/otrMessageAdd/otrMessageAdd.ts
@@ -17,9 +17,10 @@
  *
  */
 
-import {ClientAction, GenericMessage} from '@pydio/protocol-messaging';
 import {ConversationOtrMessageAddEvent} from '@wireapp/api-client/lib/event';
 import {Decoder} from 'bazinga64';
+
+import {ClientAction, GenericMessage} from '@wireapp/protocol-messaging';
 
 import {GenericMessageType} from '../../../../../conversation';
 import {DecryptionError} from '../../../../../errors/DecryptionError';

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -36,7 +36,7 @@ import {SendProteusMessageParams} from './ProteusService.types';
 import {buildProteusService} from './ProteusService.mocks';
 import {constructSessionId} from '../Utility/SessionHandler';
 import {CONVERSATION_EVENT, ConversationOtrMessageAddEvent} from '@wireapp/api-client/lib/event';
-import {GenericMessage} from '@pydio/protocol-messaging';
+import {GenericMessage} from '@wireapp/protocol-messaging';
 import {ProteusService} from './ProteusService';
 import {NonFederatingBackendsError} from '../../../errors';
 import {generateQualifiedId, generateQualifiedIds} from '../../../testUtils';

--- a/packages/core/src/messagingProtocols/proteus/Utility/getGenericMessageParams.ts
+++ b/packages/core/src/messagingProtocols/proteus/Utility/getGenericMessageParams.ts
@@ -17,10 +17,11 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {APIClient} from '@wireapp/api-client/lib/APIClient';
 import {QualifiedUserClients} from '@wireapp/api-client/lib/conversation';
 import {QualifiedId, QualifiedUserPreKeyBundleMap} from '@wireapp/api-client/lib/user';
+
+import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {getRecipientsForConversation} from './Recipients';
 import {extractQualifiedUserIds} from './UserIds';

--- a/packages/core/src/notification/NotificationService.ts
+++ b/packages/core/src/notification/NotificationService.ts
@@ -17,12 +17,12 @@
  *
  */
 
-import {GenericMessage} from '@pydio/protocol-messaging';
 import {BackendEvent} from '@wireapp/api-client/lib/event';
 import {Notification} from '@wireapp/api-client/lib/notification/';
 
 import {APIClient} from '@wireapp/api-client';
 import {LogFactory, TypedEventEmitter} from '@wireapp/commons';
+import {GenericMessage} from '@wireapp/protocol-messaging';
 import {CRUDEngine, error as StoreEngineError} from '@wireapp/store-engine';
 
 import {NotificationBackendRepository} from './NotificationBackendRepository';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4672,18 +4672,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pydio/protocol-messaging@npm:1.51.0, @pydio/protocol-messaging@npm:^1.51.0":
-  version: 1.51.0
-  resolution: "@pydio/protocol-messaging@npm:1.51.0"
-  dependencies:
-    long: 5.2.0
-    protobufjs: 7.2.5
-    protobufjs-cli: 1.1.2
-    typescript: 4.8.4
-  checksum: d3eb6d2d1bf71d93125933b0bb2a90a414dee23b3a2fb31621483531dd524e1f306b261d1995b6fd441b891f85e930d193538ed519ca0d7c8afcbf0072d6e144
-  languageName: node
-  linkType: hard
-
 "@rollup/pluginutils@npm:^5.1.4":
   version: 5.1.4
   resolution: "@rollup/pluginutils@npm:5.1.4"
@@ -7743,7 +7731,6 @@ __metadata:
   dependencies:
     "@aws-sdk/client-s3": 3.750.0
     "@aws-sdk/lib-storage": 3.779.0
-    "@pydio/protocol-messaging": 1.51.0
     "@swc/core": ^1.3.10
     "@swc/jest": ^0.2.23
     "@types/axios": ^0.14.0
@@ -7755,6 +7742,7 @@ __metadata:
     "@types/ws": 8.5.14
     "@wireapp/commons": "workspace:^"
     "@wireapp/priority-queue": "workspace:^"
+    "@wireapp/protocol-messaging": 1.52.0
     "@wireapp/store-engine": "workspace:^"
     "@wireapp/store-engine-fs": "workspace:^"
     axios: 1.7.9
@@ -7863,7 +7851,6 @@ __metadata:
   resolution: "@wireapp/core@workspace:packages/core"
   dependencies:
     "@faker-js/faker": ^9.0.0
-    "@pydio/protocol-messaging": ^1.51.0
     "@swc/core": ^1.3.10
     "@swc/jest": ^0.2.23
     "@types/jest": ^29.2.0
@@ -7876,6 +7863,7 @@ __metadata:
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/priority-queue": "workspace:^"
     "@wireapp/promise-queue": "workspace:^"
+    "@wireapp/protocol-messaging": 1.52.0
     "@wireapp/store-engine": "workspace:*"
     axios: 1.7.9
     bazinga64: "workspace:^"
@@ -8028,6 +8016,18 @@ __metadata:
     "@wireapp/cbor": 4.7.3
     libsodium-wrappers-sumo: 0.7.9
   checksum: 46cf49b00ebe66caf67ef38dff5a6ca8ba238fa72a73eb6bda6812da370df1c7a2e20a8d47d8ac01eea90d1a4fc1c1c43119261e6a84c0eabdfc5b6bd227cc14
+  languageName: node
+  linkType: hard
+
+"@wireapp/protocol-messaging@npm:1.52.0":
+  version: 1.52.0
+  resolution: "@wireapp/protocol-messaging@npm:1.52.0"
+  dependencies:
+    long: 5.2.0
+    protobufjs: 7.2.5
+    protobufjs-cli: 1.1.2
+    typescript: 4.8.4
+  checksum: 16dd138d148c1bc07fb56f27c42d9d5f3fc80aebbd356d74bb9f02c4b79936cf94964faa14ea229f27e7a0c6e4b708b7c10b3002314e5c0817916249fce9bcc4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

The multipart message changes have been merged https://github.com/wireapp/generic-message-proto/pull/91.

With them on the main branch, we can bring back `@wireapp/protocol-messaging` package, replaced by `@pydio/protocol-messaging` in https://github.com/wireapp/wire-web-packages/pull/6978

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
