### PR TITLE
fix(core): Do not call /notifications/last once switched to consumable-notifications

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -344,7 +344,7 @@ export class Account extends TypedEventEmitter<Events> {
   /**
    * Will register a new client for the current user
    */
-  public regsterClient = async (
+  public registerClient = async (
     loginData: LoginData,
     clientInfo: ClientInfo = coreDefaultClient,
     /** will add extra manual entropy to the client's identity being created */
@@ -362,7 +362,6 @@ export class Account extends TypedEventEmitter<Events> {
     const client = await this.service.client.register(loginData, clientInfo, initialPreKeys);
     const clientId = client.id;
 
-    await this.service.notification.initializeNotificationStream(clientId);
     await this.service.client.synchronizeClients(clientId);
     return client;
   };

--- a/packages/core/src/notification/NotificationService.ts
+++ b/packages/core/src/notification/NotificationService.ts
@@ -90,8 +90,13 @@ export class NotificationService extends TypedEventEmitter<Events> {
     return this.backend.getAllNotifications(clientId, since);
   }
 
-  /** Should only be called with a completely new client. */
-  public async initializeNotificationStream(clientId: string): Promise<string> {
+  /**
+   * Should only be called with a completely new client.
+   *
+   * @deprecated This method is used to handle legacy notifications from the backend.
+   * It can be removed when all clients are capable of handling consumable notifications.
+   */
+  public async legacyInitializeNotificationStream(clientId: string): Promise<string> {
     await this.setLastEventDate(new Date(0));
     const latestNotification = await this.backend.getLastNotification(clientId);
     return this.setLastNotificationId(latestNotification);


### PR DESCRIPTION
we're not supposed to call /notifications/last once we switched to consumable-notifications