### PR TITLE
feat(api-client/cells): remove type filter from search [WPB-17388]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -875,7 +875,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -906,7 +906,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -941,7 +941,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
         Offset: '10',
@@ -976,7 +976,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1011,7 +1011,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1033,7 +1033,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1064,7 +1064,7 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}, Type: 'LEAF'},
+        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -291,7 +291,6 @@ export class CellsAPI {
       Scope: {Root: {Path: '/'}, Recursive: true},
       Filters: {
         Text: {SearchIn: 'BaseName', Term: phrase},
-        Type: 'LEAF',
       },
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "./lib/cryptography/AssetCryptography/crypto.node": "./lib/cryptography/AssetCryptography/crypto.browser.js"
   },
   "dependencies": {
-    "@wireapp/api-client": "workspace:^",
+    "@wireapp/api-client": "file:.yalc/@wireapp/api-client",
     "@wireapp/commons": "workspace:^",
     "@wireapp/core-crypto": "3.1.1",
     "@wireapp/cryptobox": "12.8.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
     "./lib/cryptography/AssetCryptography/crypto.node": "./lib/cryptography/AssetCryptography/crypto.browser.js"
   },
   "dependencies": {
-    "@wireapp/api-client": "file:.yalc/@wireapp/api-client",
+    "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
     "@wireapp/core-crypto": "3.1.1",
     "@wireapp/cryptobox": "12.8.0",


### PR DESCRIPTION
## Description

Removing the type "leaf" filter from the search query, since we're introducing folders and want to display both of these types in the search view.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
