### PR TITLE
feat(api-client/cells): move method [WPB-17386]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -25,6 +25,7 @@ import {
   RestPublicLinkDeleteSuccess,
   RestShareLink,
   RestVersion,
+  RestPerformActionResponse,
 } from 'cells-sdk-ts';
 import {v4 as uuidv4} from 'uuid';
 
@@ -494,6 +495,100 @@ describe('CellsAPI', () => {
       mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
 
       await expect(cellsAPI.deleteFile({uuid: invalidUuid})).rejects.toThrow(errorMessage);
+    });
+  });
+
+  describe('move', () => {
+    it('moves a file to the target path', async () => {
+      const currentPath = '/current/file.txt';
+      const targetPath = '/new-location/file.txt';
+      const mockResponse: RestPerformActionResponse = {
+        Nodes: [
+          {
+            Path: targetPath,
+          },
+        ],
+      } as RestPerformActionResponse;
+
+      mockNodeServiceApi.performAction.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.move({currentPath, targetPath});
+
+      expect(mockNodeServiceApi.performAction).toHaveBeenCalledWith('move', {
+        Nodes: [{Path: currentPath}],
+        CopyMoveOptions: {TargetIsParent: true, TargetPath: targetPath},
+        AwaitStatus: 'Finished',
+        AwaitTimeout: '5000ms',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('propagates errors when move operation fails', async () => {
+      const currentPath = '/current/file.txt';
+      const targetPath = '/new-location/file.txt';
+      const errorMessage = 'Move operation failed';
+
+      mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(cellsAPI.move({currentPath, targetPath})).rejects.toThrow(errorMessage);
+    });
+
+    it('handles empty current path', async () => {
+      const emptyCurrentPath = '';
+      const targetPath = '/new-location/file.txt';
+      const errorMessage = 'Invalid path';
+
+      mockNodeServiceApi.performAction.mockRejectedValueOnce(new Error(errorMessage));
+
+      await expect(cellsAPI.move({currentPath: emptyCurrentPath, targetPath})).rejects.toThrow(errorMessage);
+    });
+
+    it('handles empty target path', async () => {
+      const currentPath = '/current/file.txt';
+      const emptyTargetPath = '';
+      const mockResponse: RestPerformActionResponse = {
+        Nodes: [
+          {
+            Path: emptyTargetPath,
+          },
+        ],
+      } as RestPerformActionResponse;
+
+      mockNodeServiceApi.performAction.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.move({currentPath, targetPath: emptyTargetPath});
+
+      expect(mockNodeServiceApi.performAction).toHaveBeenCalledWith('move', {
+        Nodes: [{Path: currentPath}],
+        CopyMoveOptions: {TargetIsParent: true, TargetPath: emptyTargetPath},
+        AwaitStatus: 'Finished',
+        AwaitTimeout: '5000ms',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('handles move to root directory', async () => {
+      const currentPath = '/current/file.txt';
+      const rootPath = '/';
+      const mockResponse: RestPerformActionResponse = {
+        Nodes: [
+          {
+            Path: rootPath,
+          },
+        ],
+      } as RestPerformActionResponse;
+
+      mockNodeServiceApi.performAction.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.move({currentPath, targetPath: rootPath});
+
+      expect(mockNodeServiceApi.performAction).toHaveBeenCalledWith('move', {
+        Nodes: [{Path: currentPath}],
+        CopyMoveOptions: {TargetIsParent: true, TargetPath: rootPath},
+        AwaitStatus: 'Finished',
+        AwaitTimeout: '5000ms',
+      });
+      expect(result).toEqual(mockResponse);
     });
   });
 

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -31,6 +31,7 @@ import {
   RestVersion,
   RestIncomingNode,
   RestNodeLocator,
+  RestActionOptionsCopyMove,
 } from 'cells-sdk-ts';
 
 import {CellsStorage} from './CellsStorage/CellsStorage';
@@ -176,6 +177,27 @@ export class CellsAPI {
     }
 
     const result = await this.client.performAction('delete', {Nodes: [{Uuid: uuid}]});
+
+    return result.data;
+  }
+
+  async move({
+    currentPath,
+    targetPath,
+  }: {
+    currentPath: RestNodeLocator['Path'];
+    targetPath: RestActionOptionsCopyMove['TargetPath'];
+  }): Promise<RestPerformActionResponse> {
+    if (!this.client || !this.storageService) {
+      throw new Error(CONFIGURATION_ERROR);
+    }
+
+    const result = await this.client.performAction('move', {
+      Nodes: [{Path: currentPath}],
+      CopyMoveOptions: {TargetIsParent: true, TargetPath: targetPath},
+      AwaitStatus: 'Finished',
+      AwaitTimeout: '5000ms',
+    });
 
     return result.data;
   }


### PR DESCRIPTION
## Description

Adds the `move` method to move files/folders between directories.
 
## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
