### PR TITLE
feat(api-client/conversation): add cells_state type field [WPB-18135]

### DIFF
--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -73,6 +73,7 @@ export interface Conversation {
   id: UUID;
   type: CONVERSATION_TYPE;
   creator: UUID;
+  cells_state: 'disabled' | 'pending' | 'ready';
   access: CONVERSATION_ACCESS[];
   group_conv_type?: GROUP_CONVERSATION_TYPE;
   add_permission?: ADD_PERMISSION;

--- a/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
+++ b/packages/core/src/messagingProtocols/proteus/ProteusService/ProteusService.test.ts
@@ -685,6 +685,7 @@ describe('ProteusService', () => {
       id: '',
       type: CONVERSATION_TYPE.REGULAR,
       creator: '',
+      cells_state: 'disabled',
       access: [],
       access_role: [CONVERSATION_ACCESS_ROLE.GUEST],
       members: {


### PR DESCRIPTION
## Description

Add `cells_state` field in the `Conversation` type - [documentation](https://wearezeta.atlassian.net/wiki/spaces/PAD/pages/1800962144/2025-03-19+Wire+Cells+implementation+in+wire-server).

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
