### PR TITLE
refactor(core): Deprecate and remove dryRun

### DIFF
--- a/packages/core/src/Account.test.ts
+++ b/packages/core/src/Account.test.ts
@@ -486,10 +486,7 @@ describe('Account', () => {
                     {domain: 'zinfra.io', type: 'federation.delete'},
                     NotificationSource.WEBSOCKET,
                   );
-                  expect(dependencies.account.service!.notification.handleNotification).not.toHaveBeenCalledWith(
-                    expect.any(Object),
-                    NotificationSource.WEBSOCKET,
-                  );
+                  expect(dependencies.account.service!.notification.handleNotification).toHaveBeenCalledTimes(2);
                   resolve();
               }
             },


### PR DESCRIPTION
we don't have any users that are using phone number to authenticate in any shape or form right anymore. 

so no need for listening to the user's changes when setting an email for an account that was created using a phone identifier.

https://github.com/wireapp/wire-webapp/pull/14435