### PR TITLE
feat(api-client/cells): remove default sorting [WPB-17387]

### DIFF
--- a/packages/api-client/src/cells/CellsAPI.test.ts
+++ b/packages/api-client/src/cells/CellsAPI.test.ts
@@ -338,8 +338,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortField: 'mtime',
-        SortDirDesc: true,
         Filters: {
           Type: 'UNKNOWN',
           Status: {
@@ -367,8 +365,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortField: 'mtime',
-        SortDirDesc: true,
         Filters: {
           Type: 'UNKNOWN',
           Status: {
@@ -396,8 +392,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortField: 'mtime',
-        SortDirDesc: true,
         Filters: {
           Type: 'UNKNOWN',
           Status: {
@@ -429,8 +423,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
         Offset: '10',
-        SortField: 'mtime',
-        SortDirDesc: true,
         Filters: {
           Type: 'UNKNOWN',
           Status: {
@@ -524,8 +516,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortField: 'mtime',
-        SortDirDesc: true,
         Filters: {
           Type: 'LEAF',
           Status: {
@@ -1251,8 +1241,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1289,8 +1277,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1327,8 +1313,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1369,8 +1353,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '5',
         Offset: '10',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1491,8 +1473,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1520,8 +1500,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1549,8 +1527,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1584,8 +1560,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });
@@ -1619,8 +1593,6 @@ describe('CellsAPI', () => {
         Flags: ['WithPreSignedURLs'],
         Limit: '10',
         Offset: '0',
-        SortDirDesc: true,
-        SortField: 'mtime',
       });
       expect(result).toEqual(mockResponse);
     });

--- a/packages/api-client/src/cells/CellsAPI.ts
+++ b/packages/api-client/src/cells/CellsAPI.ts
@@ -46,8 +46,6 @@ export type SortDirection = 'asc' | 'desc';
 const CONFIGURATION_ERROR = 'CellsAPI is not initialized. Call initialize() before using any methods.';
 const DEFAULT_LIMIT = 10;
 const DEFAULT_OFFSET = 0;
-const DEFAULT_SEARCH_SORT_FIELD = 'mtime';
-const DEFAULT_SEARCH_SORT_DIRECTION: SortDirection = 'desc';
 const USER_META_TAGS_NAMESPACE = 'usermeta-tags';
 
 interface CellsConfig {
@@ -303,8 +301,8 @@ export class CellsAPI {
     path,
     limit = DEFAULT_LIMIT,
     offset = DEFAULT_OFFSET,
-    sortBy = DEFAULT_SEARCH_SORT_FIELD,
-    sortDirection = DEFAULT_SEARCH_SORT_DIRECTION,
+    sortBy,
+    sortDirection,
     type,
     deleted = false,
   }: {
@@ -331,12 +329,9 @@ export class CellsAPI {
           Deleted: deleted ? 'Only' : 'Not',
         },
       },
+      SortField: sortBy,
+      SortDirDesc: sortDirection ? sortDirection === 'desc' : undefined,
     };
-
-    if (sortBy) {
-      request.SortField = sortBy;
-      request.SortDirDesc = sortDirection === 'desc';
-    }
 
     const result = await this.client.lookup(request);
 
@@ -347,8 +342,8 @@ export class CellsAPI {
     phrase,
     limit = DEFAULT_LIMIT,
     offset = DEFAULT_OFFSET,
-    sortBy = DEFAULT_SEARCH_SORT_FIELD,
-    sortDirection = DEFAULT_SEARCH_SORT_DIRECTION,
+    sortBy,
+    sortDirection,
     type,
     tags,
     deleted = false,
@@ -379,12 +374,9 @@ export class CellsAPI {
       Flags: ['WithPreSignedURLs'],
       Limit: `${limit}`,
       Offset: `${offset}`,
+      SortField: sortBy,
+      SortDirDesc: sortDirection ? sortDirection === 'desc' : undefined,
     };
-
-    if (sortBy) {
-      request.SortField = sortBy;
-      request.SortDirDesc = sortDirection === 'desc';
-    }
 
     const result = await this.client.lookup(request);
 


### PR DESCRIPTION
## Description

Removes default sorting from `getAllNodes` and `searchNodes` methods.

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
