### PR TITLE
fix(react-ui-kit): include zIndexes in GlobalStyles

### DIFF
--- a/packages/react-ui-kit/src/Identity/GlobalStyle/GlobalStyle.tsx
+++ b/packages/react-ui-kit/src/Identity/GlobalStyle/GlobalStyle.tsx
@@ -32,6 +32,7 @@ const getGlobalStyles: (theme: Theme) => CSSObject = (theme: Theme) => ({
   },
   body: {
     ...GlobalCssVariables.accentColors(),
+    ...GlobalCssVariables.zIndexes(),
     MozOsxFontSmoothing: 'grayscale',
     WebkitFontSmoothing: 'antialiased',
     background: theme.general.backgroundColor,


### PR DESCRIPTION
## Description

Includes z-indexes in the global styles.

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
