### PR TITLE
feat(api-client): define conversation cells state enum

### DIFF
--- a/packages/api-client/src/conversation/Conversation.ts
+++ b/packages/api-client/src/conversation/Conversation.ts
@@ -63,6 +63,12 @@ export enum ADD_PERMISSION {
   ADMINS = 'admins',
 }
 
+export enum CONVERSATION_CELLS_STATE {
+  DISABLED = 'disabled',
+  PENDING = 'pending',
+  READY = 'ready',
+}
+
 type UUID = string;
 /**
  * A conversation object as returned from the server
@@ -73,7 +79,7 @@ export interface Conversation {
   id: UUID;
   type: CONVERSATION_TYPE;
   creator: UUID;
-  cells_state: 'disabled' | 'pending' | 'ready';
+  cells_state: CONVERSATION_CELLS_STATE;
   access: CONVERSATION_ACCESS[];
   group_conv_type?: GROUP_CONVERSATION_TYPE;
   add_permission?: ADD_PERMISSION;


### PR DESCRIPTION
## Description

Adds `CONVERSATION_CELLS_STATE` enum for consistency, and further reuse inside the web app.

Related: https://github.com/wireapp/wire-web-packages/pull/7082

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
