### PR TITLE
feat: update AssetAPI [WPB-20663]

### DIFF
--- a/packages/api-client/src/APIClient.ts
+++ b/packages/api-client/src/APIClient.ts
@@ -207,7 +207,7 @@ export class APIClient extends EventEmitter {
   private configureApis(backendFeatures: BackendFeatures): Apis {
     this.logger.info('configuring APIs with config', backendFeatures);
 
-    const assetAPI = new AssetAPI(this.transport.http, backendFeatures);
+    const assetAPI = new AssetAPI(this.transport.http);
 
     // Prevents the CellsAPI from being initialized multiple times
     if (!this.cellsApi) {

--- a/packages/api-client/src/asset/AssetAPI.schema.ts
+++ b/packages/api-client/src/asset/AssetAPI.schema.ts
@@ -17,10 +17,21 @@
  *
  */
 
-export interface AssetUploadData {
-  /** ISO 8601 formatted date */
-  expires: string;
-  key: string;
-  domain?: string;
-  token: string;
-}
+import {z} from 'zod';
+
+/**
+ * Zod schema for validating POST /assets response (201 Created)
+ * Based on backend API specification
+ */
+export const PostAssetsResponseSchema = z.object({
+  /** Asset domain (example.com) */
+  domain: z.string().optional(),
+  /** ISO 8601 formatted expiration date */
+  expires: z.string().datetime(),
+  /** Asset key (e.g., "3-1-47de4580-ae51-4650-acbb-d10c028cb0ac") */
+  key: z.string().min(1),
+  /** Base64 encoded token (e.g., "aGVsbG8") */
+  token: z.string().min(1),
+});
+
+export type AssetUploadData = z.infer<typeof PostAssetsResponseSchema>;

--- a/packages/api-client/src/asset/AssetAPI.test.ts
+++ b/packages/api-client/src/asset/AssetAPI.test.ts
@@ -17,33 +17,431 @@
  *
  */
 
-import {APIClient} from '../APIClient';
-import {StatusCode} from '../http';
+import {AssetAPI} from './AssetAPI';
+import {AssetUploadData} from './AssetAPI.schema';
+import {AssetRetentionPolicy} from './AssetRetentionPolicy';
 
-describe('"AssetAPI"', () => {
-  const apiClient = new APIClient();
+import {HttpClient, StatusCode, SyntheticErrorLabel} from '../http';
+import {RequestCancellationError} from '../user';
 
-  it('adds token parameters', async () => {
-    await apiClient.useVersion(4, 5);
-    jest.spyOn(apiClient.transport.http, 'sendRequest').mockReturnValue(
-      Promise.resolve({
+describe('AssetAPI', () => {
+  let assetAPI: AssetAPI;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+  let mockSendRequest: jest.Mock;
+
+  const validAssetId = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+  const validDomain = 'example.wire.com';
+  const validToken = 'dGVzdC10b2tlbg==';
+  const mockArrayBuffer = new ArrayBuffer(8);
+
+  beforeEach(() => {
+    mockSendRequest = jest.fn();
+    mockHttpClient = {
+      sendRequest: mockSendRequest,
+    } as unknown as jest.Mocked<HttpClient>;
+
+    assetAPI = new AssetAPI(mockHttpClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getAsset', () => {
+    it('should fetch asset with qualified endpoint', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
+        headers: {'content-type': 'image/jpeg'},
+        status: StatusCode.OK,
+        statusText: 'OK',
         config: {},
-        data: '',
+      });
+
+      const result = await assetAPI.getAsset(validAssetId, validDomain, validToken).response;
+
+      expect(result).toEqual({
+        buffer: mockArrayBuffer,
+        mimeType: 'image/jpeg',
+      });
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'get',
+          url: `/assets/${validDomain}/${validAssetId}`,
+          params: expect.objectContaining({asset_token: validToken}),
+          responseType: 'arraybuffer',
+        }),
+      );
+    });
+
+    it('should work without token', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
         headers: {},
         status: StatusCode.OK,
         statusText: 'OK',
-      }),
-    );
-    const assetId = 'my-asset-id';
-    const assetToken = 'my-asset-token';
+        config: {},
+      });
 
-    let errorMessage;
-    try {
-      await apiClient.api.asset.getAssetV3(assetId, assetToken);
-    } catch (error) {
-      errorMessage = error.message;
-    } finally {
-      expect(errorMessage).toContain('Asset v3 is not supported on backend');
-    }
+      await assetAPI.getAsset(validAssetId, validDomain).response;
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.not.objectContaining({asset_token: expect.anything()}),
+        }),
+      );
+    });
+
+    it('should include forceCaching parameter when true', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
+        headers: {},
+        status: StatusCode.OK,
+        statusText: 'OK',
+        config: {},
+      });
+
+      await assetAPI.getAsset(validAssetId, validDomain, null, true).response;
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({forceCaching: true}),
+        }),
+      );
+    });
+
+    it('should throw TypeError for invalid asset ID', () => {
+      expect(() => assetAPI.getAsset('invalid id!', validDomain)).toThrow(TypeError);
+    });
+
+    it('should throw TypeError for invalid domain', () => {
+      expect(() => assetAPI.getAsset(validAssetId, 'invalid domain')).toThrow(TypeError);
+    });
+
+    it('should handle cancellation', async () => {
+      const mockError = {message: SyntheticErrorLabel.REQUEST_CANCELLED};
+      mockSendRequest.mockRejectedValue(mockError);
+
+      const request = assetAPI.getAsset(validAssetId, validDomain);
+
+      await expect(request.response).rejects.toThrow(RequestCancellationError);
+      await expect(request.response).rejects.toThrow('Asset download got cancelled.');
+    });
+
+    it('should handle progress callback', async () => {
+      const progressCallback = jest.fn();
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
+        headers: {},
+        status: StatusCode.OK,
+        statusText: 'OK',
+        config: {},
+      });
+
+      await assetAPI.getAsset(validAssetId, validDomain, null, false, progressCallback).response;
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onDownloadProgress: expect.any(Function),
+          onUploadProgress: expect.any(Function),
+        }),
+      );
+    });
+  });
+
+  describe('getServiceAsset', () => {
+    it('should fetch service/bot asset', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
+        headers: {'content-type': 'image/svg+xml'},
+        status: StatusCode.OK,
+        statusText: 'OK',
+        config: {},
+      });
+
+      const result = await assetAPI.getServiceAsset(validAssetId, validToken).response;
+
+      expect(result).toEqual({
+        buffer: mockArrayBuffer,
+        mimeType: 'image/svg+xml',
+      });
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'get',
+          url: `/bot/assets/${validAssetId}`,
+          params: expect.objectContaining({asset_token: validToken}),
+        }),
+      );
+    });
+
+    it('should throw TypeError for invalid asset ID', () => {
+      expect(() => assetAPI.getServiceAsset('not valid!')).toThrow(TypeError);
+    });
+  });
+
+  describe('postAsset', () => {
+    const mockAssetData = new Uint8Array([1, 2, 3, 4, 5]);
+    const mockUploadResponse: AssetUploadData = {
+      expires: '2025-12-31T23:59:59.000Z',
+      key: 'asset-key-123',
+      token: 'upload-token-456',
+    };
+
+    it('should upload asset to /assets endpoint', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockUploadResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      const result = await assetAPI.postAsset(mockAssetData).response;
+
+      expect(result).toEqual(mockUploadResponse);
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'post',
+          url: '/assets',
+          headers: expect.objectContaining({
+            'Content-Type': expect.stringContaining('multipart/mixed'),
+          }),
+        }),
+      );
+    });
+
+    it('should include default options when not provided', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockUploadResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      await assetAPI.postAsset(mockAssetData).response;
+
+      const callArg = mockSendRequest.mock.calls[0][0];
+      const bodyString = new TextDecoder().decode(callArg.data);
+
+      expect(bodyString).toContain('"public":true');
+      expect(bodyString).toContain(`"retention":"${AssetRetentionPolicy.PERSISTENT}"`);
+    });
+
+    it('should respect custom options', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockUploadResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      const options = {
+        public: false,
+        retention: AssetRetentionPolicy.VOLATILE,
+        domain: 'custom.wire.com',
+      };
+
+      await assetAPI.postAsset(mockAssetData, options).response;
+
+      const callArg = mockSendRequest.mock.calls[0][0];
+      const bodyString = new TextDecoder().decode(callArg.data);
+
+      expect(bodyString).toContain('"public":false');
+      expect(bodyString).toContain(`"retention":"${AssetRetentionPolicy.VOLATILE}"`);
+      expect(bodyString).toContain('"domain":"custom.wire.com"');
+    });
+
+    it('should handle cancellation', async () => {
+      const mockError = {message: SyntheticErrorLabel.REQUEST_CANCELLED};
+      mockSendRequest.mockRejectedValue(mockError);
+
+      const request = assetAPI.postAsset(mockAssetData);
+
+      await expect(request.response).rejects.toThrow(RequestCancellationError);
+      await expect(request.response).rejects.toThrow('Asset upload got cancelled.');
+    });
+
+    it('should create multipart body with correct structure', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockUploadResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      await assetAPI.postAsset(mockAssetData).response;
+
+      const callArg = mockSendRequest.mock.calls[0][0];
+      const bodyString = new TextDecoder().decode(callArg.data);
+
+      expect(bodyString).toContain('Content-Type: application/json;charset=utf-8');
+      expect(bodyString).toContain('Content-Type: application/octet-stream');
+      expect(bodyString).toContain('Content-MD5:');
+      expect(bodyString).toMatch(/--Frontier.*\r\n/);
+    });
+
+    it('should handle progress callback', async () => {
+      const progressCallback = jest.fn();
+      mockSendRequest.mockResolvedValue({
+        data: mockUploadResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      await assetAPI.postAsset(mockAssetData, undefined, progressCallback).response;
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onUploadProgress: expect.any(Function),
+        }),
+      );
+    });
+  });
+
+  describe('postServiceAsset', () => {
+    const mockAssetData = new Uint8Array([10, 20, 30]);
+    const mockUploadResponse: AssetUploadData = {
+      expires: '2025-12-31T23:59:59.000Z',
+      key: 'service-asset-key',
+      token: 'service-token',
+    };
+
+    it('should upload service/bot asset', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockUploadResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      const result = await assetAPI.postServiceAsset(mockAssetData).response;
+
+      expect(result).toEqual(mockUploadResponse);
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'post',
+          url: '/bot/assets',
+        }),
+      );
+    });
+  });
+
+  describe('Token Validation', () => {
+    it('should accept valid base64 tokens', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
+        headers: {},
+        status: StatusCode.OK,
+        statusText: 'OK',
+        config: {},
+      });
+
+      const validTokens = ['YWJjZGVm', 'dGVzdA==', 'MTIzNDU2Nzg5MA=='];
+
+      for (const token of validTokens) {
+        await expect(assetAPI.getAsset(validAssetId, validDomain, token).response).resolves.toBeDefined();
+      }
+    });
+
+    it('should reject tokens with invalid characters', () => {
+      const invalidToken = 'invalid token!';
+      expect(() => assetAPI.getAsset(validAssetId, validDomain, invalidToken)).toThrow(TypeError);
+      expect(() => assetAPI.getAsset(validAssetId, validDomain, invalidToken)).toThrow(/to be base64 encoded string/);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should propagate network errors', async () => {
+      const networkError = new Error('Network error');
+      mockSendRequest.mockRejectedValue(networkError);
+
+      await expect(assetAPI.getAsset(validAssetId, validDomain).response).rejects.toThrow('Network error');
+    });
+
+    it('should propagate backend errors', async () => {
+      const backendError = {
+        message: 'Not Found',
+        code: 404,
+        label: 'not-found',
+      };
+      mockSendRequest.mockRejectedValue(backendError);
+
+      await expect(assetAPI.postAsset(new Uint8Array([1, 2, 3])).response).rejects.toEqual(backendError);
+    });
+  });
+
+  describe('Request Cancellation', () => {
+    it('should provide cancel function for requests', async () => {
+      mockSendRequest.mockResolvedValue({
+        data: mockArrayBuffer,
+        headers: {},
+        status: StatusCode.OK,
+        statusText: 'OK',
+        config: {},
+      });
+
+      const getRequest = assetAPI.getAsset(validAssetId, validDomain);
+      const postRequest = assetAPI.postAsset(new Uint8Array([1, 2, 3]));
+
+      expect(getRequest.cancel).toBeInstanceOf(Function);
+      expect(postRequest.cancel).toBeInstanceOf(Function);
+      expect(() => getRequest.cancel()).not.toThrow();
+      expect(() => postRequest.cancel()).not.toThrow();
+    });
+  });
+
+  describe('Response Validation', () => {
+    it('should validate successful upload response', async () => {
+      const validResponse: AssetUploadData = {
+        domain: 'example.com',
+        expires: '2025-12-31T23:59:59.000Z',
+        key: '3-1-47de4580-ae51-4650-acbb-d10c028cb0ac',
+        token: 'aGVsbG8=',
+      };
+
+      mockSendRequest.mockResolvedValue({
+        data: validResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      const result = await assetAPI.postAsset(new Uint8Array([1, 2, 3])).response;
+
+      expect(result).toEqual(validResponse);
+      expect(result.key).toBeDefined();
+      expect(result.token).toBeDefined();
+      expect(result.expires).toBeDefined();
+    });
+
+    it('should log warning for invalid response but still return data', async () => {
+      const invalidResponse = {
+        // Missing required fields
+        expires: 'invalid-date',
+      };
+
+      const consoleWarnSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      mockSendRequest.mockResolvedValue({
+        data: invalidResponse,
+        headers: {},
+        status: StatusCode.CREATED,
+        statusText: 'Created',
+        config: {},
+      });
+
+      const result = await assetAPI.postAsset(new Uint8Array([1, 2, 3])).response;
+
+      expect(result).toEqual(invalidResponse);
+      consoleWarnSpy.mockRestore();
+    });
   });
 });

--- a/packages/api-client/src/asset/AssetAPI.ts
+++ b/packages/api-client/src/asset/AssetAPI.ts
@@ -18,12 +18,15 @@
  */
 
 import axios, {AxiosRequestConfig} from 'axios';
+import logdown from 'logdown';
 
+import {LogFactory} from '@wireapp/commons';
+import {QualifiedConversationId} from '@wireapp/protocol-messaging';
+
+import {AssetUploadData, PostAssetsResponseSchema} from './AssetAPI.schema';
 import {AssetRetentionPolicy} from './AssetRetentionPolicy';
-import {AssetUploadData} from './AssetUploadData';
 import {isValidToken, isValidUUID} from './AssetUtil';
 
-import {BackendFeatures} from '../APIClient';
 import {
   BackendError,
   handleProgressEvent,
@@ -43,11 +46,18 @@ export interface CipherOptions {
   hash?: Buffer;
 }
 
+export interface AssetAuditData {
+  conversationId: QualifiedConversationId;
+  filename: string;
+  filetype: string;
+}
 export interface AssetOptions extends CipherOptions {
   public?: boolean;
   retention?: AssetRetentionPolicy;
   /** If given, will upload an asset that can be shared in a federated env */
   domain?: string;
+  /** Used for identifying the conversation the asset belongs to */
+  auditData?: AssetAuditData;
 }
 
 export interface AssetResponse {
@@ -55,21 +65,12 @@ export interface AssetResponse {
   mimeType?: string;
 }
 
-const ASSET_URLS = {
-  ASSET_V3_URL: '/assets/v3',
-  ASSET_V4_URL: '/assets/v4',
-  ASSET_SERVICE_URL: '/bot/assets',
-  ASSET_V2_URL: '/otr/assets',
-  ASSET_V2_CONVERSATION_URL: '/conversations',
-  ASSET_V1_URL: '/assets',
-  ASSETS_URL: '/assets',
-} as const;
-
 export class AssetAPI {
-  constructor(
-    private readonly client: HttpClient,
-    private readonly backendFeatures: BackendFeatures,
-  ) {}
+  private readonly logger: logdown.Logger;
+
+  constructor(private readonly client: HttpClient) {
+    this.logger = LogFactory.getLogger('@wireapp/api-client/AssetAPI');
+  }
 
   private getAssetShared(
     assetUrl: string,
@@ -129,11 +130,19 @@ export class AssetAPI {
   ): RequestCancelable<AssetUploadData> {
     const BOUNDARY = `Frontier${unsafeAlphanumeric()}`;
 
-    const metadata = JSON.stringify({
+    const metadataObject: Record<string, any> = {
       public: options?.public ?? true,
       retention: options?.retention || AssetRetentionPolicy.PERSISTENT,
       domain: options?.domain,
-    });
+    };
+
+    if (options?.auditData) {
+      metadataObject.convId = options.auditData.conversationId;
+      metadataObject.filename = options.auditData.filename;
+      metadataObject.filetype = options.auditData.filetype;
+    }
+
+    const metadata = JSON.stringify(metadataObject);
 
     const body =
       `--${BOUNDARY}\r\n` +
@@ -166,6 +175,12 @@ export class AssetAPI {
     const handleRequest = async (): Promise<AssetUploadData> => {
       try {
         const response = await this.client.sendRequest<AssetUploadData>(config);
+        const validation = PostAssetsResponseSchema.safeParse(response.data);
+
+        if (!validation.success) {
+          this.logger.warn('Asset upload response validation failed:', validation.error);
+        }
+
         return response.data;
       } catch (error) {
         if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
@@ -181,128 +196,7 @@ export class AssetAPI {
     };
   }
 
-  getAssetV1(
-    assetId: string,
-    conversationId: string,
-    forceCaching: boolean = false,
-    progressCallback?: ProgressCallback,
-  ) {
-    if (!isValidUUID(assetId)) {
-      throw new TypeError(`Expected asset ID "${assetId}" to only contain alphanumeric values and dashes.`);
-    }
-    if (!isValidUUID(conversationId)) {
-      throw new TypeError(
-        `Expected conversation ID "${conversationId}" to only contain alphanumeric values and dashes.`,
-      );
-    }
-
-    const cancelSource = axios.CancelToken.source();
-    const config: AxiosRequestConfig = {
-      cancelToken: cancelSource.token,
-      method: 'get',
-      onDownloadProgress: handleProgressEvent(progressCallback),
-      onUploadProgress: handleProgressEvent(progressCallback),
-      params: {
-        conv_id: conversationId,
-      },
-      responseType: 'arraybuffer',
-      url: `${ASSET_URLS.ASSET_V1_URL}/${assetId}`,
-    };
-
-    if (forceCaching) {
-      config.params.forceCaching = forceCaching;
-    }
-
-    const handleRequest = async (): Promise<AssetResponse> => {
-      try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config);
-        return {
-          buffer: response.data,
-          mimeType: response.headers['content-type'],
-        };
-      } catch (error) {
-        if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
-          throw new RequestCancellationError('Asset download got cancelled.');
-        }
-        throw error;
-      }
-    };
-
-    return {
-      cancel: () => cancelSource.cancel(SyntheticErrorLabel.REQUEST_CANCELLED),
-      response: handleRequest(),
-    };
-  }
-
-  getAssetV2(
-    assetId: string,
-    conversationId: string,
-    forceCaching: boolean = false,
-    progressCallback?: ProgressCallback,
-  ) {
-    if (!isValidUUID(assetId)) {
-      throw new TypeError(`Expected asset ID "${assetId}" to only contain alphanumeric values and dashes.`);
-    }
-    if (!isValidUUID(conversationId)) {
-      throw new TypeError(
-        `Expected conversation ID "${conversationId}" to only contain alphanumeric values and dashes.`,
-      );
-    }
-
-    const cancelSource = axios.CancelToken.source();
-    const config: AxiosRequestConfig = {
-      cancelToken: cancelSource.token,
-      method: 'get',
-      onDownloadProgress: handleProgressEvent(progressCallback),
-      onUploadProgress: handleProgressEvent(progressCallback),
-      params: {},
-      responseType: 'arraybuffer',
-      url: `${ASSET_URLS.ASSET_V2_CONVERSATION_URL}/${conversationId}${ASSET_URLS.ASSET_V2_URL}/${assetId}`,
-    };
-
-    if (forceCaching) {
-      config.params.forceCaching = forceCaching;
-    }
-
-    const handleRequest = async (): Promise<AssetResponse> => {
-      try {
-        const response = await this.client.sendRequest<ArrayBuffer>(config);
-        return {
-          buffer: response.data,
-          mimeType: response.headers['content-type'],
-        };
-      } catch (error) {
-        if ((error as BackendError).message === SyntheticErrorLabel.REQUEST_CANCELLED) {
-          throw new RequestCancellationError('Asset download got cancelled.');
-        }
-        throw error;
-      }
-    };
-
-    return {
-      cancel: () => cancelSource.cancel(SyntheticErrorLabel.REQUEST_CANCELLED),
-      response: handleRequest(),
-    };
-  }
-
-  getAssetV3(
-    assetId: string,
-    token?: string | null,
-    forceCaching: boolean = false,
-    progressCallback?: ProgressCallback,
-  ) {
-    const version2 = 2;
-
-    if (!isValidUUID(assetId)) {
-      throw new TypeError(`Expected asset ID "${assetId}" to only contain alphanumeric values and dashes.`);
-    }
-    if (this.backendFeatures.version >= version2) {
-      throw new TypeError('Asset v3 is not supported on backend version 2 or higher.');
-    }
-    return this.getAssetShared(`${ASSET_URLS.ASSET_V3_URL}/${assetId}`, token, forceCaching, progressCallback);
-  }
-
-  getAssetV4(
+  getAsset(
     assetId: string,
     assetDomain: string,
     token?: string | null,
@@ -319,8 +213,8 @@ export class AssetAPI {
     if (!isValidDomain(assetDomain)) {
       throw new TypeError(`Invalid asset domain ${assetDomain}`);
     }
-    const assetBaseUrl = this.backendFeatures.version >= 2 ? ASSET_URLS.ASSETS_URL : ASSET_URLS.ASSET_V4_URL;
-    return this.getAssetShared(`${assetBaseUrl}/${assetDomain}/${assetId}`, token, forceCaching, progressCallback);
+
+    return this.getAssetShared(`/assets/${assetDomain}/${assetId}`, token, forceCaching, progressCallback);
   }
 
   getServiceAsset(
@@ -333,7 +227,7 @@ export class AssetAPI {
       throw new TypeError(`Expected asset ID "${assetId}" to only contain alphanumeric values and dashes.`);
     }
 
-    const assetBaseUrl = `${ASSET_URLS.ASSET_SERVICE_URL}/${assetId}`;
+    const assetBaseUrl = `/bot/assets/${assetId}`;
     return this.getAssetShared(assetBaseUrl, token, forceCaching, progressCallback);
   }
 
@@ -345,12 +239,10 @@ export class AssetAPI {
    * @param progressCallback? Will be called at every progress of the upload
    */
   postAsset(asset: Uint8Array, options?: AssetOptions, progressCallback?: ProgressCallback) {
-    const baseUrl = this.backendFeatures.version >= 2 ? ASSET_URLS.ASSETS_URL : ASSET_URLS.ASSET_V3_URL;
-    return this.postAssetShared(baseUrl, asset, options, progressCallback);
+    return this.postAssetShared('/assets', asset, options, progressCallback);
   }
 
   postServiceAsset(asset: Uint8Array, options?: AssetOptions, progressCallback?: ProgressCallback) {
-    const assetBaseUrl = ASSET_URLS.ASSET_SERVICE_URL;
-    return this.postAssetShared(assetBaseUrl, asset, options, progressCallback);
+    return this.postAssetShared('/bot/assets', asset, options, progressCallback);
   }
 }

--- a/packages/api-client/src/asset/index.ts
+++ b/packages/api-client/src/asset/index.ts
@@ -19,5 +19,5 @@
 
 export * from './AssetAPI';
 export * from './AssetRetentionPolicy';
-export * from './AssetUploadData';
+export {AssetUploadData} from './AssetAPI.schema';
 export * from './AssetUtil';

--- a/packages/core/src/conversation/AssetService/AssetService.ts
+++ b/packages/core/src/conversation/AssetService/AssetService.ts
@@ -25,36 +25,13 @@ import {APIClient} from '@wireapp/api-client';
 import {EncryptedAsset, EncryptedAssetUploaded} from '../../cryptography';
 import {decryptAsset, encryptAsset} from '../../cryptography/AssetCryptography/AssetCryptography';
 
-interface AssetDataV4 {
+export {ProgressCallback};
+export type AssetUrlData = {
   assetKey: string;
   assetToken: string;
   assetDomain: string;
   forceCaching: boolean;
-  version: 4;
-}
-interface AssetDataV3 {
-  assetKey: string;
-  assetToken: string;
-  forceCaching: boolean;
-  version: 3;
-}
-
-interface AssetDataV2 {
-  assetId: string;
-  conversationId: string;
-  forceCaching: boolean;
-  version: 2;
-}
-
-interface AssetDataV1 {
-  assetId: string;
-  conversationId: string;
-  forceCaching: boolean;
-  version: 1;
-}
-
-export {ProgressCallback};
-export type AssetUrlData = AssetDataV1 | AssetDataV2 | AssetDataV3 | AssetDataV4;
+};
 
 export class AssetService {
   constructor(private readonly apiClient: APIClient) {}
@@ -68,39 +45,13 @@ export class AssetService {
    * @return Resolves when the asset has been uploaded
    */
   public downloadRawAsset(assetData: AssetUrlData, progressCallback?: ProgressCallback) {
-    const {forceCaching} = assetData;
-
-    switch (assetData.version) {
-      case 1:
-        return this.apiClient.api.asset.getAssetV1(
-          assetData.assetId,
-          assetData.conversationId,
-          forceCaching,
-          progressCallback,
-        );
-      case 2:
-        return this.apiClient.api.asset.getAssetV2(
-          assetData.assetId,
-          assetData.conversationId,
-          forceCaching,
-          progressCallback,
-        );
-      case 3:
-        return this.apiClient.api.asset.getAssetV3(
-          assetData.assetKey,
-          assetData.assetToken,
-          forceCaching,
-          progressCallback,
-        );
-      case 4:
-        return this.apiClient.api.asset.getAssetV4(
-          assetData.assetKey,
-          assetData.assetDomain,
-          assetData.assetToken,
-          forceCaching,
-          progressCallback,
-        );
-    }
+    return this.apiClient.api.asset.getAsset(
+      assetData.assetKey,
+      assetData.assetDomain,
+      assetData.assetToken,
+      assetData.forceCaching,
+      progressCallback,
+    );
   }
 
   /**


### PR DESCRIPTION
We needed to be able to add new MetaData for Asset uploads per backend definition. 

Since the code was legacy (7+ years) and our coding standards changed, this PR also:

- adds response validation via Zod.js
- consolidates a lot of code and removes deprecated functions
- adds comprehensive unit tests