### PR TITLE
fix(core): Queue incoming pending MLS proposals [WPB-18995]

### DIFF
--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingProposalsQueue/IncomingProposalsQueue.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingProposalsQueue/IncomingProposalsQueue.ts
@@ -1,0 +1,40 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import {LogFactory} from '@wireapp/commons';
+import {Task, PromiseQueue} from '@wireapp/promise-queue';
+
+const logger = LogFactory.getLogger('@wireapp/core/MLSService/IncomingProposalsQueue');
+
+const proposalsQueue = new PromiseQueue({name: 'incoming-proposals-queue', paused: true});
+
+export function queueProposal<T>(cb: Task<T>): Promise<T> {
+  logger.info('Queueing proposal for processing');
+  return proposalsQueue.push(cb);
+}
+
+export function resumeProposalProcessing(): void {
+  logger.info('Resuming proposal processing');
+  proposalsQueue.pause(false);
+}
+
+export function pauseProposalProcessing(): void {
+  logger.info('Pausing proposal processing');
+  proposalsQueue.pause(true);
+}

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingProposalsQueue/index.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/IncomingProposalsQueue/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Wire
+ * Copyright (C) 2023 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export * from './IncomingProposalsQueue';

--- a/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
+++ b/packages/core/src/messagingProtocols/mls/EventHandler/events/messageAdd/messageAdd.ts
@@ -22,6 +22,8 @@ import {Decoder} from 'bazinga64';
 
 import {GenericMessage} from '@wireapp/protocol-messaging';
 
+import {queueProposal} from './IncomingProposalsQueue';
+
 import {HandledEventPayload} from '../../../../../notification';
 import {MLSService, optionalToUint8Array} from '../../../MLSService/MLSService';
 
@@ -57,12 +59,16 @@ export const handleMLSMessageAdd = async ({
 
   // Check if the message includes proposals
   if (typeof commitDelay === 'number') {
-    // we are dealing with a proposal, add a task to process this proposal later on
-    // Those proposals are stored inside of coreCrypto and will be handled after a timeout
-    await mlsService.handlePendingProposals({
-      groupId,
-      delayInMs: commitDelay ?? 0,
-      eventTime: event.time,
+    queueProposal(async () => {
+      // we are dealing with a proposal, add a task to process this proposal later on
+      // Those proposals are stored inside of coreCrypto and will be handled after a timeout
+      await mlsService.handlePendingProposals({
+        groupId,
+        delayInMs: commitDelay ?? 0,
+        eventTime: event.time,
+      });
+    }).catch(error => {
+      console.error('Failed to process proposal:', error);
     });
   }
 


### PR DESCRIPTION
Problem:
On web pending proposals which arrive during the incremental sync are committed immediately before the sync is completed. This is very wasteful and. leads to large amount of errors, since the the requests often will fail with  409 conflict since the proposal has already been committed by someone else.

This is sometimes causing very long decryption time or making the app freeze during initial startup.

Solution:
Commit any still remaining pending proposals after the incremental sync is complete.