### PR TITLE
refactor(core, promise-queue): Turn listen method event handler to a sync function [WPB-18813]

### DIFF
--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -783,7 +783,7 @@ export class Account extends TypedEventEmitter<Events> {
    * forwarding the event to the consumer via the `onEvent` callback.
    */
   private createEventHandler = (onEvent: (payload: HandledEventPayload, source: NotificationSource) => void) => {
-    return async (payload: HandledEventPayload, source: NotificationSource) => {
+    return (payload: HandledEventPayload, source: NotificationSource) => {
       const {event} = payload;
       switch (event?.type) {
         case CONVERSATION_EVENT.MESSAGE_TIMER_UPDATE: {
@@ -809,7 +809,7 @@ export class Account extends TypedEventEmitter<Events> {
    * when all clients are capable of handling consumable notifications.
    */
   private createLegacyNotificationHandler = (
-    handleEvent: (payload: HandledEventPayload, source: NotificationSource) => Promise<void>,
+    handleEvent: (payload: HandledEventPayload, source: NotificationSource) => void,
     onNotificationStreamProgress: (currentProcessingNotificationTimestamp: string) => void,
     dryRun: boolean,
   ) => {
@@ -831,7 +831,7 @@ export class Account extends TypedEventEmitter<Events> {
             const messages = this.service!.notification.handleNotification(notification, source, dryRun);
 
             for await (const message of messages) {
-              await handleEvent(message, source);
+              handleEvent(message, source);
             }
 
             this.logger.info(`Finished processing legacy notification "${notification.id}" in ${Date.now() - start}ms`);
@@ -847,7 +847,7 @@ export class Account extends TypedEventEmitter<Events> {
   };
 
   private createNotificationHandler = (
-    handleEvent: (payload: HandledEventPayload, source: NotificationSource) => Promise<void>,
+    handleEvent: (payload: HandledEventPayload, source: NotificationSource) => void,
     onNotificationStreamProgress: (currentProcessingNotificationTimestamp: string) => void,
     onConnectionStateChanged: (state: ConnectionState) => void,
     dryRun: boolean,
@@ -920,7 +920,7 @@ export class Account extends TypedEventEmitter<Events> {
 
   private decryptAckEmitNotification = async (
     notification: ConsumableNotificationEvent,
-    handleEvent: (payload: HandledEventPayload, source: NotificationSource) => Promise<void>,
+    handleEvent: (payload: HandledEventPayload, source: NotificationSource) => void,
     source: NotificationSource,
     onNotificationStreamProgress: (currentProcessingNotificationTimestamp: string) => void,
     dryRun: boolean,
@@ -938,7 +938,7 @@ export class Account extends TypedEventEmitter<Events> {
       }
 
       for await (const payload of payloads ?? []) {
-        await handleEvent(payload, source);
+        handleEvent(payload, source);
       }
     } catch (err) {
       this.logger.error(`Failed to process notification ${notification.data.delivery_tag}`, err);

--- a/packages/promise-queue/src/PromiseQueue.ts
+++ b/packages/promise-queue/src/PromiseQueue.ts
@@ -88,7 +88,7 @@ export class PromiseQueue {
      * In long queues (like app startup notifications) it can lead to memory bloat and unnecessary wake-ups in the event loop.
      */
     let timeoutId: ReturnType<typeof setTimeout>;
-    const timeout = new Promise<never>((_, reject) => {
+    const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
         this.logger?.warn?.(
           `Promise queue task timed-out after ${this.timeout}ms, rejecting and advancing to the next task in queue`,
@@ -100,7 +100,7 @@ export class PromiseQueue {
       }, this.timeout);
     });
 
-    Promise.race([queueEntry.fn(), timeout])
+    Promise.race([queueEntry.fn(), timeoutPromise])
       .then(result => queueEntry.resolveFn(result as any))
       .catch(err => {
         queueEntry.resolveFn = () => {};


### PR DESCRIPTION
## Description

createEventHandler is not doing any async operations at all so it shouldn't be an async function