### PR TITLE
fix(MLS): emit epoch change for conversations we join [WPB-18371]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.test.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.test.ts
@@ -48,6 +48,11 @@ const mockParams = {
     scheduleKeyMaterialRenewal: jest.fn(),
     getEpoch: jest.fn(),
     emit: jest.fn(),
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
   } as unknown as MLSService,
   dryRun: false,
 };

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts
@@ -42,8 +42,10 @@ export const handleMLSWelcomeMessage = async ({
   // After we were added to the group we need to schedule a periodic key material renewal
   await mlsService.scheduleKeyMaterialRenewal(groupIdStr);
 
+  // We also need to emit a NEW_EPOCH event to notify the rest of the system that we have joined a new group
   const newEpoch = await mlsService.getEpoch(groupIdStr);
   mlsService.emit(MLSServiceEvents.NEW_EPOCH, {groupId: groupIdStr, epoch: newEpoch});
+  mlsService.logger.info(`Joined MLS group with id ${groupIdStr} via welcome message, new epoch: ${newEpoch}`);
 
   return {
     event: {...event, data: groupIdStr},

--- a/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
+++ b/packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts
@@ -391,7 +391,14 @@ export class MLSService extends TypedEventEmitter<Events> {
     if (welcomeBundle.id) {
       //after we've successfully joined via external commit, we schedule periodic key material renewal
       const groupIdStr = Encoder.toBase64(welcomeBundle.id).asString;
+      const newEpoch = await this.getEpoch(groupIdStr);
+
+      // Schedule the next key material renewal
       await this.scheduleKeyMaterialRenewal(groupIdStr);
+
+      // Notify subscribers about the new epoch
+      this.emit(MLSServiceEvents.NEW_EPOCH, {groupId: groupIdStr, epoch: newEpoch});
+      this.logger.info(`Joined MLS group with id ${groupIdStr} via external commit, new epoch: ${newEpoch}`);
     }
   }
 


### PR DESCRIPTION
This pull request enhances the handling of MLS (Messaging Layer Security) group join events by introducing additional logging and event notifications. The changes improve observability and ensure that the system is informed when a new epoch begins after joining a group.

### Enhancements to MLS group join handling:

* **Emit `NEW_EPOCH` event upon joining a group via welcome message**: added logging when a new group is joined via a welcome message, providing better visibility into group state changes. (`packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.ts`, [packages/core/src/messagingProtocols/mls/EventHandler/events/welcomeMessage/welcomeMessage.tsR45-R48](diffhunk://#diff-d3b00a8e97ae3002de697ff37f7b040bcaf2c00a3180dda38ae38c21d01f25b2R45-R48))

* **Emit `NEW_EPOCH` event upon joining a group via external commit**: Added a similar logic to emit a `NEW_EPOCH` event and log a message when a group is joined via an external commit, ensuring consistency across different join methods. (`packages/core/src/messagingProtocols/mls/MLSService/MLSService.ts`, [packages/core/src/messagingProtocols/mls/MLSService/MLSService.tsR394-R401](diffhunk://#diff-7941cda3e6ce81bf7a6af9ffdfd95f20da9d0254bd4780f9d3493a63dcfed29cR394-R401))