### PR TITLE
fix(react-ui-kit): use id to link label to input [WPB-22420]

### DIFF
--- a/packages/react-ui-kit/src/Inputs/Select/Select.tsx
+++ b/packages/react-ui-kit/src/Inputs/Select/Select.tsx
@@ -118,7 +118,6 @@ export const Select = <IsMulti extends boolean = false, Group extends GroupBase<
       )}
 
       <ReactSelect
-        id={id}
         styles={
           customStyles({
             theme: theme as Theme,
@@ -142,6 +141,7 @@ export const Select = <IsMulti extends boolean = false, Group extends GroupBase<
           ...(hideControl && {Control: () => null}),
           ...(menuListHeading && {MenuList: SelectMenuList(menuListHeading, dataUieName)}),
         }}
+        inputId={id}
         tabIndex={TabIndex.UNFOCUSABLE}
         isDisabled={disabled}
         hideSelectedOptions={false}

--- a/packages/react-ui-kit/src/Inputs/Select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react-ui-kit/src/Inputs/Select/__snapshots__/Select.test.tsx.snap
@@ -227,7 +227,6 @@ exports[`"Select" renders 1`] = `
   >
     <div
       className="emotion-2"
-      id="test"
       onKeyDown={[Function]}
     >
       <div
@@ -268,7 +267,7 @@ exports[`"Select" renders 1`] = `
               aria-readonly={true}
               className="emotion-8"
               disabled={false}
-              id="react-select-2-input"
+              id="test"
               inputMode="none"
               onBlur={[Function]}
               onChange={[Function]}
@@ -529,7 +528,6 @@ exports[`"Select" renders as disabled 1`] = `
   >
     <div
       className="emotion-2"
-      id="test"
       onKeyDown={[Function]}
     >
       <div
@@ -571,7 +569,7 @@ exports[`"Select" renders as disabled 1`] = `
               aria-readonly={true}
               className="emotion-8"
               disabled={true}
-              id="react-select-3-input"
+              id="test"
               inputMode="none"
               onBlur={[Function]}
               onChange={[Function]}
@@ -833,7 +831,6 @@ exports[`"Select" renders as invalid 1`] = `
   >
     <div
       className="emotion-2"
-      id="test"
       onKeyDown={[Function]}
     >
       <div
@@ -874,7 +871,7 @@ exports[`"Select" renders as invalid 1`] = `
               aria-readonly={true}
               className="emotion-8"
               disabled={false}
-              id="react-select-4-input"
+              id="test"
               inputMode="none"
               onBlur={[Function]}
               onChange={[Function]}


### PR DESCRIPTION
# Pull Request

## Summary

While testing I noticed that the select component isn't that accessible as the label is not correctly linked to the input element. I re-used the already required id prop to link them correctly.

---

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-web-packages/blob/main/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-web-packages/blob/main/docs/tech-radar.md).

---

## Notes for reviewers

- I'm not sure why the `id` prop is even required, IMHO it might be safer to just use the `useId()` hook to get a unique id for linking label and input but didn't want to change the components interface right away.
