### PR TITLE
feat!: CC bump to 6. 

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "5.3.0",
+    "@wireapp/core-crypto": "6.0.1",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "workspace:^",
     "@wireapp/promise-queue": "workspace:^",

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -402,7 +402,7 @@ export class Account extends TypedEventEmitter<Events> {
         storeEngine,
         {
           ...baseConfig,
-          generateSecretKey: keyId => generateSecretKey({keyId, keySize: 16, secretsDb: encryptedStore}),
+          generateSecretKey: (keyId, keySize) => generateSecretKey({keyId, keySize, secretsDb: encryptedStore}),
         },
         this.options.coreCryptoConfig,
       );

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceInternal.ts
@@ -270,14 +270,14 @@ export class E2EIServiceInternal {
     return this.coreCryptoClient.transaction(async cx => {
       const conversations = await getAllConversations();
       const newCrlDistributionPoints = await cx.saveX509Credential(identity, certificate);
-      conversations.forEach(async conversation => {
+      for (const conversation of conversations) {
         if (Boolean(conversation.group_id?.length)) {
           const idAsBytes = new TextEncoder().encode(conversation.group_id);
           await cx.e2eiRotate(idAsBytes);
         } else {
           this.logger.error('No group id found in conversation');
         }
-      });
+      }
 
       const keyPackages = await cx.clientKeypackages(cipherSuite, CredentialType.X509, this.keyPackagesAmount);
 

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -366,7 +366,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     const welcomeBundle = await this.coreCryptoClient.transaction(cx =>
       cx.joinByExternalCommit(groupInfo, credentialType),
     );
-    await this.dispatchNewCrlDistributionPoints(welcomeBundle.crlNewDistributionPoints);
+    await this.dispatchNewCrlDistributionPoints(welcomeBundle.crl_new_distribution_points);
 
     if (welcomeBundle.id) {
       //after we've successfully joined via external commit, we schedule periodic key material renewal
@@ -389,7 +389,7 @@ export class MLSService extends TypedEventEmitter<Events> {
 
   public async processWelcomeMessage(welcomeMessage: Uint8Array): Promise<ConversationId> {
     const welcomeBundle = await this.coreCryptoClient.transaction(cx => cx.processWelcomeMessage(welcomeMessage));
-    this.dispatchNewCrlDistributionPoints(welcomeBundle.crlNewDistributionPoints);
+    this.dispatchNewCrlDistributionPoints(welcomeBundle.crl_new_distribution_points);
     return welcomeBundle.id;
   }
 

--- a/packages/core/src/secretStore/secretKeyGenerator.ts
+++ b/packages/core/src/secretStore/secretKeyGenerator.ts
@@ -24,6 +24,7 @@ export class CorruptedKeyError extends Error {}
 export type GeneratedKey = {
   key: Uint8Array;
   deleteKey: () => Promise<void>;
+  freshlyGenerated: boolean;
 };
 
 /**
@@ -41,6 +42,7 @@ export async function generateSecretKey({
   /** name of the database that will hold the secrets */
   secretsDb: EncryptedStore<any>;
 }): Promise<GeneratedKey> {
+  let freshlyGenerated = false;
   try {
     let key;
     try {
@@ -65,8 +67,9 @@ export async function generateSecretKey({
       );
       key = new Uint8Array(await crypto.subtle.exportKey('raw', key));
       await secretsDb.saveSecretValue(keyId, key);
+      freshlyGenerated = true;
     }
-    return {key, deleteKey: () => secretsDb.deleteSecretValue(keyId)};
+    return {key, deleteKey: () => secretsDb.deleteSecretValue(keyId), freshlyGenerated};
   } catch (error) {
     throw error;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7839,10 +7839,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:5.3.0":
-  version: 5.3.0
-  resolution: "@wireapp/core-crypto@npm:5.3.0"
-  checksum: 8bdd0c7735729cfeefc3ee5d1b4bc9478bc98a3af785d6733cafd256efa8d71a0629ee967bd0616c4f30a4440675e5520b08513f96633e9ac393250130ff3d3e
+"@wireapp/core-crypto@npm:6.0.1":
+  version: 6.0.1
+  resolution: "@wireapp/core-crypto@npm:6.0.1"
+  checksum: c4ba5b1a06838972e94fd7bf925e6f25d1bb9ea9a393086ab6a18978b8546969332f8ec2afb09f4e7f0fae49142e09770e933a2920d406de7862489943df481a
   languageName: node
   linkType: hard
 
@@ -7859,7 +7859,7 @@ __metadata:
     "@types/uuid": 9.0.8
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 5.3.0
+    "@wireapp/core-crypto": 6.0.1
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/priority-queue": "workspace:^"
     "@wireapp/promise-queue": "workspace:^"


### PR DESCRIPTION
## Description

The new CC version includes a breaking change for us regarding the Database Key. The format changes from 128 to 256-bit key length. Additionally, the library introduced its Key type. 

To make this work, we have to run a database migration for existing clients (only once).
To achieve this goal, we generate a new encryption key and store it in our database next to the existing one.

Following cases exist:

1. If the old key exists and the new key is freshly generated -> We run the migration, delete the old key and return the new key
2. If the old key is freshly generated and the new key is freshly generated -> We return the new key
3. If the old key is freshly generated and the new key exists -> We return the new key

