### PR TITLE
fix(events): add qualified_id to UserDeleteData type [WPB-18869]

### DIFF
--- a/packages/api-client/src/user/data/UserDeleteData.ts
+++ b/packages/api-client/src/user/data/UserDeleteData.ts
@@ -17,6 +17,9 @@
  *
  */
 
+import {QualifiedId} from '../QualifiedId';
+
 export interface UserDeleteData {
   id: string;
+  qualified_id: QualifiedId;
 }


### PR DESCRIPTION
## Description

the `user.delete` backend event returns a qualified id, required to handle deleted users in 1:1 conversations.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
