### PR TITLE
chore(gh-actions): install latest version of awscli in generate test workflow

### DIFF
--- a/.github/workflows/generate_test_report.yml
+++ b/.github/workflows/generate_test_report.yml
@@ -57,8 +57,9 @@ jobs:
 
       - name: Install AWS CLI
         run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip awscliv2.zip
+          sudo ./aws/install
 
       - name: Upload unit-tests.log to S3
         env:


### PR DESCRIPTION
## Description

The `awscli` is no longer part of the latest version of ubuntu's repos.
This uses the script provided by amazon to install `awscli` instead of apt

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
