### PR TITLE
feat: include api versioning to endpoints with credentials [WPB-16119]

### DIFF
--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -150,8 +150,8 @@ export class HttpClient extends EventEmitter {
       const response = await this.client.request<T>({
         ...config,
         signal: abortController?.signal,
-        // We want to prefix all urls, except the ones with cookies which are attached to unprefixed urls
-        url: config.withCredentials ? config.url : `${this.versionPrefix}${config.url}`,
+        // We want to prefix all urls, except for the "access" endpoint
+        url: config.url === `${AuthAPI.URL.ACCESS}` ? config.url : `${this.versionPrefix}${config.url}`,
         maxBodyLength: FILE_SIZE_100_MB,
         maxContentLength: FILE_SIZE_100_MB,
       });


### PR DESCRIPTION
## Description

If no version is part of the request, v0 will be used.
Api v0 is planned to be sunsetted soon, all endpoints should now include versioning.

The only requests that did not include versioning where requests with credentials (auth, cookies), this is the change in this PR.

The *only* exceptions are:
- the `api-version` endpoint https://github.com/wireapp/wire-web-packages/blob/main/packages/api-client/src/APIClient.ts#L286
- the 'access' endpoint

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
