### PR TITLE
fix(core): allow database deletion on logout [WPB-17316]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -520,8 +520,6 @@ export class Account extends TypedEventEmitter<Events> {
   }
 
   private async wipeCommonData(): Promise<void> {
-    await this.service?.client.deleteLocalClient();
-    // needs to be wiped last
     await this.encryptedDb?.wipe();
   }
 

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -520,6 +520,8 @@ export class Account extends TypedEventEmitter<Events> {
   }
 
   private async wipeCommonData(): Promise<void> {
+    await this.service?.client.deleteLocalClient();
+    // needs to be wiped last
     await this.encryptedDb?.wipe();
   }
 

--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -82,7 +82,11 @@ export class ClientService {
     if (!localClientId) {
       throw new Error('Trying to delete local client, but local client has not been set');
     }
-    await this.backend.deleteClient(localClientId, password);
+    try {
+      await this.backend.deleteClient(localClientId, password);
+    } catch (error) {
+      this.logger.warn('Failed to delete client on backend', error);
+    }
     return this.database.deleteLocalClient();
   }
 

--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -86,8 +86,9 @@ export class ClientService {
       await this.backend.deleteClient(localClientId, password);
     } catch (error) {
       this.logger.warn('Failed to delete client on backend', error);
+    } finally {
+      return this.database.deleteLocalClient();
     }
-    return this.database.deleteLocalClient();
   }
 
   private async getLocalClient(): Promise<MetaClient | undefined> {


### PR DESCRIPTION
## Description

Since https://github.com/wireapp/wire-web-packages/pull/7007 , we attempts to delete the local client from the backend on logout.

this fails and prevents the local database from being deleted

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
