### PR TITLE
fix(core): MLS - Filter already exisiting client ids when trying trying to add users to MLS conversation (WPB-17095)

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -134,6 +134,7 @@ describe('ConversationService', () => {
       conversationExists: jest.fn(),
       isConversationEstablished: jest.fn(),
       tryEstablishingMLSGroup: jest.fn(),
+      getClientIdsInGroup: jest.fn(),
       getKeyPackagesPayload: jest.fn(),
       addUsersToExistingConversation: jest.fn(),
       resetKeyMaterialRenewal: jest.fn(),
@@ -684,7 +685,7 @@ describe('ConversationService', () => {
         conversationId: mockConversationId,
       });
 
-      expect(mlsService.getKeyPackagesPayload).toHaveBeenCalledWith(qualifiedUsers);
+      expect(mlsService.getKeyPackagesPayload).toHaveBeenCalledWith(qualifiedUsers, undefined);
       expect(mlsService.resetKeyMaterialRenewal).toHaveBeenCalledWith(mockGroupId);
     });
 

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -364,7 +364,12 @@ export class ConversationService extends TypedEventEmitter<Events> {
     groupId,
     conversationId,
   }: Required<AddUsersParams>): Promise<MLSCreateConversationResponse> {
-    const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(qualifiedUsers);
+    const exisitingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
+
+    const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(
+      qualifiedUsers,
+      exisitingClientIdsInGroup,
+    );
 
     const {events, failures} =
       keyPackages.length > 0

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -338,7 +338,7 @@ export class MLSService extends TypedEventEmitter<Events> {
     return currentClientIdsInGroup;
   }
 
-  public async getKeyPackagesPayload(qualifiedUsers: KeyPackageClaimUser[], skipClientIds?: string[]) {
+  public async getKeyPackagesPayload(qualifiedUsers: KeyPackageClaimUser[], skipClientIds: string[] = []) {
     /**
      * @note We need to fetch key packages for all the users
      * we want to add to the new MLS conversations,
@@ -391,7 +391,7 @@ export class MLSService extends TypedEventEmitter<Events> {
         return [
           ...previousValue,
           ...key_packages
-            .filter(keyPackage => !skipClientIds?.includes(keyPackage.client))
+            .filter(keyPackage => !skipClientIds.includes(keyPackage.client))
             .map(keyPackage => Decoder.fromBase64(keyPackage.key_package).asBytes),
         ];
       }

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -297,7 +297,7 @@ export class MLSService extends TypedEventEmitter<Events> {
       throw new Error('Empty list of keys provided to addUsersToExistingConversation');
     }
 
-    //TODO: handle federation error when sending a commit bundle to backend like we do in ProteusService
+    // TODO: handle federation error when sending a commit bundle to backend like we do in ProteusService
     const response = await this.processCommitAction(groupIdBytes, async () => {
       const commitBundle = await this.coreCryptoClient.addClientsToConversation(groupIdBytes, keyPackages);
       this.dispatchNewCrlDistributionPoints(commitBundle);
@@ -319,7 +319,26 @@ export class MLSService extends TypedEventEmitter<Events> {
     return {...response, failures};
   }
 
-  public async getKeyPackagesPayload(qualifiedUsers: KeyPackageClaimUser[]) {
+  /**
+   * Will return a list of client ids which are already in the group at core crypto level
+   *
+   * @param groupId - the group id of the MLS group
+   * @returns list of client ids
+   */
+  public async getClientIdsInGroup(groupId: string) {
+    const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
+    const currentClientIdsInGroup = [];
+
+    for (const clientId of await this.coreCryptoClient.getClientIds(groupIdBytes)) {
+      // [user-id]:[client-id]@[domain] -> [client-id]
+      // example: fb880fac-b549-4d8b-9398-4246324c7b85:67f41928e2844b6c@staging.zinfra.io -> 67f41928e2844b6c
+      currentClientIdsInGroup.push(Converter.arrayBufferViewToStringUTF8(clientId).split('@')[0].split(':')[1]);
+    }
+
+    return currentClientIdsInGroup;
+  }
+
+  public async getKeyPackagesPayload(qualifiedUsers: KeyPackageClaimUser[], skipClientIds?: string[]) {
     /**
      * @note We need to fetch key packages for all the users
      * we want to add to the new MLS conversations,
@@ -371,7 +390,9 @@ export class MLSService extends TypedEventEmitter<Events> {
       if (key_packages.length > 0) {
         return [
           ...previousValue,
-          ...key_packages.map(keyPackage => Decoder.fromBase64(keyPackage.key_package).asBytes),
+          ...key_packages
+            .filter(keyPackage => !skipClientIds?.includes(keyPackage.client))
+            .map(keyPackage => Decoder.fromBase64(keyPackage.key_package).asBytes),
         ];
       }
       return previousValue;
@@ -1090,3 +1111,5 @@ export class MLSService extends TypedEventEmitter<Events> {
     }
   }
 }
+
+console.info('bardia yalc');

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -1111,5 +1111,3 @@ export class MLSService extends TypedEventEmitter<Events> {
     }
   }
 }
-
-console.info('bardia yalc');


### PR DESCRIPTION
## Description

When we don't have a established connection to a MLS conversation we add our current self client with an external commit then we should try to add our other clients as well and for this to work we need to filter whatever client we already have in the conversation otherwise core crypto will throw an error.

MlsErrorOther: Duplicate signature key in proposals and group