### PR TITLE
feat: Initiate reset of broken MLS conversations [WPB-19701]

### DIFF
--- a/packages/api-client/src/conversation/ConversationError.ts
+++ b/packages/api-client/src/conversation/ConversationError.ts
@@ -86,3 +86,27 @@ export class ConversationFullError extends ConversationError {
     this.name = 'ConversationFullError';
   }
 }
+
+export class MLSInvalidLeafNodeSignatureError extends ConversationError {
+  constructor(
+    message: string,
+    label: BackendErrorLabel = BackendErrorLabel.MLS_INVALID_LEAF_NODE_SIGNATURE,
+    code: StatusCode = StatusCode.BAD_REQUEST,
+  ) {
+    super(message, label, code);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = 'MLSInvalidLeafNodeSignatureError';
+  }
+}
+
+export class MLSInvalidLeafNodeIndexError extends ConversationError {
+  constructor(
+    message: string,
+    label: BackendErrorLabel = BackendErrorLabel.MLS_INVALID_LEAF_NODE_INDEX,
+    code: StatusCode = StatusCode.BAD_REQUEST,
+  ) {
+    super(message, label, code);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = 'MLSInvalidLeafNodeIndexError';
+  }
+}

--- a/packages/api-client/src/http/BackendErrorMapper.ts
+++ b/packages/api-client/src/http/BackendErrorMapper.ts
@@ -29,7 +29,12 @@ import {
   MissingCookieError,
   TokenExpiredError,
 } from '../auth/';
-import {ConversationIsUnknownError, ConversationOperationError} from '../conversation/';
+import {
+  ConversationIsUnknownError,
+  ConversationOperationError,
+  MLSInvalidLeafNodeIndexError,
+  MLSInvalidLeafNodeSignatureError,
+} from '../conversation/';
 import {InvalidInvitationCodeError, InviteEmailInUseError, ServiceNotFoundError} from '../team/';
 import {UnconnectedUserError, UserIsUnknownError} from '../user/';
 
@@ -124,6 +129,13 @@ export class BackendErrorMapper {
             e.label,
             e.code,
           ),
+      },
+      [BackendErrorLabel.MLS_INVALID_LEAF_NODE_SIGNATURE]: {
+        'Invalid leaf node signature': e =>
+          new MLSInvalidLeafNodeSignatureError('Invalid leaf node signature', e.label, e.code),
+      },
+      [BackendErrorLabel.MLS_INVALID_LEAF_NODE_INDEX]: {
+        'Invalid leaf node index': e => new MLSInvalidLeafNodeIndexError('Invalid leaf node index', e.label, e.code),
       },
       [BackendErrorLabel.INVALID_OPERATION]: {
         'invalid operation for 1:1 conversations': e =>

--- a/packages/core/__mocks__/@wireapp/core-crypto.ts
+++ b/packages/core/__mocks__/@wireapp/core-crypto.ts
@@ -95,3 +95,38 @@ export class ConversationId extends ByteContainer {}
 export class ExternalSenderKey extends ByteContainer {}
 export class KeyPackage extends ByteContainer {}
 export class SecretKey extends ByteContainer {}
+
+export enum ErrorType {
+  Mls = 'Mls',
+  Proteus = 'Proteus',
+  E2ei = 'E2ei',
+  TransactionFailed = 'TransactionFailed',
+  Other = 'Other',
+}
+
+export enum ProteusErrorType {
+  SessionNotFound = 'SessionNotFound',
+  DuplicateMessage = 'DuplicateMessage',
+  RemoteIdentityChanged = 'RemoteIdentityChanged',
+  Other = 'Other',
+}
+
+type CcError<T extends ErrorType> = Error & {type: T; context?: {type: string}};
+
+export const isCcError = <E extends ErrorType>(error: unknown, errorType: E): error is CcError<E> => {
+  return typeof error === 'object' && error !== null && (error as any).type === errorType;
+};
+
+export const isProteusError = <E extends ProteusErrorType>(
+  error: unknown,
+  errorType: E,
+): error is CcError<ErrorType.Proteus> & {context: {type: E}} => {
+  return isCcError(error, ErrorType.Proteus) && (error as any).context?.type === errorType;
+};
+
+export const isProteusSessionNotFoundError = (error: unknown) =>
+  isProteusError(error, ProteusErrorType.SessionNotFound);
+export const isProteusDuplicateMessageError = (error: unknown) =>
+  isProteusError(error, ProteusErrorType.DuplicateMessage);
+export const isProteusRemoteIdentityChangedError = (error: unknown) =>
+  isProteusError(error, ProteusErrorType.RemoteIdentityChanged);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wireapp/api-client": "workspace:^",
     "@wireapp/commons": "workspace:^",
-    "@wireapp/core-crypto": "9.0.1",
+    "@wireapp/core-crypto": "9.1.0",
     "@wireapp/cryptobox": "12.8.0",
     "@wireapp/priority-queue": "workspace:^",
     "@wireapp/promise-queue": "workspace:^",

--- a/packages/core/src/conversation/ConversationService/ConversationService.ts
+++ b/packages/core/src/conversation/ConversationService/ConversationService.ts
@@ -305,6 +305,34 @@ export class ConversationService extends TypedEventEmitter<Events> {
   }
 
   /**
+   * Centralized handler for scenarios where an MLS conversation is detected as broken.
+   * It resets the conversation and then invokes the provided callback so callers can retry
+   * their original operation (e.g., re-adding/removing users, re-joining, etc.) with the new group id.
+   *
+   * Contract:
+   * - input: conversationId to reset; callback invoked after reset with the new group id
+   * - output: the value returned by the callback
+   * - error: throws if reset fails or new group id is missing
+   */
+  private async handleBrokenMLSConversation<T = void>(
+    conversationId: QualifiedId,
+    afterReset?: (newGroupId: string) => Promise<T>,
+  ): Promise<T> {
+    const {
+      conversation: {group_id: newGroupId},
+    } = await this.resetMLSConversation(conversationId);
+    if (!newGroupId) {
+      const errorMessage = 'Tried to reset MLS conversation but no group_id found in response';
+      this.logger.error(errorMessage, {conversationId});
+      throw new Error(errorMessage);
+    }
+    if (afterReset) {
+      return afterReset(newGroupId);
+    }
+    return undefined as unknown as T;
+  }
+
+  /**
    * Will create a conversation on backend and register it to CoreCrypto once created
    * @param conversationData
    */
@@ -336,7 +364,15 @@ export class ConversationService extends TypedEventEmitter<Events> {
     const groupIdBytes = Decoder.fromBase64(groupId).asBytes;
 
     // immediately execute pending commits before sending the message
-    await this.mlsService.commitPendingProposals(groupId);
+    await this.mlsService.commitPendingProposals(groupId, true, params).catch(async error => {
+      if (MLSService.isBrokenMLSConversationError(error)) {
+        this.logger.info('Failed to execute pending proposals because broken MLS conversation, triggering a reset', {
+          error,
+          groupId,
+        });
+        await this.handleBrokenMLSConversation(conversationId);
+      }
+    });
 
     const encrypted = await this.mlsService.encryptMessage(
       new ConversationId(groupIdBytes),
@@ -388,50 +424,173 @@ export class ConversationService extends TypedEventEmitter<Events> {
     qualifiedUsers,
     groupId,
     conversationId,
-  }: Required<AddUsersParams>): Promise<BaseCreateConversationResponse> {
-    const exisitingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
-    const conversation = await this.getConversation(conversationId);
+    shouldRetry = true,
+  }: Required<AddUsersParams> & {shouldRetry?: boolean}): Promise<BaseCreateConversationResponse> {
+    try {
+      const exisitingClientIdsInGroup = await this.mlsService.getClientIdsInGroup(groupId);
+      const conversation = await this.getConversation(conversationId);
 
-    const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(
-      qualifiedUsers,
-      exisitingClientIdsInGroup,
-    );
+      const {keyPackages, failures: keysClaimingFailures} = await this.mlsService.getKeyPackagesPayload(
+        qualifiedUsers,
+        exisitingClientIdsInGroup,
+      );
 
-    // We had cases where did not get any key packages, but still used core-crypto to call the backend (which results in failure).
-    if (keyPackages && keyPackages.length > 0) {
-      await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
+      // We had cases where did not get any key packages, but still used core-crypto to call the backend (which results in failure).
+      if (keyPackages && keyPackages.length > 0) {
+        await this.mlsService.addUsersToExistingConversation(groupId, keyPackages);
 
-      //We store the info when user was added (and key material was created), so we will know when to renew it
-      await this.mlsService.resetKeyMaterialRenewal(groupId);
+        //We store the info when user was added (and key material was created), so we will know when to renew it
+        await this.mlsService.resetKeyMaterialRenewal(groupId);
+      }
+
+      return {
+        conversation,
+        failedToAdd: keysClaimingFailures,
+      };
+    } catch (error) {
+      if (MLSService.isBrokenMLSConversationError(error)) {
+        if (!shouldRetry) {
+          this.logger.warn("Tried to add users to MLS conversation but it's still broken after reset", error);
+          throw error;
+        }
+        this.logger.warn("Tried to add users to MLS conversation but it's broken, resetting the conversation", error);
+        return this.handleBrokenMLSConversation(conversationId, newGroupId =>
+          this.addUsersToMLSConversation({qualifiedUsers, groupId: newGroupId, conversationId, shouldRetry: false}),
+        );
+      }
+      throw error;
     }
-
-    return {
-      conversation,
-      failedToAdd: keysClaimingFailures,
-    };
   }
 
   public async removeUsersFromMLSConversation({
     groupId,
     conversationId,
     qualifiedUserIds,
-  }: RemoveUsersParams): Promise<Conversation> {
-    const clientsToRemove = await this.apiClient.api.user.postListClients({qualified_users: qualifiedUserIds});
+    shouldRetry = true,
+  }: RemoveUsersParams & {shouldRetry?: boolean}): Promise<Conversation> {
+    try {
+      const clientsToRemove = await this.apiClient.api.user.postListClients({qualified_users: qualifiedUserIds});
 
-    const fullyQualifiedClientIds = mapQualifiedUserClientIdsToFullyQualifiedClientIds(
-      clientsToRemove.qualified_user_map,
-    );
+      const fullyQualifiedClientIds = mapQualifiedUserClientIdsToFullyQualifiedClientIds(
+        clientsToRemove.qualified_user_map,
+      );
 
-    await this.mlsService.removeClientsFromConversation(groupId, fullyQualifiedClientIds);
+      await this.mlsService.removeClientsFromConversation(groupId, fullyQualifiedClientIds);
 
-    //key material gets updated after removing a user from the group, so we can reset last key update time value in the store
-    await this.mlsService.resetKeyMaterialRenewal(groupId);
+      // key material gets updated after removing a user from the group, so we can reset last key update time value in the store
+      await this.mlsService.resetKeyMaterialRenewal(groupId);
 
-    return await this.getConversation(conversationId);
+      return await this.getConversation(conversationId);
+    } catch (error) {
+      if (MLSService.isBrokenMLSConversationError(error)) {
+        if (!shouldRetry) {
+          this.logger.warn("Tried to remove users from MLS conversation but it's still broken after reset", error);
+          throw error;
+        }
+        this.logger.info(
+          "Tried to remove users from MLS conversation but it's broken, resetting the conversation",
+          error,
+        );
+        return this.handleBrokenMLSConversation(conversationId, newGroupId =>
+          this.removeUsersFromMLSConversation({
+            groupId: newGroupId,
+            conversationId,
+            qualifiedUserIds,
+            shouldRetry: false,
+          }),
+        );
+      }
+    } finally {
+      return await this.getConversation(conversationId);
+    }
   }
 
-  public async joinByExternalCommit(conversationId: QualifiedId) {
-    return this.mlsService.joinByExternalCommit(() => this.apiClient.api.conversation.getGroupInfo(conversationId));
+  public async joinByExternalCommit(conversationId: QualifiedId, shouldRetry = true): Promise<void> {
+    try {
+      await this.mlsService.joinByExternalCommit(() => this.apiClient.api.conversation.getGroupInfo(conversationId));
+    } catch (error) {
+      if (MLSService.isBrokenMLSConversationError(error)) {
+        this.logger.info(
+          "Failed to join MLS conversation via external commit because it's broken, resetting the conversation",
+          error,
+        );
+        if (!shouldRetry) {
+          this.logger.warn("Tried to join MLS conversation but it's still broken after reset", error);
+          throw error;
+        }
+        return this.handleBrokenMLSConversation(conversationId, (_newGroupId: string) =>
+          this.joinByExternalCommit(conversationId, false),
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async resetMLSConversation(conversationId: QualifiedId): Promise<BaseCreateConversationResponse> {
+    this.logger.info(`Resetting MLS conversation with id ${conversationId.id}`);
+
+    // STEP 1: Fetch the conversation to retrieve the group ID & epoch
+    const conversation = await this.apiClient.api.conversation.getConversation(conversationId);
+    const {group_id: groupId, epoch} = conversation;
+
+    if (!groupId || !epoch) {
+      const errorMessage = 'Could not find group id or epoch for the conversation';
+      this.logger.error(errorMessage, {conversationId});
+      throw new Error(errorMessage);
+    }
+
+    // STEP 2: Request backend to reset the conversation
+    this.logger.info(`Requesting backend to reset the conversation (group_id: ${groupId}, epoch: ${String(epoch)})`);
+    await this.apiClient.api.conversation.resetMLSConversation({
+      epoch,
+      groupId,
+    });
+
+    // STEP 3: Re-establish the conversation by re-adding all members
+    this.logger.info(
+      `Re-establishing the conversation by re-adding all members (conversation_id: ${conversationId.id})`,
+    );
+    const clientId = this.apiClient.validatedClientId;
+    const {userId, domain} = this.apiClient;
+
+    if (!userId || !domain) {
+      const errorMessage = 'Could not find userId or domain of the self user';
+      this.logger.error(errorMessage, {conversationId});
+      throw new Error(errorMessage);
+    }
+
+    const selfUserQualifiedId = {id: userId, domain};
+
+    // STEP 4: Fetch the updated conversation data from backend to retrieve the new group ID
+    const updatedConversation = await this.apiClient.api.conversation.getConversation(conversationId);
+    const {group_id: newGroupId, members} = updatedConversation;
+
+    this.logger.info(`MLS conversation new group ID fetched from backend ${conversationId.id}`, {
+      newGroupId,
+    });
+    if (!newGroupId || !selfUserQualifiedId || !clientId) {
+      throw new Error(
+        `Failed to recover MLS conversation: missing groupId (${newGroupId}), selfUserQualifiedId (${selfUserQualifiedId}), or clientId (${clientId})`,
+      );
+    }
+
+    const usersToReAdd = members.others.map(member => member.qualified_id).filter(userId => !!userId);
+
+    // STEP 5: Re-establish the conversation by re-adding all members
+    return await this.establishMLSGroupConversation(
+      newGroupId,
+      usersToReAdd,
+      selfUserQualifiedId,
+      clientId,
+      conversationId,
+    ).then(result => {
+      this.logger.info(`Successfully reset MLS conversation`, {
+        conversationId: conversationId.id,
+        oldGroupId: groupId,
+        newGroupId,
+      });
+      return result;
+    });
   }
 
   /**
@@ -698,7 +857,7 @@ export class ConversationService extends TypedEventEmitter<Events> {
           throw new Error('Qualified conversation id is missing in the event');
         }
 
-        queueConversationRejoin(conversationId.id, () =>
+        void queueConversationRejoin(conversationId.id, () =>
           this.recoverMLSGroupFromEpochMismatch(conversationId, subconv),
         );
         return null;

--- a/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
+++ b/packages/core/src/messagingProtocols/mls/E2EIdentityService/E2EIServiceExternal.ts
@@ -44,7 +44,7 @@ import {StringifiedQualifiedId, stringifyQualifiedId} from '../../../util/qualif
 import {RecurringTaskScheduler} from '../../../util/RecurringTaskScheduler';
 import {MLSService, MLSServiceEvents} from '../MLSService';
 
-export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status'> & {
+export type DeviceIdentity = Omit<WireIdentity, 'free' | 'status' | typeof Symbol.dispose> & {
   status?: DeviceStatus;
   deviceId: string;
   qualifiedUserId: QualifiedId;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9618,10 +9618,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@wireapp/core-crypto@npm:9.0.1":
-  version: 9.0.1
-  resolution: "@wireapp/core-crypto@npm:9.0.1"
-  checksum: 09a62e205d58de5d6b4eb0e77df373c903cf3d11e59be3c99e72e0615aa12a717a6c0031120f3969f9d41bfe639af39feb3c11283e25cad7d24bc2a785447fba
+"@wireapp/core-crypto@npm:9.1.0":
+  version: 9.1.0
+  resolution: "@wireapp/core-crypto@npm:9.1.0"
+  checksum: d60212e55bdd5163af7788647dfdd1426a914ad8177c35a69061f9794bf6b88ba1a4320b005c5d44e2e562ac8f10018422110d7a5f008c509db59e095428d438
   languageName: node
   linkType: hard
 
@@ -9638,7 +9638,7 @@ __metadata:
     "@types/uuid": 9.0.8
     "@wireapp/api-client": "workspace:^"
     "@wireapp/commons": "workspace:^"
-    "@wireapp/core-crypto": 9.0.1
+    "@wireapp/core-crypto": 9.1.0
     "@wireapp/cryptobox": 12.8.0
     "@wireapp/priority-queue": "workspace:^"
     "@wireapp/promise-queue": "workspace:^"


### PR DESCRIPTION
## Description

when the backend rejects commits with invalid leaf node signature/index, we now catch those via new error mappings and trigger a reset of the conversation, fetch the new group_id, and retry the original action once. This is used in add/remove members, joining via external commit, and committing pending proposals, plus better logging around groupId/params so we can trace what happened.

We stop after a single retry to avoid loops; if it’s still broken, we surface the error. Also tightened Proteus decryption error handling to use the new core-crypto guards, and did a small typing tweak in the E2E identity service.
