### PR TITLE
feat(api-client/cells): getAllFiles sorting [WPB-17384]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -335,6 +335,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
+        SortField: 'mtime',
+        SortDirDesc: true,
       });
       expect(result).toEqual(mockCollection);
     });
@@ -356,6 +358,8 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
+        SortField: 'mtime',
+        SortDirDesc: true,
       });
       expect(result).toEqual(mockCollection);
     });
@@ -381,6 +385,62 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
         Offset: '10',
+        SortField: 'mtime',
+        SortDirDesc: true,
+      });
+      expect(result).toEqual(mockCollection);
+    });
+
+    it('respects custom sorting parameters', async () => {
+      const mockCollection: Partial<RestNodeCollection> = {
+        Nodes: [
+          {Path: '/file1.txt', Uuid: 'uuid1'},
+          {Path: '/file2.txt', Uuid: 'uuid2'},
+        ],
+      };
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockCollection as RestNodeCollection));
+
+      const result = await cellsAPI.getAllFiles({
+        path: TEST_FILE_PATH,
+        sortBy: 'name',
+        sortDirection: 'asc',
+      });
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: TEST_FILE_PATH}},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortField: 'name',
+        SortDirDesc: false,
+      });
+      expect(result).toEqual(mockCollection);
+    });
+
+    it('handles descending sort direction', async () => {
+      const mockCollection: Partial<RestNodeCollection> = {
+        Nodes: [
+          {Path: '/file1.txt', Uuid: 'uuid1'},
+          {Path: '/file2.txt', Uuid: 'uuid2'},
+        ],
+      };
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockCollection as RestNodeCollection));
+
+      const result = await cellsAPI.getAllFiles({
+        path: TEST_FILE_PATH,
+        sortBy: 'size',
+        sortDirection: 'desc',
+      });
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: TEST_FILE_PATH}},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortField: 'size',
+        SortDirDesc: true,
       });
       expect(result).toEqual(mockCollection);
     });

--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -951,6 +951,76 @@ describe('CellsAPI', () => {
       expect(result).toEqual(mockResponse);
     });
 
+    it('respects custom sorting parameters', async () => {
+      const searchPhrase = 'test';
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/test.txt',
+            Uuid: 'file-uuid-1',
+          },
+          {
+            Path: '/folder/test-file.txt',
+            Uuid: 'file-uuid-2',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchFiles({
+        phrase: searchPhrase,
+        sortBy: 'name',
+        sortDirection: 'asc',
+      });
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: '/'}, Recursive: true},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortField: 'name',
+        SortDirDesc: false,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('handles descending sort direction', async () => {
+      const searchPhrase = 'test';
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/test.txt',
+            Uuid: 'file-uuid-1',
+          },
+          {
+            Path: '/folder/test-file.txt',
+            Uuid: 'file-uuid-2',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchFiles({
+        phrase: searchPhrase,
+        sortBy: 'size',
+        sortDirection: 'desc',
+      });
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: '/'}, Recursive: true},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortField: 'size',
+        SortDirDesc: true,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
     it('returns empty collection when no files match search phrase', async () => {
       const searchPhrase = 'nonexistent';
       const mockResponse: RestNodeCollection = {

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -240,21 +240,32 @@ export class CellsAPI {
     path,
     limit = DEFAULT_LIMIT,
     offset = DEFAULT_OFFSET,
+    sortBy = DEFAULT_SEARCH_SORT_FIELD,
+    sortDirection = DEFAULT_SEARCH_SORT_DIRECTION,
   }: {
     path: string;
     limit?: number;
     offset?: number;
+    sortBy?: string;
+    sortDirection?: SortDirection;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    const result = await this.client.lookup({
+    const request: RestLookupRequest = {
       Scope: {Root: {Path: path}},
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,
       Offset: `${offset}`,
-    });
+    };
+
+    if (sortBy) {
+      request.SortField = sortBy;
+      request.SortDirDesc = sortDirection === 'desc';
+    }
+
+    const result = await this.client.lookup(request);
 
     return result.data;
   }


### PR DESCRIPTION
## Description

Adds sort options to the `getAllFiles` method, similarly to `searchFiles` in https://github.com/wireapp/wire-web-packages/pull/7018 + adds tests for the `searchFiles` method.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
