### PR TITLE
feat(api-client/cell): permanent delete + restore + rename methods [WPB-17716]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -338,6 +338,39 @@ describe('CellsAPI', () => {
         Offset: '0',
         SortField: 'mtime',
         SortDirDesc: true,
+        Filters: {
+          Status: {
+            Deleted: 'Not',
+          },
+        },
+      });
+      expect(result).toEqual(mockCollection);
+    });
+
+    it('retrieves deleted files when deleted is true', async () => {
+      const mockCollection: Partial<RestNodeCollection> = {
+        Nodes: [
+          {Path: '/deleted1.txt', Uuid: 'uuid1'},
+          {Path: '/deleted2.txt', Uuid: 'uuid2'},
+        ],
+      };
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockCollection as RestNodeCollection));
+
+      const result = await cellsAPI.getAllNodes({path: TEST_FILE_PATH, deleted: true});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: TEST_FILE_PATH}},
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortField: 'mtime',
+        SortDirDesc: true,
+        Filters: {
+          Status: {
+            Deleted: 'Only',
+          },
+        },
       });
       expect(result).toEqual(mockCollection);
     });
@@ -1058,7 +1091,48 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('searches for deleted files when deleted is true', async () => {
+      const searchPhrase = 'test';
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/deleted-test.txt',
+            Uuid: 'file-uuid-1',
+          },
+          {
+            Path: '/folder/deleted-test-file.txt',
+            Uuid: 'file-uuid-2',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchNodes({phrase: searchPhrase, deleted: true});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: '/'}, Recursive: true},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Only',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1089,7 +1163,12 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1124,7 +1203,12 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
         Offset: '10',
@@ -1159,7 +1243,12 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1194,7 +1283,12 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1227,6 +1321,9 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Type: 'LEAF',
+          Status: {
+            Deleted: 'Not',
+          },
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1249,7 +1346,12 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
@@ -1280,7 +1382,12 @@ describe('CellsAPI', () => {
 
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
-        Filters: {Text: {SearchIn: 'BaseName', Term: searchPhrase}},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Status: {
+            Deleted: 'Not',
+          },
+        },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',

--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -339,6 +339,7 @@ describe('CellsAPI', () => {
         SortField: 'mtime',
         SortDirDesc: true,
         Filters: {
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -367,6 +368,7 @@ describe('CellsAPI', () => {
         SortField: 'mtime',
         SortDirDesc: true,
         Filters: {
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Only',
           },
@@ -394,6 +396,12 @@ describe('CellsAPI', () => {
         Offset: '0',
         SortField: 'mtime',
         SortDirDesc: true,
+        Filters: {
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+        },
       });
       expect(result).toEqual(mockCollection);
     });
@@ -421,6 +429,12 @@ describe('CellsAPI', () => {
         Offset: '10',
         SortField: 'mtime',
         SortDirDesc: true,
+        Filters: {
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+        },
       });
       expect(result).toEqual(mockCollection);
     });
@@ -448,6 +462,12 @@ describe('CellsAPI', () => {
         Offset: '0',
         SortField: 'name',
         SortDirDesc: false,
+        Filters: {
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+        },
       });
       expect(result).toEqual(mockCollection);
     });
@@ -475,6 +495,12 @@ describe('CellsAPI', () => {
         Offset: '0',
         SortField: 'size',
         SortDirDesc: true,
+        Filters: {
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+        },
       });
       expect(result).toEqual(mockCollection);
     });
@@ -500,6 +526,9 @@ describe('CellsAPI', () => {
         SortDirDesc: true,
         Filters: {
           Type: 'LEAF',
+          Status: {
+            Deleted: 'Not',
+          },
         },
       });
       expect(result).toEqual(mockCollection);
@@ -1093,6 +1122,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -1129,6 +1159,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Only',
           },
@@ -1165,6 +1196,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -1205,6 +1237,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -1245,6 +1278,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -1285,6 +1319,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -1320,6 +1355,7 @@ describe('CellsAPI', () => {
       expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
           Type: 'LEAF',
           Status: {
             Deleted: 'Not',
@@ -1348,6 +1384,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },
@@ -1384,6 +1421,7 @@ describe('CellsAPI', () => {
         Scope: {Root: {Path: '/'}, Recursive: true},
         Filters: {
           Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
           Status: {
             Deleted: 'Not',
           },

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -286,6 +286,7 @@ export class CellsAPI {
     sortBy = DEFAULT_SEARCH_SORT_FIELD,
     sortDirection = DEFAULT_SEARCH_SORT_DIRECTION,
     type,
+    deleted = false,
   }: {
     path: string;
     limit?: number;
@@ -293,6 +294,7 @@ export class CellsAPI {
     sortBy?: string;
     sortDirection?: SortDirection;
     type?: RestIncomingNode['Type'];
+    deleted?: boolean;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
@@ -303,17 +305,17 @@ export class CellsAPI {
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,
       Offset: `${offset}`,
+      Filters: {
+        Type: type,
+        Status: {
+          Deleted: deleted ? 'Only' : 'Not',
+        },
+      },
     };
 
     if (sortBy) {
       request.SortField = sortBy;
       request.SortDirDesc = sortDirection === 'desc';
-    }
-
-    if (type) {
-      request.Filters = {
-        Type: type,
-      };
     }
 
     const result = await this.client.lookup(request);
@@ -328,6 +330,7 @@ export class CellsAPI {
     sortBy = DEFAULT_SEARCH_SORT_FIELD,
     sortDirection = DEFAULT_SEARCH_SORT_DIRECTION,
     type,
+    deleted = false,
   }: {
     phrase: string;
     limit?: number;
@@ -335,6 +338,7 @@ export class CellsAPI {
     sortBy?: string;
     sortDirection?: SortDirection;
     type?: RestIncomingNode['Type'];
+    deleted?: boolean;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
@@ -344,6 +348,10 @@ export class CellsAPI {
       Scope: {Root: {Path: '/'}, Recursive: true},
       Filters: {
         Text: {SearchIn: 'BaseName', Term: phrase},
+        Type: type,
+        Status: {
+          Deleted: deleted ? 'Only' : 'Not',
+        },
       },
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,
@@ -353,12 +361,6 @@ export class CellsAPI {
     if (sortBy) {
       request.SortField = sortBy;
       request.SortDirDesc = sortDirection === 'desc';
-    }
-
-    if (type) {
-      request.Filters = {
-        Type: type,
-      };
     }
 
     const result = await this.client.lookup(request);

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -105,7 +105,7 @@ export class CellsAPI {
     this.client = new NodeServiceApi(undefined, undefined, http.client);
   }
 
-  async uploadFileDraft({
+  async uploadNodeDraft({
     uuid,
     versionId,
     path,
@@ -151,7 +151,7 @@ export class CellsAPI {
     return result.data;
   }
 
-  async promoteFileDraft({uuid, versionId}: {uuid: string; versionId: string}): Promise<RestPromoteVersionResponse> {
+  async promoteNodeDraft({uuid, versionId}: {uuid: string; versionId: string}): Promise<RestPromoteVersionResponse> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -161,7 +161,7 @@ export class CellsAPI {
     return result.data;
   }
 
-  async deleteFileDraft({uuid, versionId}: {uuid: string; versionId: string}): Promise<RestDeleteVersionResponse> {
+  async deleteNodeDraft({uuid, versionId}: {uuid: string; versionId: string}): Promise<RestDeleteVersionResponse> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -171,12 +171,21 @@ export class CellsAPI {
     return result.data;
   }
 
-  async deleteFile({uuid}: {uuid: string}): Promise<RestPerformActionResponse> {
+  async deleteNode({
+    uuid,
+    permanently = false,
+  }: {
+    uuid: string;
+    permanently?: boolean;
+  }): Promise<RestPerformActionResponse> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
 
-    const result = await this.client.performAction('delete', {Nodes: [{Uuid: uuid}]});
+    const result = await this.client.performAction('delete', {
+      Nodes: [{Uuid: uuid}],
+      DeleteOptions: {PermanentDelete: permanently},
+    });
 
     return result.data;
   }
@@ -202,7 +211,17 @@ export class CellsAPI {
     return result.data;
   }
 
-  async lookupFileByPath({path}: {path: string}): Promise<RestNode | undefined> {
+  async restoreNode({uuid}: {uuid: string}): Promise<RestPerformActionResponse> {
+    if (!this.client || !this.storageService) {
+      throw new Error(CONFIGURATION_ERROR);
+    }
+
+    const result = await this.client.performAction('restore', {Nodes: [{Uuid: uuid}]});
+
+    return result.data;
+  }
+
+  async lookupNodeByPath({path}: {path: string}): Promise<RestNode | undefined> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -221,7 +240,7 @@ export class CellsAPI {
     return node;
   }
 
-  async lookupFileByUuid({uuid}: {uuid: string}): Promise<RestNode | undefined> {
+  async lookupNodeByUuid({uuid}: {uuid: string}): Promise<RestNode | undefined> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -240,7 +259,7 @@ export class CellsAPI {
     return node;
   }
 
-  async getFileVersions({uuid}: {uuid: string}): Promise<RestVersion[] | undefined> {
+  async getNodeVersions({uuid}: {uuid: string}): Promise<RestVersion[] | undefined> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -250,7 +269,7 @@ export class CellsAPI {
     return result.data.Versions;
   }
 
-  async getFile({id}: {id: string}): Promise<RestNode> {
+  async getNode({id}: {id: string}): Promise<RestNode> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -407,7 +426,7 @@ export class CellsAPI {
     });
   }
 
-  async deleteFilePublicLink({uuid}: {uuid: string}): Promise<RestPublicLinkDeleteSuccess> {
+  async deleteNodePublicLink({uuid}: {uuid: string}): Promise<RestPublicLinkDeleteSuccess> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -417,7 +436,7 @@ export class CellsAPI {
     return result.data;
   }
 
-  async createFilePublicLink({uuid, label}: {uuid: string; label?: string}): Promise<RestShareLink> {
+  async createNodePublicLink({uuid, label}: {uuid: string; label?: string}): Promise<RestShareLink> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }
@@ -432,7 +451,7 @@ export class CellsAPI {
     return result.data;
   }
 
-  async getFilePublicLink({uuid}: {uuid: string}): Promise<RestShareLink> {
+  async getNodePublicLink({uuid}: {uuid: string}): Promise<RestShareLink> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);
     }

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -306,7 +306,7 @@ export class CellsAPI {
       Limit: `${limit}`,
       Offset: `${offset}`,
       Filters: {
-        Type: type,
+        Type: type || 'UNKNOWN',
         Status: {
           Deleted: deleted ? 'Only' : 'Not',
         },
@@ -348,7 +348,7 @@ export class CellsAPI {
       Scope: {Root: {Path: '/'}, Recursive: true},
       Filters: {
         Text: {SearchIn: 'BaseName', Term: phrase},
-        Type: type,
+        Type: type || 'UNKNOWN',
         Status: {
           Deleted: deleted ? 'Only' : 'Not',
         },


### PR DESCRIPTION
## Description

1. Add `permanently` option to the `deleteNode` method
2. Add `restoreNode` method
3. Rename existing methods to contain "node" instead of "file"

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
