### PR TITLE
feat(mls): detect a client mismatch and emit an specific event [WPB-16934]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -519,6 +519,12 @@ export class Account extends TypedEventEmitter<Events> {
     this.resetContext();
   }
 
+  private async wipeCommonData(): Promise<void> {
+    await this.service?.client.deleteLocalClient();
+    // needs to be wiped last
+    await this.encryptedDb?.wipe();
+  }
+
   /**
    * Will delete the identity and history of the current user
    */
@@ -527,9 +533,7 @@ export class Account extends TypedEventEmitter<Events> {
     if (this.db) {
       await deleteDB(this.db);
     }
-    await this.service?.client.deleteLocalClient();
-    // needs to be wiped last
-    await this.encryptedDb?.wipe();
+    await this.wipeCommonData();
   }
 
   /**
@@ -541,9 +545,7 @@ export class Account extends TypedEventEmitter<Events> {
     if (this.storeEngine) {
       await deleteIdentity(this.storeEngine, true);
     }
-    await this.service?.client.deleteLocalClient();
-    // needs to be wiped last
-    await this.encryptedDb?.wipe();
+    await this.wipeCommonData();
   }
 
   /**

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.test.ts
@@ -25,7 +25,7 @@ import {APIClient} from '@wireapp/api-client';
 
 import {SubconversationService} from './SubconversationService';
 
-import {MLSService} from '../../messagingProtocols/mls';
+import {MLSService, MLSServiceEvents} from '../../messagingProtocols/mls';
 import {openDB} from '../../storage/CoreDB';
 import {constructFullyQualifiedClientId} from '../../util/fullyQualifiedClientIdUtils';
 
@@ -491,7 +491,7 @@ describe('SubconversationService', () => {
       );
 
       expect(mlsService.getEpoch).toHaveBeenCalledWith(subconversationGroupId);
-      expect(mlsService.on).toHaveBeenCalledWith('newEpoch', expect.any(Function));
+      expect(mlsService.on).toHaveBeenCalledWith(MLSServiceEvents.NEW_EPOCH, expect.any(Function));
       expect(subconversationService.getSubconversationEpochInfo).toHaveBeenCalledWith(
         parentConversationId,
         parentConversationGroupId,
@@ -499,7 +499,7 @@ describe('SubconversationService', () => {
       expect(onEpochUpdateCallback).toHaveBeenCalledWith(mockedEpochInfo);
 
       unsubscribe();
-      expect(mlsService.off).toHaveBeenCalledWith('newEpoch', expect.any(Function));
+      expect(mlsService.off).toHaveBeenCalledWith(MLSServiceEvents.NEW_EPOCH, expect.any(Function));
     });
   });
 

--- a/packages/core/src/conversation/SubconversationService/SubconversationService.ts
+++ b/packages/core/src/conversation/SubconversationService/SubconversationService.ts
@@ -26,7 +26,7 @@ import {LogFactory, TypedEventEmitter} from '@wireapp/commons';
 
 import {generateSubconversationStoreKey} from './subconversationUtil';
 
-import {MLSService} from '../../messagingProtocols/mls';
+import {MLSService, MLSServiceEvents} from '../../messagingProtocols/mls';
 import {CoreDatabase} from '../../storage/CoreDB';
 import {constructFullyQualifiedClientId} from '../../util/fullyQualifiedClientIdUtils';
 
@@ -255,11 +255,11 @@ export class SubconversationService extends TypedEventEmitter<Events> {
       });
     };
 
-    this.mlsService.on('newEpoch', forwardNewEpoch);
+    this.mlsService.on(MLSServiceEvents.NEW_EPOCH, forwardNewEpoch);
 
     await forwardNewEpoch({groupId: subconversationGroupId, epoch: initialEpoch});
 
-    return () => this.mlsService.off('newEpoch', forwardNewEpoch);
+    return () => this.mlsService.off(MLSServiceEvents.NEW_EPOCH, forwardNewEpoch);
   }
 
   public async removeClientFromConferenceSubconversation(

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -34,7 +34,7 @@ import {parseFullQualifiedClientId} from '../../../util/fullyQualifiedClientIdUt
 import {LowPrecisionTaskScheduler} from '../../../util/LowPrecisionTaskScheduler';
 import {StringifiedQualifiedId, stringifyQualifiedId} from '../../../util/qualifiedIdUtil';
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
-import {MLSService} from '../MLSService';
+import {MLSService, MLSServiceEvents} from '../MLSService';
 
 export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {
   status?: DeviceStatus;
@@ -205,7 +205,7 @@ export class E2EIServiceExternal extends TypedEventEmitter<Events> {
   public async initialize(discoveryUrl: string): Promise<void> {
     this._acmeService = new AcmeService(discoveryUrl);
 
-    this.mlsService.on('newCrlDistributionPoints', distributionPoints =>
+    this.mlsService.on(MLSServiceEvents.NEW_CRL_DISTRIBUTION_POINTS, distributionPoints =>
       this.handleNewCrlDistributionPoints(distributionPoints),
     );
 

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
@@ -77,7 +77,7 @@ export const getMLSDeviceStatus = (
   const signatureAlogrithm = getSignatureAlgorithmForCiphersuite(ciphersuite);
   const signature = mls_public_keys[signatureAlogrithm];
 
-  if (!signature) {
+  if (!signature || !existingClientSignature) {
     return MLSDeviceStatus.FRESH;
   }
   if (signature !== existingClientSignature) {

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/Helper/index.ts
@@ -64,4 +64,26 @@ export const isMLSDevice = ({mls_public_keys}: RegisteredClient, ciphersuite: Ci
   return typeof signature === 'string' && signature.length > 0;
 };
 
+export enum MLSDeviceStatus {
+  REGISTERED = 'registered',
+  FRESH = 'fresh',
+  MISMATCH = 'mismatch',
+}
+export const getMLSDeviceStatus = (
+  {mls_public_keys}: RegisteredClient,
+  ciphersuite: Ciphersuite,
+  existingClientSignature: string,
+): MLSDeviceStatus => {
+  const signatureAlogrithm = getSignatureAlgorithmForCiphersuite(ciphersuite);
+  const signature = mls_public_keys[signatureAlogrithm];
+
+  if (!signature) {
+    return MLSDeviceStatus.FRESH;
+  }
+  if (signature !== existingClientSignature) {
+    return MLSDeviceStatus.MISMATCH;
+  }
+  return MLSDeviceStatus.REGISTERED;
+};
+
 export const isResponseStatusValid = (status: string | undefined) => status && status === 'valid';

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.test.ts
@@ -24,7 +24,7 @@ import {GenericMessage, Text} from '@wireapp/protocol-messaging';
 
 import {handleMLSMessageAdd} from './messageAdd';
 
-import {MLSService} from '../../../MLSService';
+import {MLSService, MLSServiceEvents} from '../../../MLSService';
 
 const mockedMLSService = {
   getGroupIdFromConversationId: jest.fn(),
@@ -115,7 +115,7 @@ describe('handleMLSMessageAdd', () => {
 
     await handleMLSMessageAdd({event, mlsService: mockedMLSService, groupId: mockGroupId});
 
-    expect(mockedMLSService.emit).toHaveBeenCalledWith('newEpoch', {
+    expect(mockedMLSService.emit).toHaveBeenCalledWith(MLSServiceEvents.NEW_EPOCH, {
       groupId: mockGroupId,
       epoch: mockedNewEpoch,
     });

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
@@ -23,7 +23,7 @@ import {Decoder} from 'bazinga64';
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
 import {HandledEventPayload} from '../../../../../notification';
-import {MLSService, optionalToUint8Array} from '../../../MLSService/MLSService';
+import {MLSService, MLSServiceEvents, optionalToUint8Array} from '../../../MLSService/MLSService';
 
 interface HandleMLSMessageAddParams {
   event: ConversationMLSMessageAddEvent;
@@ -67,7 +67,7 @@ export const handleMLSMessageAdd = async ({
 
   if (hasEpochChanged) {
     const newEpoch = await mlsService.getEpoch(groupId);
-    mlsService.emit('newEpoch', {groupId, epoch: newEpoch});
+    mlsService.emit(MLSServiceEvents.NEW_EPOCH, {groupId, epoch: newEpoch});
   }
 
   return message ? {event, decryptedData: GenericMessage.decode(message)} : null;

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.test.ts
@@ -21,7 +21,7 @@ import {ConversationMLSWelcomeEvent, CONVERSATION_EVENT} from '@wireapp/api-clie
 
 import {handleMLSWelcomeMessage} from './welcomeMessage';
 
-import {MLSService} from '../../..';
+import {MLSService, MLSServiceEvents} from '../../..';
 import {NotificationSource} from '../../../../../notification';
 
 jest.mock('bazinga64', () => ({
@@ -71,7 +71,10 @@ describe('MLS welcomeMessage eventHandler', () => {
 
       await handleMLSWelcomeMessage(mockParams);
 
-      expect(mockParams.mlsService.emit).toHaveBeenCalledWith('newEpoch', {groupId: 'conversationId', epoch: 1});
+      expect(mockParams.mlsService.emit).toHaveBeenCalledWith(MLSServiceEvents.NEW_EPOCH, {
+        groupId: 'conversationId',
+        epoch: 1,
+      });
     });
   });
 });

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
@@ -21,7 +21,7 @@ import {ConversationMLSWelcomeEvent} from '@wireapp/api-client/lib/event';
 import {Decoder, Encoder} from 'bazinga64';
 
 import {HandledEventPayload} from '../../../../../notification';
-import {MLSService} from '../../../MLSService';
+import {MLSService, MLSServiceEvents} from '../../../MLSService';
 
 interface HandleWelcomeMessageParams {
   event: ConversationMLSWelcomeEvent;
@@ -43,7 +43,7 @@ export const handleMLSWelcomeMessage = async ({
   await mlsService.scheduleKeyMaterialRenewal(groupIdStr);
 
   const newEpoch = await mlsService.getEpoch(groupIdStr);
-  mlsService.emit('newEpoch', {groupId: groupIdStr, epoch: newEpoch});
+  mlsService.emit(MLSServiceEvents.NEW_EPOCH, {groupId: groupIdStr, epoch: newEpoch});
 
   return {
     event: {...event, data: groupIdStr},

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -32,7 +32,7 @@ import {APIClient} from '@wireapp/api-client';
 import {Ciphersuite, CommitBundle, CoreCrypto, DecryptedMessage} from '@wireapp/core-crypto';
 
 import {CORE_CRYPTO_ERROR_NAMES} from './CoreCryptoMLSError';
-import {InitClientOptions, MLSService} from './MLSService';
+import {InitClientOptions, MLSService, MLSServiceEvents} from './MLSService';
 
 import {AddUsersFailure, AddUsersFailureReasons} from '../../../conversation';
 import {openDB} from '../../../storage/CoreDB';
@@ -616,7 +616,10 @@ describe('MLSService', () => {
 
       await mlsService.handleMLSMessageAddEvent(mockedMLSWelcomeEvent, getGroupIdFromConversationId);
       expect(mockCoreCrypto.transaction).toHaveBeenCalled();
-      expect(mlsService.emit).toHaveBeenCalledWith('newEpoch', {epoch: mockedNewEpoch, groupId: mockGroupId});
+      expect(mlsService.emit).toHaveBeenCalledWith(MLSServiceEvents.NEW_EPOCH, {
+        epoch: mockedNewEpoch,
+        groupId: mockGroupId,
+      });
     });
 
     it('handles pending propoals with a delay after decrypting a message', async () => {

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.test.ts
@@ -458,12 +458,10 @@ describe('MLSService', () => {
 
       apiClient.context = {clientType: ClientType.PERMANENT, clientId: mockClientId, userId: ''};
 
-      const mockedClientPublicKey = new Uint8Array();
-
-      jest.spyOn(coreCrypto, 'clientPublicKey').mockResolvedValueOnce(mockedClientPublicKey);
       jest.spyOn(apiClient.api.client, 'putClient').mockResolvedValueOnce(undefined);
       jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
       jest.spyOn(Helper, 'getMLSDeviceStatus').mockReturnValueOnce(Helper.MLSDeviceStatus.FRESH);
+      jest.spyOn(coreCrypto, 'clientPublicKey').mockResolvedValue(new Uint8Array());
 
       await mlsService.initClient(mockUserId, mockClient, defaultMLSInitConfig);
 
@@ -483,6 +481,7 @@ describe('MLSService', () => {
 
       const mockedClientKeyPackages = [new Uint8Array()];
       jest.spyOn(coreCrypto, 'clientKeypackages').mockResolvedValueOnce(mockedClientKeyPackages);
+      jest.spyOn(coreCrypto, 'clientPublicKey').mockResolvedValueOnce(new Uint8Array());
       jest.spyOn(Helper, 'getMLSDeviceStatus').mockReturnValueOnce(Helper.MLSDeviceStatus.REGISTERED);
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages').mockResolvedValueOnce(undefined);
 
@@ -510,6 +509,8 @@ describe('MLSService', () => {
       jest.spyOn(apiClient.api.client, 'getMLSKeyPackageCount').mockResolvedValueOnce(mlsService.config.nbKeyPackages);
       jest.spyOn(apiClient.api.client, 'uploadMLSKeyPackages');
       jest.spyOn(apiClient.api.client, 'putClient');
+
+      jest.spyOn(coreCrypto, 'clientPublicKey').mockResolvedValueOnce(new Uint8Array());
 
       await mlsService.initClient(mockUserId, mockClient, defaultMLSInitConfig);
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -55,7 +55,12 @@ import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {TaskScheduler} from '../../../util/TaskScheduler';
 import {User} from '../E2EIdentityService';
 import {E2EIServiceInternal, getTokenCallback} from '../E2EIdentityService/E2EIServiceInternal';
-import {getSignatureAlgorithmForCiphersuite, isMLSDevice} from '../E2EIdentityService/Helper';
+import {
+  getMLSDeviceStatus,
+  getSignatureAlgorithmForCiphersuite,
+  isMLSDevice,
+  MLSDeviceStatus,
+} from '../E2EIdentityService/Helper';
 import {handleMLSMessageAdd, handleMLSWelcomeMessage} from '../EventHandler/events';
 import {
   deleteMLSMessagesQueue,
@@ -96,9 +101,16 @@ const defaultConfig = {
   nbKeyPackages: 100,
 };
 
+export enum MLSServiceEvents {
+  NEW_EPOCH = 'newEpoch',
+  MLS_CLIENT_MISMATCH = 'mlsClientMismatch',
+  NEW_CRL_DISTRIBUTION_POINTS = 'newCrlDistributionPoints',
+}
+
 type Events = {
-  newEpoch: {epoch: number; groupId: string};
-  newCrlDistributionPoints: string[];
+  [MLSServiceEvents.NEW_EPOCH]: {epoch: number; groupId: string};
+  [MLSServiceEvents.NEW_CRL_DISTRIBUTION_POINTS]: string[];
+  [MLSServiceEvents.MLS_CLIENT_MISMATCH]: void;
 };
 export class MLSService extends TypedEventEmitter<Events> {
   logger = LogFactory.getLogger('@wireapp/core/MLSService');
@@ -149,7 +161,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     userId: QualifiedId,
     client: RegisteredClient,
     {skipInitIdentity, ...mlsConfig}: InitClientOptions,
-  ) {
+  ): Promise<void> {
     // filter out undefined values from mlsConfig
     const filteredMLSConfig = Object.fromEntries(
       Object.entries(mlsConfig).filter(([_, value]) => value !== undefined),
@@ -173,17 +185,28 @@ export class MLSService extends TypedEventEmitter<Events> {
       userAuthorize: async () => true,
     });
 
-    const isFreshMLSSelfClient = !this.isInitializedMLSClient(client);
-    const shouldinitIdentity = !(isFreshMLSSelfClient && skipInitIdentity);
+    const ccClientSignature = await this.getCCClientSignatureString();
+    const mlsDeviceStatus = getMLSDeviceStatus(client, this.config.defaultCiphersuite, ccClientSignature);
 
-    if (shouldinitIdentity) {
-      // We need to make sure keypackages and public key are uploaded to the backend
-      if (isFreshMLSSelfClient) {
-        await this.uploadMLSPublicKeys(client);
-      }
-      await this.verifyRemoteMLSKeyPackagesAmount(client.id);
-    } else {
-      this.logger.info(`Blocked initial key package upload for client ${client.id} as E2EI is enabled`);
+    switch (mlsDeviceStatus) {
+      case MLSDeviceStatus.REGISTERED:
+        if (!skipInitIdentity) {
+          await this.verifyRemoteMLSKeyPackagesAmount(client.id);
+        } else {
+          this.logger.info(`Blocked initial key package upload for client ${client.id} as E2EI is enabled`);
+        }
+        break;
+      case MLSDeviceStatus.MISMATCH:
+        this.logger.error(`Client ${client.id} is registered but with a different signature`);
+        this.emit(MLSServiceEvents.MLS_CLIENT_MISMATCH);
+        break;
+      case MLSDeviceStatus.FRESH:
+        if (!skipInitIdentity) {
+          await this.uploadMLSPublicKeys(client);
+        } else {
+          this.logger.info(`Blocked initial key package upload for client ${client.id} as E2EI is enabled`);
+        }
+        break;
     }
   }
 
@@ -238,7 +261,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         }
         const newEpoch = await this.getEpoch(groupId);
 
-        this.emit('newEpoch', {epoch: newEpoch, groupId: groupIdStr});
+        this.emit(MLSServiceEvents.NEW_EPOCH, {epoch: newEpoch, groupId: groupIdStr});
         return response;
       } catch (error) {
         if (isExternalCommit) {
@@ -408,7 +431,7 @@ export class MLSService extends TypedEventEmitter<Events> {
   private dispatchNewCrlDistributionPoints(payload: NewCrlDistributionPointsPayload) {
     const {crlNewDistributionPoints} = payload;
     if (crlNewDistributionPoints && crlNewDistributionPoints.length > 0) {
-      this.emit('newCrlDistributionPoints', crlNewDistributionPoints);
+      this.emit(MLSServiceEvents.NEW_CRL_DISTRIBUTION_POINTS, crlNewDistributionPoints);
     }
   }
 
@@ -799,6 +822,12 @@ export class MLSService extends TypedEventEmitter<Events> {
     return this.apiClient.api.client.getMLSKeyPackageCount(clientId, numberToHex(this.config.defaultCiphersuite));
   }
 
+  private async getCCClientSignatureString() {
+    const credentialType = await this.getCredentialType();
+    const publicKey = await this.coreCryptoClient.clientPublicKey(this.config.defaultCiphersuite, credentialType);
+    return btoa(Converter.arrayBufferViewToBaselineString(publicKey));
+  }
+
   /**
    * Will update the given client on backend with its public key.
    *
@@ -807,13 +836,10 @@ export class MLSService extends TypedEventEmitter<Events> {
    */
   private async uploadMLSPublicKeys(client: RegisteredClient) {
     // If we've already updated a client with its public key, there's no need to do it again.
-    const credentialType = await this.getCredentialType();
-    const publicKey = await this.coreCryptoClient.clientPublicKey(this.config.defaultCiphersuite, credentialType);
+    const clientSignature = await this.getCCClientSignatureString();
     return this.apiClient.api.client.putClient(client.id, {
       mls_public_keys: {
-        [getSignatureAlgorithmForCiphersuite(this.config.defaultCiphersuite)]: btoa(
-          Converter.arrayBufferViewToBaselineString(publicKey),
-        ),
+        [getSignatureAlgorithmForCiphersuite(this.config.defaultCiphersuite)]: clientSignature,
       },
     });
   }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -822,10 +822,13 @@ export class MLSService extends TypedEventEmitter<Events> {
     return this.apiClient.api.client.getMLSKeyPackageCount(clientId, numberToHex(this.config.defaultCiphersuite));
   }
 
-  private async getCCClientSignatureString() {
+  private async getCCClientSignatureString(): Promise<string> {
     const credentialType = await this.getCredentialType();
     const publicKey = await this.coreCryptoClient.clientPublicKey(this.config.defaultCiphersuite, credentialType);
-    return btoa(Converter.arrayBufferViewToBaselineString(publicKey));
+    if (!publicKey) {
+      return '';
+    }
+    return Buffer.from(Converter.arrayBufferViewToBaselineString(publicKey)).toString('base64');
   }
 
   /**

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/identityClearer.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/identityClearer.ts
@@ -25,8 +25,9 @@ const IDENTITY_STORES = ['amplify', 'clients', 'keys', 'prekeys', 'sessions', 'g
 /**
  * Will remove any information relative to the client identity.
  * @param storeEngine The engine that currently holds the identity information
+ * @param spareKeys If true, the keys table will not be deleted
  */
-export function deleteIdentity(storeEngine: CRUDEngine, spareKeys: boolean = false): Promise<boolean[]> {
+export function deleteIdentity(storeEngine: CRUDEngine, spareKeys = false): Promise<boolean[]> {
   return Promise.all(
     //make sure we use enum's lowercase values, not uppercase keys
 

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/identityClearer.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/identityClearer.ts
@@ -26,9 +26,15 @@ const IDENTITY_STORES = ['amplify', 'clients', 'keys', 'prekeys', 'sessions', 'g
  * Will remove any information relative to the client identity.
  * @param storeEngine The engine that currently holds the identity information
  */
-export function deleteIdentity(storeEngine: CRUDEngine): Promise<boolean[]> {
+export function deleteIdentity(storeEngine: CRUDEngine, spareKeys: boolean = false): Promise<boolean[]> {
   return Promise.all(
     //make sure we use enum's lowercase values, not uppercase keys
-    IDENTITY_STORES.map(store => storeEngine.deleteAll(store)),
+
+    IDENTITY_STORES.map(store => {
+      if (store === 'keys' && spareKeys) {
+        return Promise.resolve(true);
+      }
+      return storeEngine.deleteAll(store);
+    }),
   );
 }


### PR DESCRIPTION
## Description

There is an issue where our existing RegisteredClient and the CryptoClient no longer have matching signatures. This makes the client unusable for MLS purposes.

- This PR adds a check to the client initialisation that ensures that the Registered Client and the Crypto clients have matching signatures and emits an even in case they don't.
- This PR adds a possibility to wipe only the cryptographic database and the stored SelfClient while processing a logout action
- - Wiping only this data ensures that the message history of the user stays intact
- This PR refactors the Event propagation of the MLSService.ts

The event handling will be part of the webapp repository.