### PR TITLE
feat(api-client): Support for reset MLS event [WPB-17706]

### DIFF
--- a/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
+++ b/packages/api-client/src/conversation/ConversationAPI/ConversationAPI.ts
@@ -101,6 +101,7 @@ export class ConversationAPI {
     SUBCONVERSATIONS: 'subconversations',
     GROUP_INFO: 'groupinfo',
     MLS: 'mls',
+    RESET_CONVERSATION: 'reset-conversation',
     JOIN: 'join',
     LIST: 'list',
     LIST_IDS: 'list-ids',
@@ -980,5 +981,15 @@ export class ConversationAPI {
     }
 
     return response.data;
+  }
+
+  public async resetMLSConversation({groupId, epoch}: {groupId: string; epoch: number}) {
+    const config: AxiosRequestConfig = {
+      method: 'post',
+      url: `/${ConversationAPI.URL.MLS}/${ConversationAPI.URL.RESET_CONVERSATION}`,
+      data: {group_id: groupId, epoch},
+    };
+
+    await this.client.sendJSON(config);
   }
 }

--- a/packages/api-client/src/conversation/data/ConversationMLSResetData.ts
+++ b/packages/api-client/src/conversation/data/ConversationMLSResetData.ts
@@ -1,0 +1,23 @@
+/*
+ * Wire
+ * Copyright (C) 2019 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+export interface ConversationMLSResetData {
+  group_id: string;
+  new_group_id: string;
+}

--- a/packages/api-client/src/event/ConversationEvent.ts
+++ b/packages/api-client/src/event/ConversationEvent.ts
@@ -35,6 +35,7 @@ import {
   ConversationMLSMessageAddData,
 } from '../conversation/data/';
 import {ConversationAddPermissionUpdateData} from '../conversation/data/ConversationAddPermissionUpdateData';
+import {ConversationMLSResetData} from '../conversation/data/ConversationMLSResetData';
 import {ConversationProtocolUpdateData} from '../conversation/data/ConversationProtocolUpdateData';
 import {QualifiedId} from '../user';
 
@@ -53,6 +54,7 @@ export enum CONVERSATION_EVENT {
   OTR_MESSAGE_ADD = 'conversation.otr-message-add',
   MLS_MESSAGE_ADD = 'conversation.mls-message-add',
   MLS_WELCOME_MESSAGE = 'conversation.mls-welcome',
+  MLS_RESET = 'conversation.mls-reset',
   RECEIPT_MODE_UPDATE = 'conversation.receipt-mode-update',
   ADD_PERMISSION_UPDATE = 'conversation.add-permission-update',
   RENAME = 'conversation.rename',
@@ -72,6 +74,7 @@ export type ConversationEventData =
   | ConversationOtrMessageAddData
   | ConversationMLSWelcomeData
   | ConversationMLSMessageAddData
+  | ConversationMLSResetData
   | ConversationReceiptModeUpdateData
   | ConversationRenameData
   | ConversationTypingData
@@ -91,6 +94,7 @@ export type ConversationEvent =
   | ConversationMessageTimerUpdateEvent
   | ConversationOtrMessageAddEvent
   | ConversationMLSMessageAddEvent
+  | ConversationMLSResetEvent
   | ConversationMLSWelcomeEvent
   | ConversationReceiptModeUpdateEvent
   | ConversationRenameEvent
@@ -179,6 +183,11 @@ export interface ConversationMLSMessageAddEvent extends BaseConversationEvent {
 export interface ConversationMLSWelcomeEvent extends BaseConversationEvent {
   data: ConversationMLSWelcomeData;
   type: CONVERSATION_EVENT.MLS_WELCOME_MESSAGE;
+}
+
+export interface ConversationMLSResetEvent extends BaseConversationEvent {
+  data: ConversationMLSResetData;
+  type: CONVERSATION_EVENT.MLS_RESET;
 }
 
 export interface ConversationReceiptModeUpdateEvent extends BaseConversationEvent {

--- a/packages/api-client/src/http/BackendErrorLabel.ts
+++ b/packages/api-client/src/http/BackendErrorLabel.ts
@@ -66,6 +66,8 @@ export enum BackendErrorLabel {
   NOT_CONNECTED = 'not-connected',
   INVALID_CONVERSATION_PASSWORD = 'invalid-conversation-password',
   MLS_STALE_MESSAGE = 'mls-stale-message',
+  MLS_INVALID_LEAF_NODE_SIGNATURE = 'mls-invalid-leaf-node-signature',
+  MLS_INVALID_LEAF_NODE_INDEX = 'mls-invalid-leaf-node-index',
 
   // Handle errors
   HANDLE_EXISTS = 'handle-exists',


### PR DESCRIPTION
Support for mls reset conversation event & added the implementation of the endpoint needed to trigger a reset on the backend.