### PR TITLE
feat(CellsAPI): add sorting parameters to searchFiles() method

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -818,6 +818,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -846,6 +848,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -878,6 +882,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
         Offset: '10',
+        SortDirDesc: true,
+        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -897,6 +903,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -925,6 +933,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });


### PR DESCRIPTION
## Description

Add sorting to searchFiles() method, defaulting to "mtime/descending". 
[WPB-16997] This is linked to Pagination to make sure "Load More" returns consistent results.


[WPB-16997]: https://wearezeta.atlassian.net/browse/WPB-16997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ