### PR TITLE
fix: User gets logged out while trying to delete a device - using a wrong password

### DIFF
--- a/packages/api-client/src/client/ClientAPI.ts
+++ b/packages/api-client/src/client/ClientAPI.ts
@@ -116,6 +116,9 @@ export class ClientAPI {
       },
       method: 'delete',
       url: `${ClientAPI.URL.CLIENTS}/${clientId}`,
+      requestOptions: {
+        skipLogout: true,
+      },
     };
 
     await this.client.sendJSON(config);

--- a/packages/api-client/src/http/HttpClient.ts
+++ b/packages/api-client/src/http/HttpClient.ts
@@ -145,6 +145,7 @@ export class HttpClient extends EventEmitter {
         Authorization: `${token_type} ${access_token}`,
       };
     }
+    const skipLogout = config.requestOptions?.skipLogout === true;
 
     try {
       const response = await this.client.request<T>({
@@ -188,9 +189,10 @@ export class HttpClient extends EventEmitter {
         }
 
         if (
-          mappedError instanceof InvalidTokenError ||
-          mappedError instanceof MissingCookieError ||
-          mappedError instanceof MissingCookieAndTokenError
+          !skipLogout &&
+          (mappedError instanceof InvalidTokenError ||
+            mappedError instanceof MissingCookieError ||
+            mappedError instanceof MissingCookieAndTokenError)
         ) {
           // On invalid cookie the application is supposed to logout.
           this.logger.warn(

--- a/packages/api-client/src/types/axios-internal-meta.d.ts
+++ b/packages/api-client/src/types/axios-internal-meta.d.ts
@@ -1,0 +1,28 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import 'axios';
+
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    requestOptions?: {
+      skipLogout?: boolean;
+    };
+  }
+}


### PR DESCRIPTION
## Description 
Steps to reproduce [Jira ticket](https://wearezeta.atlassian.net/browse/WPB-20387)
1. Log in with user A in Browser A → Either existing account or create new one
2. Log in with user A in Browser B →  Either existing account or create new one
3. Go to Browser A, Settings → Devices
4. Click on remove device (any device)
5. Use a wrong password and click “Remove device”

Expected behaviour:
User gets told that the authentication failed and the modal stays open for reattempt

Current behaviour:
User gets logged out from Browser A, with an “expired” cause

<!-- Uncomment this section if your PR has UI changes -->
<!--
## Screenshots/Screencast (for UI changes)
-->

## Checklist

- [x] mentions the JIRA issue in the PR name (Ex. [WPB-XXXX])
- [x] PR has been self reviewed by the author;
- [x] Hard-to-understand areas of the code have been commented;
- [x] If it is a core feature, unit tests have been added;

<!-- Uncomment this section if it is necessary to understand the PR -->
<!-- ## Important Details for the Reviewers

- use (x) data
- can be reviewed commit-by-commit
- be sure to look at ... -->
