### PR TITLE
fix(CellsAPI): prevent update empty tags [WPB-17811]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -1685,7 +1685,7 @@ describe('CellsAPI', () => {
       expect(mockNodeServiceApi.patchNode).toHaveBeenCalledWith(uuid, {
         MetaUpdates: [
           {
-            Operation: 'PUT',
+            Operation: 'DELETE',
             UserMeta: {Namespace: 'usermeta-tags', JsonValue: '""'},
           },
         ],

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -483,7 +483,7 @@ export class CellsAPI {
     const result = await this.client.patchNode(uuid, {
       MetaUpdates: [
         {
-          Operation: 'PUT',
+          Operation: tags.length > 0 ? 'PUT' : 'DELETE',
           UserMeta: {Namespace: USER_META_TAGS_NAMESPACE, JsonValue: JSON.stringify(tags.join(','))},
         },
       ],


### PR DESCRIPTION
## Description

If there are no passed tags (an empty array), delete all tags from the node. It prevents a situation where we set the tag as an empty string.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
