### PR TITLE
fix: Add a guard against empty websocket messages [WPB-19372]

### DIFF
--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -99,6 +99,11 @@ export class WebSocketClient extends EventEmitter {
   }
 
   private readonly onMessage = (data: string) => {
+    if (!data) {
+      this.logger.warn('Received empty message from WebSocket');
+      return;
+    }
+
     if (this.isLocked()) {
       this.bufferedMessages.push(data);
     } else {


### PR DESCRIPTION
## Description

We are not exactly sure why an empty message arrived from websocket from the backend but when it does it is able to crash the application so this PR is adding a guard to not to try to parse empty messages from websocket.