### PR TITLE
feat: update GroupButtonProps interface [WPB-20282] 

### DIFF
--- a/packages/react-ui-kit/src/DataDisplay/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/react-ui-kit/src/DataDisplay/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`<Tooltip /> renders correctly 1`] = `
         <div
           data-testid="tooltip-wrapper"
           role="presentation"
+          style="width: max-content;"
         >
           Hover Me
         </div>
@@ -36,6 +37,7 @@ exports[`<Tooltip /> renders correctly 1`] = `
       <div
         data-testid="tooltip-wrapper"
         role="presentation"
+        style="width: max-content;"
       >
         Hover Me
       </div>

--- a/packages/react-ui-kit/src/Inputs/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-ui-kit/src/Inputs/ButtonGroup/ButtonGroup.tsx
@@ -74,7 +74,7 @@ const buttonStyle: <T>(theme: Theme, props: IconButtonProps<T>) => CSSObject = (
   }),
 });
 
-type GroupButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+type GroupedButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   icon?: ReactNode;
 };
 
@@ -87,7 +87,7 @@ const ButtonGroup = ({children}: ButtonGroupProps) => (
   </div>
 );
 
-const Button = forwardRef<HTMLButtonElement, GroupButtonProps>(({children, icon, ...props}, ref) => {
+const Button = forwardRef<HTMLButtonElement, GroupedButtonProps>(({children, icon, ...props}, ref) => {
   return (
     <button ref={ref} css={(theme: Theme) => buttonStyle(theme, props)} {...props}>
       {icon}

--- a/packages/react-ui-kit/src/Inputs/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-ui-kit/src/Inputs/ButtonGroup/ButtonGroup.tsx
@@ -17,7 +17,7 @@
  *
  */
 
-import {forwardRef, ReactNode} from 'react';
+import {ButtonHTMLAttributes, forwardRef, ReactNode} from 'react';
 
 import {CSSObject} from '@emotion/react';
 
@@ -74,10 +74,9 @@ const buttonStyle: <T>(theme: Theme, props: IconButtonProps<T>) => CSSObject = (
   }),
 });
 
-interface GroupButtonProps {
-  children?: ReactNode;
+type GroupButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   icon?: ReactNode;
-}
+};
 
 interface ButtonGroupProps {
   children: ReactNode;


### PR DESCRIPTION
## Description
Update the interface GroupButtonProps so that it can inherit all the native options of HTM Button Element

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [ ] Hard-to-understand areas of the code have been commented;
- [ ] If it is a core feature, unit tests have been added;