### PR TITLE
fix(cc): make sure to delete the cc database when wiping data

### DIFF
--- a/packages/core/src/conversation/ConversationService/ConversationService.test.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.test.ts
@@ -668,7 +668,9 @@ describe('ConversationService', () => {
 
       const qualifiedUsers = [...otherUsersToAdd, selfUserToAdd];
 
-      jest.spyOn(mlsService, 'getKeyPackagesPayload').mockResolvedValueOnce({keyPackages: [], failures: []});
+      jest
+        .spyOn(mlsService, 'getKeyPackagesPayload')
+        .mockResolvedValueOnce({keyPackages: [new Uint8Array(0)], failures: []});
 
       jest.spyOn(apiClient.api.conversation, 'getConversation').mockResolvedValueOnce({
         qualified_id: mockConversationId,


### PR DESCRIPTION
This pull request includes updates to enhance the handling of cryptographic data, improve error recovery, and fix issues in conversation service workflows. Key changes include introducing a new utility for wiping the CoreCrypto database, modifying cryptographic client initialization to handle errors more robustly, and refactoring conversation-related logic for better reliability.

### Cryptographic Data Handling:
* Added a utility function `wipeCoreCryptoDb` to encapsulate logic for wiping the CoreCrypto database, improving code reuse and error handling. (`packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts`, [packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.tsR116-R131](diffhunk://#diff-bd3d3c86e95bb9a865ac584d930a5546ab080920fc994752538865791462b75aR116-R131))
* Updated the `buildClient` function to use `wipeCoreCryptoDb` for handling corrupted keys and initialization failures, ensuring the CoreCrypto database is properly reset in these scenarios. (`packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.ts`, [packages/core/src/messagingProtocols/proteus/ProteusService/CryptoClient/CoreCryptoWrapper/CoreCryptoWrapper.tsL137-R174](diffhunk://#diff-bd3d3c86e95bb9a865ac584d930a5546ab080920fc994752538865791462b75aL137-R174))

### Account Service Enhancements:
* Integrated `wipeCoreCryptoDb` into the `wipeCommonData` method to ensure the CoreCrypto database is cleared when wiping common data during logout. (`packages/core/src/Account.ts`, [packages/core/src/Account.tsR525-R542](diffhunk://#diff-0a7e6d4a8ee3b5e3153dbc2336fecd1741ea0f39e7226d6b7a5d63be31b2747fR525-R542))

### Conversation Service Improvements:
* Updated a test in `ConversationService.test.ts` to mock a non-empty `keyPackages` array, ensuring the test reflects realistic scenarios. (`packages/core/src/conversation/ConversationService/ConversationService.test.ts`, [packages/core/src/conversation/ConversationService/ConversationService.test.tsL671-R673](diffhunk://#diff-123d2f0ee1a8a87b5a287e6932e52aa7b79901be6d33c8745938d083a24b1b3bL671-R673))