### PR TITLE
fix: create fresh error instances via handler functions in BackendErrorMapper and add fallback for unknown messages(WPB-19061)

### DIFF
--- a/packages/api-client/src/http/BackendErrorMapper.test.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.test.ts
@@ -39,7 +39,7 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.INVALID_CREDENTIALS,
         StatusCode.FORBIDDEN,
       );
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(InvalidTokenError);
     });
 
@@ -49,19 +49,19 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.INVALID_CREDENTIALS,
         StatusCode.FORBIDDEN,
       );
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(InvalidCredentialsError);
     });
 
     it('maps "Token expired" to TokenExpiredError', () => {
       const error = new BackendError('Token expired', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(TokenExpiredError);
     });
 
     it('maps "Missing cookie" to MissingCookieError', () => {
       const error = new BackendError('Missing cookie', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(MissingCookieError);
     });
 
@@ -71,7 +71,7 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.CLIENT_ERROR,
         StatusCode.BAD_REQUEST,
       );
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(ConversationIsUnknownError);
     });
 
@@ -81,13 +81,13 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.CLIENT_ERROR,
         StatusCode.BAD_REQUEST,
       );
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(UserIsUnknownError);
     });
 
     it('maps suspended account to SuspendedAccountError', () => {
       const error = new BackendError('Account suspended.', BackendErrorLabel.SUSPENDED_ACCOUNT, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBeInstanceOf(SuspendedAccountError);
     });
   });
@@ -95,14 +95,14 @@ describe('BackendErrorMapper', () => {
   describe('Fallback behavior', () => {
     it('falls back to default handler when message variant is unknown', () => {
       const error = new BackendError('unknown message', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).not.toBe(error);
       expect(mapped).toBeInstanceOf(BackendError);
       expect(mapped.message).toBe('Authentication failed because the token is invalid.');
     });
     it('returns original error when no handler exists for code and label', () => {
       const error = new BackendError('unknown message', BackendErrorLabel.CLIENT_ERROR, StatusCode.UNAUTHORIZED);
-      const mapped = BackendErrorMapper.mapBackendError(error);
+      const mapped = BackendErrorMapper.map(error);
       expect(mapped).toBe(error);
     });
   });

--- a/packages/api-client/src/http/BackendErrorMapper.test.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.test.ts
@@ -39,7 +39,7 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.INVALID_CREDENTIALS,
         StatusCode.FORBIDDEN,
       );
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(InvalidTokenError);
     });
 
@@ -49,19 +49,19 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.INVALID_CREDENTIALS,
         StatusCode.FORBIDDEN,
       );
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(InvalidCredentialsError);
     });
 
     it('maps "Token expired" to TokenExpiredError', () => {
       const error = new BackendError('Token expired', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(TokenExpiredError);
     });
 
     it('maps "Missing cookie" to MissingCookieError', () => {
       const error = new BackendError('Missing cookie', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(MissingCookieError);
     });
 
@@ -71,7 +71,7 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.CLIENT_ERROR,
         StatusCode.BAD_REQUEST,
       );
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(ConversationIsUnknownError);
     });
 
@@ -81,21 +81,28 @@ describe('BackendErrorMapper', () => {
         BackendErrorLabel.CLIENT_ERROR,
         StatusCode.BAD_REQUEST,
       );
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(UserIsUnknownError);
     });
 
     it('maps suspended account to SuspendedAccountError', () => {
       const error = new BackendError('Account suspended.', BackendErrorLabel.SUSPENDED_ACCOUNT, StatusCode.FORBIDDEN);
-      const mapped = BackendErrorMapper.map(error);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBeInstanceOf(SuspendedAccountError);
     });
   });
 
   describe('Fallback behavior', () => {
-    it('returns original error when no mapping exists', () => {
-      const error = new BackendError('unknown message', BackendErrorLabel.CLIENT_ERROR, StatusCode.BAD_REQUEST);
-      const mapped = BackendErrorMapper.map(error);
+    it('falls back to default handler when message variant is unknown', () => {
+      const error = new BackendError('unknown message', BackendErrorLabel.INVALID_CREDENTIALS, StatusCode.FORBIDDEN);
+      const mapped = BackendErrorMapper.mapBackendError(error);
+      expect(mapped).not.toBe(error);
+      expect(mapped).toBeInstanceOf(BackendError);
+      expect(mapped.message).toBe('Authentication failed because the token is invalid.');
+    });
+    it('returns original error when no handler exists for code and label', () => {
+      const error = new BackendError('unknown message', BackendErrorLabel.CLIENT_ERROR, StatusCode.UNAUTHORIZED);
+      const mapped = BackendErrorMapper.mapBackendError(error);
       expect(mapped).toBe(error);
     });
   });

--- a/packages/api-client/src/http/BackendErrorMapper.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {StatusCodes as StatusCode} from 'http-status-codes';
+
 import {
   IdentifierExistsError,
   InvalidCredentialsError,
@@ -31,7 +33,7 @@ import {ConversationIsUnknownError, ConversationOperationError} from '../convers
 import {InvalidInvitationCodeError, InviteEmailInUseError, ServiceNotFoundError} from '../team/';
 import {UnconnectedUserError, UserIsUnknownError} from '../user/';
 
-import {BackendError, BackendErrorLabel, StatusCode} from './';
+import {BackendError, BackendErrorLabel} from './';
 
 type BackendErrorWithLabel = BackendError & {label: BackendErrorLabel};
 type ErrorBuilder = (e: BackendErrorWithLabel) => BackendError;
@@ -145,7 +147,7 @@ export class BackendErrorMapper {
     }
   }
 
-  public static mapBackendError(error: BackendError): BackendError {
+  public static map(error: BackendError): BackendError {
     const code = Number(error.code) as StatusCode;
     const label = error.label as BackendErrorLabel;
     const message = error.message ?? '';

--- a/packages/api-client/src/http/BackendErrorMapper.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.ts
@@ -20,11 +20,11 @@
 import {
   IdentifierExistsError,
   InvalidCredentialsError,
-  InvalidTokenError,
   LoginTooFrequentError,
+  SuspendedAccountError,
+  InvalidTokenError,
   MissingCookieAndTokenError,
   MissingCookieError,
-  SuspendedAccountError,
   TokenExpiredError,
 } from '../auth/';
 import {ConversationIsUnknownError, ConversationOperationError} from '../conversation/';
@@ -33,69 +33,106 @@ import {UnconnectedUserError, UserIsUnknownError} from '../user/';
 
 import {BackendError, BackendErrorLabel, StatusCode} from './';
 
+type BackendErrorWithLabel = BackendError & {label: BackendErrorLabel};
+type ErrorBuilder = (e: BackendErrorWithLabel) => BackendError;
+
+// A mapper builds the appropriate error instance from the backend error payload.
+type ErrorLabelToBuilderMap = Partial<Record<BackendErrorLabel, ErrorBuilder>>;
+
+type StatusCodeToLabelMap = Partial<Record<StatusCode, ErrorLabelToBuilderMap>>;
+type MessageToBuilderMap = Record<string, ErrorBuilder>;
+type StatusCodeToMessageVariantMap = Partial<
+  Record<StatusCode, Partial<Record<BackendErrorLabel, MessageToBuilderMap>>>
+>;
+
 export class BackendErrorMapper {
-  public static get ERRORS(): Record<number, Record<string, Record<string, BackendError>>> {
-    return {
-      [StatusCode.BAD_REQUEST]: {
-        [BackendErrorLabel.CLIENT_ERROR]: {
-          'Error in $: Failed reading: satisfy': new BackendError('Wrong set of parameters.'),
-          "[path] 'cnv' invalid: Failed reading: Invalid UUID": new ConversationIsUnknownError(
-            'Conversation ID is unknown.',
+  /**
+   * Baseline/default handler for each (code, label). Used when no message variant matches.
+   */
+  public static defaultHandlers: StatusCodeToLabelMap = {
+    [StatusCode.BAD_REQUEST]: {
+      [BackendErrorLabel.CLIENT_ERROR]: e => new BackendError('Wrong set of parameters.', e.label, e.code),
+
+      [BackendErrorLabel.INVALID_INVITATION_CODE]: e =>
+        new InvalidInvitationCodeError('Invalid invitation code.', e.label, e.code),
+    },
+
+    [StatusCode.FORBIDDEN]: {
+      [BackendErrorLabel.INVALID_CREDENTIALS]: e =>
+        // default to logout-safe type for unknown messages
+        new InvalidTokenError('Authentication failed because the token is invalid.', e.label, e.code),
+
+      [BackendErrorLabel.CLIENT_ERROR]: e => new BackendError('Operation not permitted.', e.label, e.code),
+
+      [BackendErrorLabel.NOT_CONNECTED]: e => new UnconnectedUserError('Users are not connected.', e.label, e.code),
+
+      [BackendErrorLabel.INVALID_OPERATION]: e =>
+        new ConversationOperationError('Cannot perform this operation.', e.label, e.code),
+
+      [BackendErrorLabel.SUSPENDED_ACCOUNT]: e => new SuspendedAccountError('Account suspended.', e.label, e.code),
+    },
+
+    [StatusCode.TOO_MANY_REQUESTS]: {
+      [BackendErrorLabel.CLIENT_ERROR]: e =>
+        new LoginTooFrequentError('Logins too frequent. User login temporarily disabled.', e.label, e.code),
+    },
+
+    [StatusCode.CONFLICT]: {
+      [BackendErrorLabel.INVITE_EMAIL_EXISTS]: e =>
+        new InviteEmailInUseError('The given e-mail address is in use.', e.label, e.code),
+
+      [BackendErrorLabel.KEY_EXISTS]: e =>
+        new IdentifierExistsError('The given e-mail address is in use.', e.label, e.code),
+    },
+
+    [StatusCode.NOT_FOUND]: {
+      [BackendErrorLabel.NOT_FOUND]: e => new ServiceNotFoundError('Service not found', e.label, e.code),
+    },
+  };
+
+  /**
+   * Message-specific variants for known texts under a given (code,label).
+   * Provides finer granularity when wording matches; otherwise we fall back to defaultHandlers.
+   */
+  private static messageVariantHandlers: StatusCodeToMessageVariantMap = {
+    [StatusCode.BAD_REQUEST]: {
+      [BackendErrorLabel.CLIENT_ERROR]: {
+        'Error in $: Failed reading: satisfy': e => new BackendError('Wrong set of parameters.', e.label, e.code),
+        "[path] 'cnv' invalid: Failed reading: Invalid UUID": e =>
+          new ConversationIsUnknownError('Conversation ID is unknown.', e.label, e.code),
+        "[path] 'usr' invalid: Failed reading: Invalid UUID": e =>
+          new UserIsUnknownError('User ID is unknown.', e.label, e.code),
+      },
+    },
+    [StatusCode.FORBIDDEN]: {
+      [BackendErrorLabel.INVALID_CREDENTIALS]: {
+        'Invalid zauth token': e =>
+          new InvalidTokenError('Authentication failed because the token is invalid.', e.label, e.code),
+        'Invalid token': e =>
+          new InvalidTokenError('Authentication failed because the token is invalid.', e.label, e.code),
+        'Authentication failed.': e =>
+          new InvalidCredentialsError('Authentication failed because of invalid credentials.', e.label, e.code),
+        'Missing cookie': e =>
+          new MissingCookieError('Authentication failed because the cookie is missing.', e.label, e.code),
+        'Token expired': e =>
+          new TokenExpiredError('Authentication failed because the token is expired.', e.label, e.code),
+        'Missing cookie and token': e =>
+          new MissingCookieAndTokenError(
+            'Authentication failed because both cookie and token are missing.',
+            e.label,
+            e.code,
           ),
-          "[path] 'usr' invalid: Failed reading: Invalid UUID": new UserIsUnknownError('User ID is unknown.'),
-        },
-        [BackendErrorLabel.INVALID_INVITATION_CODE]: {
-          'Invalid invitation code.': new InvalidInvitationCodeError('Invalid invitation code.'),
-        },
       },
-      [StatusCode.FORBIDDEN]: {
-        [BackendErrorLabel.INVALID_CREDENTIALS]: {
-          'Invalid zauth token': new InvalidTokenError('Authentication failed because the token is invalid.'),
-          'Authentication failed.': new InvalidCredentialsError(
-            'Authentication failed because of invalid credentials.',
-          ),
-          'Invalid token': new InvalidTokenError('Authentication failed because the token is invalid.'),
-          'Missing cookie': new MissingCookieError('Authentication failed because the cookie is missing.'),
-          'Token expired': new TokenExpiredError('Authentication failed because the token is expired.'),
-          'Missing cookie and token': new MissingCookieAndTokenError(
-            'Authentication failed because the cookie and token is missing.',
-          ),
-        },
-        [BackendErrorLabel.CLIENT_ERROR]: {
-          'Failed reading: Invalid zauth token': new InvalidTokenError(
-            'Authentication failed because the token is invalid.',
-          ),
-        },
-        [BackendErrorLabel.NOT_CONNECTED]: {
-          'Users are not connected': new UnconnectedUserError('Users are not connected.'),
-        },
-        [BackendErrorLabel.INVALID_OPERATION]: {
-          'invalid operation for 1:1 conversations': new ConversationOperationError('Cannot leave 1:1 conversation.'),
-        },
-        [BackendErrorLabel.SUSPENDED_ACCOUNT]: {
-          'Account suspended.': new SuspendedAccountError('Account suspended.'),
-        },
+      [BackendErrorLabel.INVALID_OPERATION]: {
+        'invalid operation for 1:1 conversations': e =>
+          new ConversationOperationError('Cannot leave 1:1 conversation.', e.label, e.code),
       },
-      [StatusCode.TOO_MANY_REQUESTS]: {
-        [BackendErrorLabel.CLIENT_ERROR]: {
-          'Logins too frequent': new LoginTooFrequentError('Logins too frequent. User login temporarily disabled.'),
-        },
+      [BackendErrorLabel.CLIENT_ERROR]: {
+        'Failed reading: Invalid zauth token': e =>
+          new InvalidTokenError('Authentication failed because the token is invalid.', e.label, e.code),
       },
-      [StatusCode.CONFLICT]: {
-        [BackendErrorLabel.INVITE_EMAIL_EXISTS]: {
-          'The given e-mail address is in use.': new InviteEmailInUseError('The given e-mail address is in use.'),
-        },
-        [BackendErrorLabel.KEY_EXISTS]: {
-          'The given e-mail address is in use.': new IdentifierExistsError('The given e-mail address is in use.'),
-        },
-      },
-      [StatusCode.NOT_FOUND]: {
-        [BackendErrorLabel.NOT_FOUND]: {
-          'Service not found': new ServiceNotFoundError('Service not found'),
-        },
-      },
-    };
-  }
+    },
+  };
 
   private static logUnmapped(error: BackendError, reason: string) {
     if (process.env.NODE_ENV === 'development') {
@@ -108,17 +145,25 @@ export class BackendErrorMapper {
     }
   }
 
-  public static map(error: BackendError): BackendError {
-    try {
-      const mappedError: BackendError | undefined =
-        BackendErrorMapper.ERRORS[Number(error.code)][error.label][error.message];
-      if (mappedError) {
-        return mappedError;
-      }
-      this.logUnmapped(error, 'No matching entry found in error mapping');
-    } catch (mappingError) {
-      this.logUnmapped(error, 'Error mapping lookup failed with exception');
+  public static mapBackendError(error: BackendError): BackendError {
+    const code = Number(error.code) as StatusCode;
+    const label = error.label as BackendErrorLabel;
+    const message = error.message ?? '';
+
+    // 1) Message-specific variant
+    const messageVariantHandler = BackendErrorMapper.messageVariantHandlers[code]?.[label]?.[message];
+    if (messageVariantHandler) {
+      return messageVariantHandler(error as BackendErrorWithLabel);
     }
+
+    // 2) Default fallback for this (code,label)
+    const fallbackHandler = BackendErrorMapper.defaultHandlers[code]?.[label];
+    if (fallbackHandler) {
+      return fallbackHandler(error as BackendErrorWithLabel);
+    }
+
+    // 3) Unknown (code,label) — keep original but log in dev
+    this.logUnmapped(error, 'No mapping for code+label (+message)');
     return error;
   }
 }

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -176,7 +176,7 @@ export class HttpClient extends EventEmitter {
       }
 
       if (HttpClient.isBackendError(error)) {
-        const mappedError = BackendErrorMapper.map(
+        const mappedError = BackendErrorMapper.mapBackendError(
           new BackendError(error.response.data.message, error.response.data.label, error.response.data.code),
         );
 

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -176,7 +176,7 @@ export class HttpClient extends EventEmitter {
       }
 
       if (HttpClient.isBackendError(error)) {
-        const mappedError = BackendErrorMapper.mapBackendError(
+        const mappedError = BackendErrorMapper.map(
           new BackendError(error.response.data.message, error.response.data.label, error.response.data.code),
         );
 


### PR DESCRIPTION
## Summary
- replaced pre-built error instances with handler functions
- ensures each backend error maps to a new object with actual code/label
- added label-level default handlers as fallback when message does not match
- prevents user sessions getting stuck on unmapped messages (e.g. token errors)

## Description
Our previous BackendErrorMapper relied on message strings and stored pre-built error instances. This caused two problems:

Stuck loading: if the backend sent an unmapped message (same label, different text), the mapper returned a raw BackendError, so refresh/logout flows didn’t trigger.

Reused instances: the same Error object was returned repeatedly, losing the actual backend code/label and risking stale stack traces.

## Changes

Introduced handler functions ((e: BackendError) => new …Error(...)) for each mapping, so a fresh error instance is created per backend response.

Added default handlers per (code,label) to fall back safely if message text changes.

Example: (403, INVALID_CREDENTIALS) now defaults to InvalidTokenError → guarantees logout instead of stuck loading.

Preserved message-specific mappings where needed for finer granularity (e.g. "Token expired" → TokenExpiredError).

Added logging for unmapped (code,label) combos in development.

Safer, cleaner, easier to extend (new handlers can be added without touching global defaults).
<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
