### PR TITLE
feat(api-client/cells): createFile & createFolder [WPB-17571]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -1074,6 +1074,134 @@ describe('CellsAPI', () => {
       expect(result).toEqual(mockResponse);
     });
   });
+
+  describe('createFile', () => {
+    it('creates a file with the correct parameters', async () => {
+      const path = '/test.txt';
+      const uuid = 'file-uuid';
+      const versionId = 'version-uuid';
+
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+
+      await cellsAPI.createFile({path, uuid, versionId});
+
+      expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
+        Inputs: [
+          {
+            Type: 'LEAF',
+            Locator: {Path: path},
+            ResourceUuid: uuid,
+            VersionId: versionId,
+          },
+        ],
+      });
+    });
+
+    it('propagates errors when file creation fails', async () => {
+      const path = '/test.txt';
+      const uuid = 'file-uuid';
+      const versionId = 'version-uuid';
+      const errorMessage = 'File creation failed';
+
+      mockNodeServiceApi.create.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(cellsAPI.createFile({path, uuid, versionId})).rejects.toThrow(errorMessage);
+    });
+
+    it('handles empty path', async () => {
+      const path = '';
+      const uuid = 'file-uuid';
+      const versionId = 'version-uuid';
+
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+
+      await cellsAPI.createFile({path, uuid, versionId});
+
+      expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
+        Inputs: [
+          {
+            Type: 'LEAF',
+            Locator: {Path: path},
+            ResourceUuid: uuid,
+            VersionId: versionId,
+          },
+        ],
+      });
+    });
+
+    it('handles empty UUID', async () => {
+      const path = '/test.txt';
+      const uuid = '';
+      const versionId = 'version-uuid';
+      const errorMessage = 'Invalid UUID';
+
+      mockNodeServiceApi.create.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(cellsAPI.createFile({path, uuid, versionId})).rejects.toThrow(errorMessage);
+    });
+  });
+
+  describe('createFolder', () => {
+    it('creates a folder with the correct parameters', async () => {
+      const path = '/test-folder';
+      const uuid = 'folder-uuid';
+
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+
+      await cellsAPI.createFolder({path, uuid});
+
+      expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
+        Inputs: [
+          {
+            Type: 'COLLECTION',
+            Locator: {Path: path},
+            ResourceUuid: uuid,
+            VersionId: '',
+          },
+        ],
+      });
+    });
+
+    it('propagates errors when folder creation fails', async () => {
+      const path = '/test-folder';
+      const uuid = 'folder-uuid';
+      const errorMessage = 'Folder creation failed';
+
+      mockNodeServiceApi.create.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(cellsAPI.createFolder({path, uuid})).rejects.toThrow(errorMessage);
+    });
+
+    it('handles empty path', async () => {
+      const path = '';
+      const uuid = 'folder-uuid';
+
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+
+      await cellsAPI.createFolder({path, uuid});
+
+      expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
+        Inputs: [
+          {
+            Type: 'COLLECTION',
+            Locator: {Path: path},
+            ResourceUuid: uuid,
+            VersionId: '',
+          },
+        ],
+      });
+    });
+
+    it('handles empty UUID', async () => {
+      const path = '/test-folder';
+      const uuid = '';
+      const errorMessage = 'Invalid UUID';
+
+      mockNodeServiceApi.create.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(cellsAPI.createFolder({path, uuid})).rejects.toThrow(errorMessage);
+    });
+  });
 });
 
 const TEST_FILE_NAME = 'test.txt';

--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -1076,25 +1076,35 @@ describe('CellsAPI', () => {
   });
 
   describe('createFile', () => {
-    it('creates a file with the correct parameters', async () => {
+    it('creates a file with the correct parameters and returns the response', async () => {
       const path = '/test.txt';
       const uuid = 'file-uuid';
       const versionId = 'version-uuid';
+      const mockResponse = {
+        Nodes: [
+          {
+            Path: path,
+            Uuid: uuid,
+            Type: 'LEAF',
+          },
+        ],
+      } as RestNodeCollection;
 
-      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      await cellsAPI.createFile({path, uuid, versionId});
+      const result = await cellsAPI.createFile({path, uuid, versionId});
 
       expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
         Inputs: [
           {
             Type: 'LEAF',
-            Locator: {Path: path},
+            Locator: {Path: path.normalize('NFC')},
             ResourceUuid: uuid,
             VersionId: versionId,
           },
         ],
       });
+      expect(result).toEqual(mockResponse);
     });
 
     it('propagates errors when file creation fails', async () => {
@@ -1108,25 +1118,35 @@ describe('CellsAPI', () => {
       await expect(cellsAPI.createFile({path, uuid, versionId})).rejects.toThrow(errorMessage);
     });
 
-    it('handles empty path', async () => {
+    it('handles empty path and returns the response', async () => {
       const path = '';
       const uuid = 'file-uuid';
       const versionId = 'version-uuid';
+      const mockResponse = {
+        Nodes: [
+          {
+            Path: path,
+            Uuid: uuid,
+            Type: 'LEAF',
+          },
+        ],
+      } as RestNodeCollection;
 
-      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      await cellsAPI.createFile({path, uuid, versionId});
+      const result = await cellsAPI.createFile({path, uuid, versionId});
 
       expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
         Inputs: [
           {
             Type: 'LEAF',
-            Locator: {Path: path},
+            Locator: {Path: path.normalize('NFC')},
             ResourceUuid: uuid,
             VersionId: versionId,
           },
         ],
       });
+      expect(result).toEqual(mockResponse);
     });
 
     it('handles empty UUID', async () => {
@@ -1142,24 +1162,34 @@ describe('CellsAPI', () => {
   });
 
   describe('createFolder', () => {
-    it('creates a folder with the correct parameters', async () => {
+    it('creates a folder with the correct parameters and returns the response', async () => {
       const path = '/test-folder';
       const uuid = 'folder-uuid';
+      const mockResponse = {
+        Nodes: [
+          {
+            Path: path,
+            Uuid: uuid,
+            Type: 'COLLECTION',
+          },
+        ],
+      } as RestNodeCollection;
 
-      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      await cellsAPI.createFolder({path, uuid});
+      const result = await cellsAPI.createFolder({path, uuid});
 
       expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
         Inputs: [
           {
             Type: 'COLLECTION',
-            Locator: {Path: path},
+            Locator: {Path: path.normalize('NFC')},
             ResourceUuid: uuid,
             VersionId: '',
           },
         ],
       });
+      expect(result).toEqual(mockResponse);
     });
 
     it('propagates errors when folder creation fails', async () => {
@@ -1172,24 +1202,34 @@ describe('CellsAPI', () => {
       await expect(cellsAPI.createFolder({path, uuid})).rejects.toThrow(errorMessage);
     });
 
-    it('handles empty path', async () => {
+    it('handles empty path and returns the response', async () => {
       const path = '';
       const uuid = 'folder-uuid';
+      const mockResponse = {
+        Nodes: [
+          {
+            Path: path,
+            Uuid: uuid,
+            Type: 'COLLECTION',
+          },
+        ],
+      } as RestNodeCollection;
 
-      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse({}));
+      mockNodeServiceApi.create.mockResolvedValueOnce(createMockResponse(mockResponse));
 
-      await cellsAPI.createFolder({path, uuid});
+      const result = await cellsAPI.createFolder({path, uuid});
 
       expect(mockNodeServiceApi.create).toHaveBeenCalledWith({
         Inputs: [
           {
             Type: 'COLLECTION',
-            Locator: {Path: path},
+            Locator: {Path: path.normalize('NFC')},
             ResourceUuid: uuid,
             VersionId: '',
           },
         ],
       });
+      expect(result).toEqual(mockResponse);
     });
 
     it('handles empty UUID', async () => {

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -308,14 +308,16 @@ export class CellsAPI {
     return result.data;
   }
 
-  async createFile({
+  private async createNode({
     path,
     uuid,
-    versionId,
+    type,
+    versionId = '',
   }: {
     path: NonNullable<RestNodeLocator['Path']>;
     uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
-    versionId: NonNullable<RestIncomingNode['VersionId']>;
+    type: 'LEAF' | 'COLLECTION';
+    versionId?: string;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
@@ -324,7 +326,7 @@ export class CellsAPI {
     const response = await this.client.create({
       Inputs: [
         {
-          Type: 'LEAF',
+          Type: type,
           Locator: {Path: path.normalize('NFC')},
           ResourceUuid: uuid,
           VersionId: versionId,
@@ -335,6 +337,23 @@ export class CellsAPI {
     return response.data;
   }
 
+  async createFile({
+    path,
+    uuid,
+    versionId,
+  }: {
+    path: NonNullable<RestNodeLocator['Path']>;
+    uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
+    versionId: NonNullable<RestIncomingNode['VersionId']>;
+  }): Promise<RestNodeCollection> {
+    return this.createNode({
+      path,
+      uuid,
+      type: 'LEAF',
+      versionId,
+    });
+  }
+
   async createFolder({
     path,
     uuid,
@@ -342,22 +361,11 @@ export class CellsAPI {
     path: NonNullable<RestNodeLocator['Path']>;
     uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
   }): Promise<RestNodeCollection> {
-    if (!this.client || !this.storageService) {
-      throw new Error(CONFIGURATION_ERROR);
-    }
-
-    const response = await this.client.create({
-      Inputs: [
-        {
-          Type: 'COLLECTION',
-          Locator: {Path: path.normalize('NFC')},
-          ResourceUuid: uuid,
-          VersionId: '',
-        },
-      ],
+    return this.createNode({
+      path,
+      uuid,
+      type: 'COLLECTION',
     });
-
-    return response.data;
   }
 
   async deleteFilePublicLink({uuid}: {uuid: string}): Promise<RestPublicLinkDeleteSuccess> {

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -306,6 +306,40 @@ export class CellsAPI {
     return result.data;
   }
 
+  async createFile({path, uuid, versionId}: {path: string; uuid: string; versionId: string}) {
+    if (!this.client || !this.storageService) {
+      throw new Error(CONFIGURATION_ERROR);
+    }
+
+    await this.client.create({
+      Inputs: [
+        {
+          Type: 'LEAF',
+          Locator: {Path: path.normalize('NFC')},
+          ResourceUuid: uuid,
+          VersionId: versionId,
+        },
+      ],
+    });
+  }
+
+  async createFolder({path, uuid}: {path: string; uuid: string}) {
+    if (!this.client || !this.storageService) {
+      throw new Error(CONFIGURATION_ERROR);
+    }
+
+    await this.client.create({
+      Inputs: [
+        {
+          Type: 'COLLECTION',
+          Locator: {Path: path.normalize('NFC')},
+          ResourceUuid: uuid,
+          VersionId: '',
+        },
+      ],
+    });
+  }
+
   async deleteFilePublicLink({uuid}: {uuid: string}): Promise<RestPublicLinkDeleteSuccess> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -29,6 +29,8 @@ import {
   RestPublicLinkDeleteSuccess,
   RestShareLink,
   RestVersion,
+  RestIncomingNode,
+  RestNodeLocator,
 } from 'cells-sdk-ts';
 
 import {CellsStorage} from './CellsStorage/CellsStorage';
@@ -311,9 +313,9 @@ export class CellsAPI {
     uuid,
     versionId,
   }: {
-    path: string;
-    uuid: string;
-    versionId: string;
+    path: NonNullable<RestNodeLocator['Path']>;
+    uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
+    versionId: NonNullable<RestIncomingNode['VersionId']>;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
@@ -333,7 +335,13 @@ export class CellsAPI {
     return response.data;
   }
 
-  async createFolder({path, uuid}: {path: string; uuid: string}): Promise<RestNodeCollection> {
+  async createFolder({
+    path,
+    uuid,
+  }: {
+    path: NonNullable<RestNodeLocator['Path']>;
+    uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
+  }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -306,12 +306,20 @@ export class CellsAPI {
     return result.data;
   }
 
-  async createFile({path, uuid, versionId}: {path: string; uuid: string; versionId: string}) {
+  async createFile({
+    path,
+    uuid,
+    versionId,
+  }: {
+    path: string;
+    uuid: string;
+    versionId: string;
+  }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    await this.client.create({
+    const response = await this.client.create({
       Inputs: [
         {
           Type: 'LEAF',
@@ -321,14 +329,16 @@ export class CellsAPI {
         },
       ],
     });
+
+    return response.data;
   }
 
-  async createFolder({path, uuid}: {path: string; uuid: string}) {
+  async createFolder({path, uuid}: {path: string; uuid: string}): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    await this.client.create({
+    const response = await this.client.create({
       Inputs: [
         {
           Type: 'COLLECTION',
@@ -338,6 +348,8 @@ export class CellsAPI {
         },
       ],
     });
+
+    return response.data;
   }
 
   async deleteFilePublicLink({uuid}: {uuid: string}): Promise<RestPublicLinkDeleteSuccess> {

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -316,8 +316,8 @@ export class CellsAPI {
   }: {
     path: NonNullable<RestNodeLocator['Path']>;
     uuid: NonNullable<RestIncomingNode['ResourceUuid']>;
-    type: 'LEAF' | 'COLLECTION';
-    versionId?: string;
+    type: RestIncomingNode['Type'];
+    versionId?: RestIncomingNode['VersionId'];
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);


### PR DESCRIPTION
## Description

Adds createFile and createFolder methods to the CellsAPI.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
