### PR TITLE
feat(api-client): cells rename node

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -223,6 +223,24 @@ export class CellsAPI {
     return result.data;
   }
 
+  async renameNode({currentPath, newName}: {currentPath: string; newName: string}): Promise<RestPerformActionResponse> {
+    if (!this.client || !this.storageService) {
+      throw new Error(CONFIGURATION_ERROR);
+    }
+
+    const basePath = currentPath.split('/').slice(0, -1).join('/');
+    const newPath = `${basePath}/${newName}`;
+
+    const result = await this.client.performAction('move', {
+      Nodes: [{Path: currentPath}],
+      CopyMoveOptions: {TargetIsParent: false, TargetPath: newPath},
+      AwaitStatus: 'Finished',
+      AwaitTimeout: '5000ms',
+    });
+
+    return result.data;
+  }
+
   async lookupNodeByPath({path}: {path: string}): Promise<RestNode | undefined> {
     if (!this.client || !this.storageService) {
       throw new Error(CONFIGURATION_ERROR);


### PR DESCRIPTION
## Description

Adds `renameNode` cells method.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
