### PR TITLE
feat(react-ui-kit): ComboboxSelect without the creatable option

### DIFF
--- a/packages/react-ui-kit/src/Form/Select/ComboboxSelect/ComboboxSelect.stories.tsx
+++ b/packages/react-ui-kit/src/Form/Select/ComboboxSelect/ComboboxSelect.stories.tsx
@@ -56,8 +56,6 @@ export const Default: Story = {
     options: initialOptions,
     placeholder: 'Select options...',
     dataUieName: 'default-select',
-    createOptionLabel: inputValue => `Create item "${inputValue}"`,
-    onCreateOption: () => {},
     noOptionsMessage: 'No options available',
   },
 };
@@ -69,8 +67,6 @@ export const WithValue: Story = {
     value: [initialOptions[0], initialOptions[1]],
     placeholder: 'Select options...',
     dataUieName: 'with-value-select',
-    createOptionLabel: inputValue => `Create item "${inputValue}"`,
-    onCreateOption: () => {},
     noOptionsMessage: 'No options available',
   },
 };
@@ -82,8 +78,6 @@ export const Disabled: Story = {
     isDisabled: true,
     placeholder: 'Select options...',
     dataUieName: 'disabled-select',
-    createOptionLabel: inputValue => `Create item "${inputValue}"`,
-    onCreateOption: () => {},
     noOptionsMessage: 'No options available',
   },
 };
@@ -122,8 +116,6 @@ export const Creatable: Story = {
     options: initialOptions,
     placeholder: 'Select or create options...',
     dataUieName: 'creatable-select',
-    createOptionLabel: inputValue => `Create item "${inputValue}"`,
-    onCreateOption: () => {},
     noOptionsMessage: 'No options available',
     required: true,
   },
@@ -135,8 +127,6 @@ export const WithLabel: Story = {
     id: 'with-label-select',
     label: 'Select options',
     options: initialOptions,
-    createOptionLabel: inputValue => `Create item "${inputValue}"`,
-    onCreateOption: () => {},
     noOptionsMessage: 'No options available',
   },
 };
@@ -146,8 +136,6 @@ export const Loading: Story = {
     id: 'loading-select',
     isLoading: true,
     options: [],
-    createOptionLabel: inputValue => `Create item "${inputValue}"`,
-    onCreateOption: () => {},
     noOptionsMessage: 'No options available',
     loadingMessage: 'Loading options...',
   },

--- a/packages/react-ui-kit/src/Form/Select/ComboboxSelect/ComboboxSelect.tsx
+++ b/packages/react-ui-kit/src/Form/Select/ComboboxSelect/ComboboxSelect.tsx
@@ -17,8 +17,10 @@
  *
  */
 
+import {useMemo} from 'react';
+
 import {CSSObject, useTheme} from '@emotion/react';
-import {components, MenuPosition, MultiValueRemoveProps, NoticeProps} from 'react-select';
+import BaseSelect, {components, MenuPosition, MultiValueRemoveProps, NoticeProps} from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 
 import {selectStyles, noOptionsMessageStyles, wrapperStyles, loadingMessageStyles} from './ComboboxSelect.styles';
@@ -42,12 +44,12 @@ export interface ComboboxSelectProps {
   isDisabled?: boolean;
   placeholder?: string;
   dataUieName?: string;
-  onCreateOption: (inputValue: string) => void;
-  createOptionLabel: (inputValue: string) => string;
+  onCreateOption?: (inputValue: string) => void;
+  createOptionLabel?: (inputValue: string) => string;
   noOptionsMessage: string;
   label?: string;
   required?: boolean;
-  menuPotralTarget?: HTMLElement;
+  menuPortalTarget?: HTMLElement;
   menuPosition?: MenuPosition;
   menuListCSS?: CSSObject;
   isLoading?: boolean;
@@ -67,14 +69,12 @@ export const ComboboxSelect = ({
   noOptionsMessage,
   label,
   required,
-  menuPotralTarget,
+  menuPortalTarget,
   menuPosition = 'absolute',
   menuListCSS,
   isLoading = false,
   loadingMessage,
 }: ComboboxSelectProps) => {
-  const theme = useTheme() as Theme;
-
   return (
     <div css={wrapperStyles} data-uie-name={dataUieName}>
       {label && (
@@ -82,7 +82,59 @@ export const ComboboxSelect = ({
           {label}
         </InputLabel>
       )}
-      <CreatableSelect
+      <Select
+        id={id}
+        options={options}
+        value={value}
+        onChange={onChange}
+        isDisabled={isDisabled}
+        placeholder={placeholder}
+        menuPortalTarget={menuPortalTarget}
+        menuPosition={menuPosition}
+        createOptionLabel={createOptionLabel}
+        onCreateOption={onCreateOption}
+        creatable={!!onCreateOption}
+        isLoading={isLoading}
+        noOptionsMessage={noOptionsMessage}
+        loadingMessage={loadingMessage}
+        menuListCSS={menuListCSS}
+      />
+    </div>
+  );
+};
+
+const Select = ({
+  id,
+  options,
+  value,
+  onChange,
+  isDisabled = false,
+  placeholder,
+  onCreateOption,
+  createOptionLabel,
+  noOptionsMessage,
+  menuPortalTarget,
+  menuPosition = 'absolute',
+  menuListCSS,
+  isLoading = false,
+  loadingMessage,
+  creatable = false,
+}: ComboboxSelectProps & {creatable?: boolean}) => {
+  const theme = useTheme() as Theme;
+
+  const components = useMemo(() => {
+    return {
+      ClearIndicator: () => null,
+      DropdownIndicator: BaseSelectDropdownIndicator,
+      MultiValueRemove: (props: MultiValueRemoveProps) => <MultiValueRemove {...props} />,
+      NoOptionsMessage: (props: NoticeProps) => <NoOptionsMessage {...props} message={noOptionsMessage} />,
+      LoadingMessage: (props: NoticeProps) => <LoadingMessage {...props} message={loadingMessage} />,
+    };
+  }, [loadingMessage, noOptionsMessage]);
+
+  if (!creatable) {
+    return (
+      <BaseSelect
         id={id}
         options={options}
         value={value}
@@ -91,23 +143,36 @@ export const ComboboxSelect = ({
         isSearchable
         isDisabled={isDisabled}
         placeholder={placeholder}
-        menuPortalTarget={menuPotralTarget}
+        menuPortalTarget={menuPortalTarget}
         menuPosition={menuPosition}
         styles={selectStyles({theme, menuListCSS})}
         classNamePrefix="select"
-        formatCreateLabel={createOptionLabel}
-        onCreateOption={onCreateOption}
         closeMenuOnSelect={false}
-        isLoading={isLoading}
-        components={{
-          ClearIndicator: () => null,
-          DropdownIndicator: BaseSelectDropdownIndicator,
-          MultiValueRemove: props => <MultiValueRemove {...props} />,
-          NoOptionsMessage: props => <NoOptionsMessage {...props} message={noOptionsMessage} />,
-          LoadingMessage: props => <LoadingMessage {...props} message={loadingMessage} />,
-        }}
+        components={components}
       />
-    </div>
+    );
+  }
+
+  return (
+    <CreatableSelect
+      id={id}
+      options={options}
+      value={value}
+      onChange={onChange}
+      isMulti
+      isSearchable
+      isDisabled={isDisabled}
+      placeholder={placeholder}
+      menuPortalTarget={menuPortalTarget}
+      menuPosition={menuPosition}
+      styles={selectStyles({theme, menuListCSS})}
+      classNamePrefix="select"
+      formatCreateLabel={createOptionLabel}
+      onCreateOption={onCreateOption}
+      closeMenuOnSelect={false}
+      isLoading={isLoading}
+      components={components}
+    />
   );
 };
 


### PR DESCRIPTION
## Description

Marks creatable props as not required, enable ComboboxSelect without the creatable view - if search doesn't match, display "No results" instead of "Create item xyz".

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
