### PR TITLE
fix: Handle expired token gracefully(WPB-19368)

### DIFF
--- a/packages/api-client/src/http/BackendErrorMapper.test.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.test.ts
@@ -19,13 +19,7 @@
 
 import {BackendErrorMapper} from './BackendErrorMapper';
 
-import {
-  InvalidCredentialsError,
-  InvalidTokenError,
-  MissingCookieError,
-  SuspendedAccountError,
-  TokenExpiredError,
-} from '../auth/';
+import {InvalidCredentialsError, MissingCookieError, SuspendedAccountError, TokenExpiredError} from '../auth/';
 import {ConversationIsUnknownError} from '../conversation/';
 import {UserIsUnknownError} from '../user/';
 
@@ -33,16 +27,6 @@ import {BackendError, BackendErrorLabel, StatusCode} from './';
 
 describe('BackendErrorMapper', () => {
   describe('Focused critical cases', () => {
-    it('maps "Invalid zauth token" to InvalidTokenError', () => {
-      const error = new BackendError(
-        'Invalid zauth token',
-        BackendErrorLabel.INVALID_CREDENTIALS,
-        StatusCode.FORBIDDEN,
-      );
-      const mapped = BackendErrorMapper.map(error);
-      expect(mapped).toBeInstanceOf(InvalidTokenError);
-    });
-
     it('maps "Authentication failed." to InvalidCredentialsError', () => {
       const error = new BackendError(
         'Authentication failed.',

--- a/packages/api-client/src/http/BackendErrorMapper.test.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.test.ts
@@ -17,36 +17,86 @@
  *
  */
 
-import {BackendErrorLabel} from './BackendErrorLabel';
 import {BackendErrorMapper} from './BackendErrorMapper';
 
-import {ConversationIsUnknownError} from '../conversation/ConversationError';
-import {UserIsUnknownError} from '../user/UserError';
+import {
+  InvalidCredentialsError,
+  InvalidTokenError,
+  MissingCookieError,
+  SuspendedAccountError,
+  TokenExpiredError,
+} from '../auth/';
+import {ConversationIsUnknownError} from '../conversation/';
+import {UserIsUnknownError} from '../user/';
 
-import {StatusCode} from '.';
+import {BackendError, BackendErrorLabel, StatusCode} from './';
 
 describe('BackendErrorMapper', () => {
-  describe('"map"', () => {
-    it('maps backend error payloads into error objects', () => {
-      const userIdError = {
-        code: StatusCode.BAD_REQUEST,
-        label: BackendErrorLabel.CLIENT_ERROR,
-        message: "[path] 'usr' invalid: Failed reading: Invalid UUID",
-        name: '',
-      };
+  describe('Focused critical cases', () => {
+    it('maps "Invalid zauth token" to InvalidTokenError', () => {
+      const error = new BackendError(
+        'Invalid zauth token',
+        BackendErrorLabel.INVALID_CREDENTIALS,
+        StatusCode.FORBIDDEN,
+      );
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(InvalidTokenError);
+    });
 
-      const userError = BackendErrorMapper.map(userIdError);
-      expect(userError).toEqual(expect.any(UserIsUnknownError));
+    it('maps "Authentication failed." to InvalidCredentialsError', () => {
+      const error = new BackendError(
+        'Authentication failed.',
+        BackendErrorLabel.INVALID_CREDENTIALS,
+        StatusCode.FORBIDDEN,
+      );
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(InvalidCredentialsError);
+    });
 
-      const conversationIdError = {
-        code: StatusCode.BAD_REQUEST,
-        label: BackendErrorLabel.CLIENT_ERROR,
-        message: "[path] 'cnv' invalid: Failed reading: Invalid UUID",
-        name: '',
-      };
+    it('maps "Token expired" to TokenExpiredError', () => {
+      const error = new BackendError('Token expired', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(TokenExpiredError);
+    });
 
-      const conversationError = BackendErrorMapper.map(conversationIdError);
-      expect(conversationError).toEqual(expect.any(ConversationIsUnknownError));
+    it('maps "Missing cookie" to MissingCookieError', () => {
+      const error = new BackendError('Missing cookie', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(MissingCookieError);
+    });
+
+    it('maps invalid conversation UUID to ConversationIsUnknownError', () => {
+      const error = new BackendError(
+        "[path] 'cnv' invalid: Failed reading: Invalid UUID",
+        BackendErrorLabel.CLIENT_ERROR,
+        StatusCode.BAD_REQUEST,
+      );
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(ConversationIsUnknownError);
+    });
+
+    it('maps invalid user UUID to UserIsUnknownError', () => {
+      const error = new BackendError(
+        "[path] 'usr' invalid: Failed reading: Invalid UUID",
+        BackendErrorLabel.CLIENT_ERROR,
+        StatusCode.BAD_REQUEST,
+      );
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(UserIsUnknownError);
+    });
+
+    it('maps suspended account to SuspendedAccountError', () => {
+      const error = new BackendError('Account suspended.', BackendErrorLabel.SUSPENDED_ACCOUNT, StatusCode.FORBIDDEN);
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBeInstanceOf(SuspendedAccountError);
+    });
+  });
+
+  describe('Fallback behavior', () => {
+    it('returns original error when no mapping exists', () => {
+      const error = new BackendError('unknown message', BackendErrorLabel.CLIENT_ERROR, StatusCode.BAD_REQUEST);
+      const mapped = BackendErrorMapper.map(error);
+      expect(mapped).toBe(error);
     });
   });
 });

--- a/packages/api-client/src/http/BackendErrorMapper.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.ts
@@ -60,6 +60,11 @@ export class BackendErrorMapper {
             'Authentication failed because the cookie and token is missing.',
           ),
         },
+        [BackendErrorLabel.CLIENT_ERROR]: {
+          'Failed reading: Invalid zauth token': new InvalidTokenError(
+            'Authentication failed because the token is invalid.',
+          ),
+        },
         [BackendErrorLabel.NOT_CONNECTED]: {
           'Users are not connected': new UnconnectedUserError('Users are not connected.'),
         },
@@ -91,6 +96,17 @@ export class BackendErrorMapper {
     };
   }
 
+  private static logUnmapped(error: BackendError, reason: string) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('[BackendErrorMapper] Unmapped error:', {
+        code: error.code,
+        label: error.label,
+        message: error.message,
+        reason,
+      });
+    }
+  }
+
   public static map(error: BackendError): BackendError {
     try {
       const mappedError: BackendError | undefined =
@@ -98,9 +114,10 @@ export class BackendErrorMapper {
       if (mappedError) {
         return mappedError;
       }
-      return error;
+      this.logUnmapped(error, 'No matching entry found in error mapping');
     } catch (mappingError) {
-      return error;
+      this.logUnmapped(error, 'Error mapping lookup failed with exception');
     }
+    return error;
   }
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where sharing the same cookie across multiple tabs/users caused inconsistent session handling.

## Context

When two different users share the same cookie, the session gets invalidated.

The access token remains valid, so the site continues to appear responsive.

After 15 minutes when the access token expires(/access JSON response expires_in: 900), the invalid user stays logged in but the console is flooded with 403 errors.

This happened due to incorrect error mapping, which prevented a proper logout flow.

## Changes

Corrected error mapping for 403 responses tied to invalid sessions.

Ensured that doLogout is triggered when session invalidation is detected.

Prevents flooding of 403 errors after access token expiry.

Provides a smoother and more consistent logout experience.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
