### PR TITLE
chore: Add logs for migration to async notifications [WPB-19981]

### DIFF
--- a/packages/api-client/src/tcp/WebSocketClient.ts
+++ b/packages/api-client/src/tcp/WebSocketClient.ts
@@ -267,13 +267,13 @@ export class WebSocketClient extends EventEmitter {
 
     const queryString = queryParams.toString();
 
-    this.logger.info(`WebSocket URL: ${this.baseUrl}${this.versionPrefix}/events?${queryString}`);
+    const websocketAddress = this.useLegacySocket
+      ? `${this.baseUrl}/await?${queryString}`
+      : `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
 
-    if (this.useLegacySocket) {
-      return `${this.baseUrl}/await?${queryString}`;
-    }
+    this.logger.info(`WebSocket URL: ${websocketAddress}`);
 
-    return `${this.baseUrl}${this.versionPrefix}/events?${queryString}`;
+    return websocketAddress;
   }
 
   public useAsyncNotificationsSocket() {

--- a/packages/core/src/Account.ts
+++ b/packages/core/src/Account.ts
@@ -758,6 +758,7 @@ export class Account extends TypedEventEmitter<Events> {
     if (!isClientCapableOfConsumableNotifications && !useLegacy) {
       // do the last legacy sync without connecting to any websockets
       await legacyProcessNotificationStream();
+      this.logger.info('Completed final legacy notification stream processing after enabling async notifications');
     }
 
     if (useLegacy) {


### PR DESCRIPTION
## Description

When these logs are added we can create charts on datadog to see number of migrations to async notification system and the calls to legacy vs async
