### PR TITLE
feat(react-ui-kit): breadcrumbs with icons

### DIFF
--- a/packages/react-ui-kit/src/Misc/Breadcrumbs/BreadcrumbItem/BreadcrumbItem.styles.ts
+++ b/packages/react-ui-kit/src/Misc/Breadcrumbs/BreadcrumbItem/BreadcrumbItem.styles.ts
@@ -34,6 +34,9 @@ export const buttonStyles: CSSObject = {
   cursor: 'pointer',
   fontSize: '14px',
   color: COLOR_V2.GRAY_70,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
 
   '&:hover': {
     color: 'var(--main-color)',
@@ -41,7 +44,9 @@ export const buttonStyles: CSSObject = {
 };
 
 export const activeItemStyles: CSSObject = {
-  display: 'inline-block',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '8px',
   padding: '0 8px',
   fontSize: '14px',
   color: 'var(--main-color)',

--- a/packages/react-ui-kit/src/Misc/Breadcrumbs/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/packages/react-ui-kit/src/Misc/Breadcrumbs/BreadcrumbItem/BreadcrumbItem.tsx
@@ -17,23 +17,28 @@
  *
  */
 
-import {MouseEvent as ReactMouseEvent} from 'react';
+import {MouseEvent as ReactMouseEvent, ReactNode} from 'react';
 
 import {activeItemStyles, buttonStyles, listItemStyles} from './BreadcrumbItem.styles';
 
 interface BreadcrumbItemProps {
   name: string;
+  icon?: ReactNode;
   isActive: boolean;
   onClick: (event: ReactMouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export const BreadcrumbItem = ({name, isActive, onClick}: BreadcrumbItemProps) => {
+export const BreadcrumbItem = ({name, icon, isActive, onClick}: BreadcrumbItemProps) => {
   return (
     <li css={listItemStyles}>
       {isActive ? (
-        <span css={activeItemStyles}>{name}</span>
+        <span css={activeItemStyles}>
+          {icon}
+          {name}
+        </span>
       ) : (
         <button type="button" css={buttonStyles} onClick={onClick}>
+          {icon}
           {name}
         </button>
       )}

--- a/packages/react-ui-kit/src/Misc/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react-ui-kit/src/Misc/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -21,6 +21,8 @@ import {Meta, StoryObj} from '@storybook/react/*';
 
 import {Breadcrumbs} from './Breadcrumbs';
 
+import {TrashIcon} from '../../Icon';
+
 const meta: Meta<typeof Breadcrumbs> = {
   component: Breadcrumbs,
   title: 'Misc/Breadcrumbs',
@@ -41,6 +43,30 @@ export const WithCombinedItems: Story = {
   render: () => (
     <Breadcrumbs
       items={[{name: 'Home'}, {name: 'Folder'}, {name: 'Subfolder 1'}, {name: 'Subfolder 2'}, {name: 'Subfolder 3'}]}
+      onItemClick={() => {}}
+    />
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <Breadcrumbs
+      items={[{name: 'Home'}, {name: 'Folder', icon: <TrashIcon />}, {name: 'Subfolder'}]}
+      onItemClick={() => {}}
+    />
+  ),
+};
+
+export const WithIconsAndCombinedItems: Story = {
+  render: () => (
+    <Breadcrumbs
+      items={[
+        {name: 'Home'},
+        {name: 'Folder', icon: <TrashIcon />},
+        {name: 'Subfolder 1'},
+        {name: 'Subfolder 2'},
+        {name: 'Subfolder 3'},
+      ]}
       onItemClick={() => {}}
     />
   ),

--- a/packages/react-ui-kit/src/Misc/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react-ui-kit/src/Misc/Breadcrumbs/Breadcrumbs.tsx
@@ -17,6 +17,8 @@
  *
  */
 
+import {ReactNode} from 'react';
+
 import {BreadcrumbItem} from './BreadcrumbItem/BreadcrumbItem';
 import {BreadcrumbLeaf} from './BreadcrumbLeaf/BreadcrumbLeaf';
 import {listStyles} from './Breadcrumbs.styles';
@@ -31,7 +33,7 @@ interface BreadcrumbsProps {
    */
   maxNotCombinedItems?: number;
 
-  items: Array<{name: string}>;
+  items: Array<{name: string; icon?: ReactNode}>;
 
   onItemClick: (item: {name: string}) => void;
 }
@@ -60,6 +62,7 @@ export const Breadcrumbs = ({
             <BreadcrumbItem
               key={crumb.name}
               name={crumb.name}
+              icon={crumb.icon}
               isActive={index === items.length - 1}
               onClick={() => onItemClick(crumb)}
             />
@@ -78,7 +81,12 @@ export const Breadcrumbs = ({
 
   return (
     <ol css={listStyles}>
-      <BreadcrumbItem name={firstCrumb.name} isActive={false} onClick={() => onItemClick(firstCrumb)} />
+      <BreadcrumbItem
+        name={firstCrumb.name}
+        icon={firstCrumb.icon}
+        isActive={false}
+        onClick={() => onItemClick(firstCrumb)}
+      />
       <BreadcrumbLeaf />
       <CombainedBreadcrumbs items={middleCrumbs} onItemClick={onItemClick} />
       <BreadcrumbLeaf />
@@ -88,6 +96,7 @@ export const Breadcrumbs = ({
           <BreadcrumbItem
             key={crumb.name}
             name={crumb.name}
+            icon={crumb.icon}
             isActive={index === lastTwoCrumbs.length - 1}
             onClick={() => onItemClick(crumb)}
           />

--- a/packages/react-ui-kit/src/Misc/Breadcrumbs/CombainedBreadcrumbs/CombainedBreadcrumbs.styles.ts
+++ b/packages/react-ui-kit/src/Misc/Breadcrumbs/CombainedBreadcrumbs/CombainedBreadcrumbs.styles.ts
@@ -33,3 +33,9 @@ export const buttonStyles: CSSObject = {
     color: 'var(--main-color)',
   },
 };
+
+export const itemStyles: CSSObject = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+};

--- a/packages/react-ui-kit/src/Misc/Breadcrumbs/CombainedBreadcrumbs/CombainedBreadcrumbs.tsx
+++ b/packages/react-ui-kit/src/Misc/Breadcrumbs/CombainedBreadcrumbs/CombainedBreadcrumbs.tsx
@@ -17,12 +17,14 @@
  *
  */
 
-import {buttonStyles} from './CombainedBreadcrumbs.styles';
+import {ReactNode} from 'react';
+
+import {buttonStyles, itemStyles} from './CombainedBreadcrumbs.styles';
 
 import {DropdownMenu} from '../../../Modal/DropdownMenu';
 
 interface CombainedBreadcrumbsProps {
-  items: Array<{name: string}>;
+  items: Array<{name: string; icon?: ReactNode}>;
   onItemClick: (item: {name: string}) => void;
 }
 
@@ -39,7 +41,10 @@ export const CombainedBreadcrumbs = ({items, onItemClick}: CombainedBreadcrumbsP
       <DropdownMenu.Content>
         {items.map(crumb => (
           <DropdownMenu.Item key={crumb.name} onClick={() => onItemClick(crumb)}>
-            {crumb.name}
+            <div css={itemStyles}>
+              {crumb.icon}
+              {crumb.name}
+            </div>
           </DropdownMenu.Item>
         ))}
       </DropdownMenu.Content>


### PR DESCRIPTION
## Description

Add the `icon` prop for breadcrumbs.

## Demo

<img width="243" alt="Screenshot 2025-05-21 at 11 40 57" src="https://github.com/user-attachments/assets/6dd6f400-b457-45a4-9d73-0dcc691f45f4" />

<img width="337" alt="Screenshot 2025-05-21 at 11 41 10" src="https://github.com/user-attachments/assets/4dfcbc4b-e9c4-49ef-b832-a4ef2e6a8185" />

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
