### PR TITLE
fix: wipe identity/crypto on CLIENT_REMOVED and make local-client delete safe(WPB-19348)

### DIFF
--- a/packages/core/src/client/ClientService.ts
+++ b/packages/core/src/client/ClientService.ts
@@ -86,15 +86,16 @@ export class ClientService {
   public async deleteLocalClient(password?: string): Promise<string> {
     const localClientId = this.apiClient.context?.clientId;
     if (!localClientId) {
-      throw new Error('Trying to delete local client, but local client has not been set');
+      // No client in context -> there's nothing to delete on backend, just drop local state
+      this.logger.warn('No local client id in context; deleting local client data from DB only.');
+      return this.database.deleteLocalClient();
     }
     try {
       await this.backend.deleteClient(localClientId, password);
     } catch (error) {
       this.logger.warn('Failed to delete client on backend', error);
-    } finally {
-      return this.database.deleteLocalClient();
     }
+    return this.database.deleteLocalClient();
   }
 
   private async getLocalClient(): Promise<MetaClient | undefined> {


### PR DESCRIPTION
## Description
Make deleteLocalClient resilient to tolerate missing local client id and still deletes local DB; use it in wipeCommonData().

Prevents reusing stale lastPreKey/MLS public key that caused mls-duplicate-public-key on first login.

Improves stability when the tab was closed prior to remote deletion.

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
