### PR TITLE
fix(api-client): remove version prefix for all access endpoints [SECC-641]

### DIFF
--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -151,7 +151,7 @@ export class HttpClient extends EventEmitter {
         ...config,
         signal: abortController?.signal,
         // We want to prefix all urls, except for the "access" endpoint
-        url: config.url === `${AuthAPI.URL.ACCESS}` ? config.url : `${this.versionPrefix}${config.url}`,
+        url: config.url?.startsWith(AuthAPI.URL.ACCESS) ? config.url : `${this.versionPrefix}${config.url}`,
         maxBodyLength: FILE_SIZE_100_MB,
         maxContentLength: FILE_SIZE_100_MB,
       });


### PR DESCRIPTION
## Description

version prefix is still present for the remaining `/access` endpoints and needs to be removed

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
