### PR TITLE
fix(CC): unrecoverable client error and avoiding unnecessary backend calls

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -336,8 +336,15 @@ export class Account extends TypedEventEmitter<Events> {
     if (!this.service || !this.apiClient.context || !this.storeEngine) {
       throw new Error('Services are not set or context not initialized.');
     }
+
     // we reset the services to re-instantiate a new CryptoClient instance
     await this.initServices(this.apiClient.context);
+
+    // make sure we wipe the proteus client before creating a new one in case the client already exists
+    // if a client exists and we dont wipe, the proteus client will try to reuse the existing identity and will fail to create a new one
+    // which results in an unrecoverable state for the user
+    await this.service.proteus.wipe();
+
     const initialPreKeys = await this.service.proteus.createClient(entropyData);
 
     const client = await this.service.client.register(loginData, clientInfo, initialPreKeys);

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -376,7 +376,10 @@ export class ConversationService extends TypedEventEmitter<Events> {
       exisitingClientIdsInGroup,
     );
 
-    await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
+    // We had cases where did not get any key packages, but still used core-crypto to call the backend (which results in failure).
+    if (keyPackages && keyPackages.length > 0) {
+      await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
+    }
 
     const conversation = await this.getConversation(conversationId);
 


### PR DESCRIPTION
This pull request introduces critical updates to enhance error handling and ensure proper initialization in the `Account` and `ConversationService` classes. The changes address potential issues with client state and backend calls, improving system reliability.

### Enhancements to error handling and initialization:

* **`Account` class (`packages/core/src/Account.ts`)**:
  - Added a step to wipe the existing Proteus client before creating a new one. This prevents the reuse of an existing identity, which could lead to an unrecoverable state for the user.

* **`ConversationService` class (`packages/core/src/conversation/ConversationService/ConversationService.ts`)**:
  - Introduced a validation to ensure `keyPackages` is not empty before calling `core-crypto` to add users to an existing conversation. This avoids backend failures caused by invalid inputs.
  - The errors started appearing trough adding self-clients to existing conversations [19115](https://github.com/wireapp/wire-webapp/pull/19115) (self-client keypackages could be empty)
