### PR TITLE
chore: Revert "chore(deps-dev): bump @lerna-lite/publish from 4.7.0 to 4.7.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@emotion/eslint-plugin": "^11.10.0",
     "@lerna-lite/changed": "4.7.2",
     "@lerna-lite/cli": "3.12.1",
-    "@lerna-lite/publish": "4.7.2",
+    "@lerna-lite/publish": "4.7.0",
     "@lerna-lite/run": "4.7.2",
     "@lerna-lite/version": "4.7.2",
     "@swc/core": "^1.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4598,14 +4598,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lerna-lite/publish@npm:4.7.2":
-  version: 4.7.2
-  resolution: "@lerna-lite/publish@npm:4.7.2"
+"@lerna-lite/publish@npm:4.7.0":
+  version: 4.7.0
+  resolution: "@lerna-lite/publish@npm:4.7.0"
   dependencies:
-    "@lerna-lite/cli": 4.7.2
-    "@lerna-lite/core": 4.7.2
-    "@lerna-lite/npmlog": 4.7.1
-    "@lerna-lite/version": 4.7.2
+    "@lerna-lite/cli": 4.7.0
+    "@lerna-lite/core": 4.7.0
+    "@lerna-lite/npmlog": 4.7.0
+    "@lerna-lite/version": 4.7.0
     "@npmcli/arborist": ^9.1.3
     "@npmcli/package-json": ^6.2.0
     byte-size: ^9.0.1
@@ -4626,7 +4626,7 @@ __metadata:
     tar: ^7.4.3
     tinyglobby: ^0.2.14
     tinyrainbow: ^2.0.0
-  checksum: 3f7a2b36a1b3719937c74eba413f8c980140ad317a099d0de4f11ab526c2d417087b968724c06f6dca3fe6a00a05820073481d03c5f1668f39b7492e09f371a0
+  checksum: b32ae32fe96f6ef78d074feed8d36b242aa77a1802c67923515d4475e1b5bccc9b9836390f032d2bd4ba10fdd85b62d36d18850a149a8cc4776704c86c965297
   languageName: node
   linkType: hard
 
@@ -21356,7 +21356,7 @@ __metadata:
     "@emotion/eslint-plugin": ^11.10.0
     "@lerna-lite/changed": 4.7.2
     "@lerna-lite/cli": 3.12.1
-    "@lerna-lite/publish": 4.7.2
+    "@lerna-lite/publish": 4.7.0
     "@lerna-lite/run": 4.7.2
     "@lerna-lite/version": 4.7.2
     "@swc/core": ^1.3.10


### PR DESCRIPTION
This reverts commit 0424d396109d8f35533d594683d35ffc2c817079.

## Description

This Dependabot merge s causing a [lockfile issue](https://github.com/wireapp/wire-web-packages/actions/runs/17022165600/job/48252732100)

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [ ] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [ ] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
