### PR TITLE
feat(api-client/cells): filter by tags in searchNodes [WPB-17818]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -1128,6 +1128,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1165,6 +1166,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Only',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1202,6 +1204,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1243,6 +1246,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
@@ -1284,6 +1288,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1325,6 +1330,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1362,6 +1368,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1390,6 +1397,7 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
@@ -1398,15 +1406,6 @@ describe('CellsAPI', () => {
         SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
-    });
-
-    it('propagates errors from the NodeServiceApi', async () => {
-      const searchPhrase = 'test';
-      const errorMessage = 'Search failed';
-
-      mockNodeServiceApi.lookup.mockRejectedValueOnce(new Error(errorMessage));
-
-      await expect(cellsAPI.searchNodes({phrase: searchPhrase})).rejects.toThrow(errorMessage);
     });
 
     it('handles empty search phrase', async () => {
@@ -1427,6 +1426,77 @@ describe('CellsAPI', () => {
           Status: {
             Deleted: 'Not',
           },
+          Metadata: [],
+        },
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('filters by tags when provided', async () => {
+      const searchPhrase = 'test';
+      const tags = ['tag1', 'tag2'];
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/test.txt',
+            Uuid: 'file-uuid-1',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchNodes({phrase: searchPhrase, tags});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: '/'}, Recursive: true},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+          Metadata: [{Namespace: 'usermeta-tags', Term: tags.join(',')}],
+        },
+        Flags: ['WithPreSignedURLs'],
+        Limit: '10',
+        Offset: '0',
+        SortDirDesc: true,
+        SortField: 'mtime',
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('handles empty tags array', async () => {
+      const searchPhrase = 'test';
+      const tags: string[] = [];
+      const mockResponse: RestNodeCollection = {
+        Nodes: [
+          {
+            Path: '/test.txt',
+            Uuid: 'file-uuid-1',
+          },
+        ],
+      } as RestNodeCollection;
+
+      mockNodeServiceApi.lookup.mockResolvedValueOnce(createMockResponse(mockResponse));
+
+      const result = await cellsAPI.searchNodes({phrase: searchPhrase, tags});
+
+      expect(mockNodeServiceApi.lookup).toHaveBeenCalledWith({
+        Scope: {Root: {Path: '/'}, Recursive: true},
+        Filters: {
+          Text: {SearchIn: 'BaseName', Term: searchPhrase},
+          Type: 'UNKNOWN',
+          Status: {
+            Deleted: 'Not',
+          },
+          Metadata: [],
         },
         Flags: ['WithPreSignedURLs'],
         Limit: '10',

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -332,6 +332,7 @@ export class CellsAPI {
     sortBy = DEFAULT_SEARCH_SORT_FIELD,
     sortDirection = DEFAULT_SEARCH_SORT_DIRECTION,
     type,
+    tags,
     deleted = false,
   }: {
     phrase: string;
@@ -340,6 +341,7 @@ export class CellsAPI {
     sortBy?: string;
     sortDirection?: SortDirection;
     type?: RestIncomingNode['Type'];
+    tags?: string[];
     deleted?: boolean;
   }): Promise<RestNodeCollection> {
     if (!this.client || !this.storageService) {
@@ -354,6 +356,7 @@ export class CellsAPI {
         Status: {
           Deleted: deleted ? 'Only' : 'Not',
         },
+        Metadata: tags?.length ? [{Namespace: USER_META_TAGS_NAMESPACE, Term: tags.join(',')}] : [],
       },
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,
@@ -484,6 +487,7 @@ export class CellsAPI {
       MetaUpdates: [
         {
           Operation: tags.length > 0 ? 'PUT' : 'DELETE',
+
           UserMeta: {Namespace: USER_META_TAGS_NAMESPACE, JsonValue: JSON.stringify(tags.join(','))},
         },
       ],

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -487,7 +487,6 @@ export class CellsAPI {
       MetaUpdates: [
         {
           Operation: tags.length > 0 ? 'PUT' : 'DELETE',
-
           UserMeta: {Namespace: USER_META_TAGS_NAMESPACE, JsonValue: JSON.stringify(tags.join(','))},
         },
       ],


### PR DESCRIPTION
## Description

Adds a tags filter for the `searchNodes` cells method.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
