### PR TITLE
feat: add styled DropdownMenu submenu trigger/content with default indicator(WPB-22465)

### DIFF
--- a/packages/react-ui-kit/src/Surface/DropdownMenu/DropdownMenu.styles.ts
+++ b/packages/react-ui-kit/src/Surface/DropdownMenu/DropdownMenu.styles.ts
@@ -131,3 +131,11 @@ export const triggerStyles: CSSObject = {
   background: 'none',
   cursor: 'pointer',
 };
+
+export const subTriggerStyle: CSSObject = {
+  justifyContent: 'space-between',
+};
+
+export const subContentStyle: CSSObject = {
+  minWidth: '160px',
+};

--- a/packages/react-ui-kit/src/Surface/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react-ui-kit/src/Surface/DropdownMenu/DropdownMenu.tsx
@@ -17,12 +17,19 @@
  *
  */
 
-import {ReactNode} from 'react';
+import {forwardRef, ReactNode} from 'react';
 
 import {CSSObject} from '@emotion/react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 
-import {contentStyle, itemStyle, textStyles, triggerStyles} from './DropdownMenu.styles';
+import {
+  contentStyle,
+  itemStyle,
+  subContentStyle,
+  subTriggerStyle,
+  textStyles,
+  triggerStyles,
+} from './DropdownMenu.styles';
 
 /**
  * A dropdown menu component that provides a customizable and accessible dropdown interface.
@@ -100,6 +107,53 @@ const DropdownMenuItem = ({children, onClick}: {children: ReactNode; onClick: ()
 
 DropdownMenu.Item = DropdownMenuItem;
 
-DropdownMenu.SubContent = DropdownMenuPrimitive.SubContent;
-DropdownMenu.SubTrigger = DropdownMenuPrimitive.SubTrigger;
+const defaultSubmenuIndicator = (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" focusable="false">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M5.85355 12.1464C5.53857 12.4614 5 12.2383 5 11.7929L5 4.20711C5 3.76165 5.53857 3.53857 5.85355 3.85355L9.64645 7.64645C9.84171 7.84171 9.84171 8.15829 9.64645 8.35355L5.85355 12.1464Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const DropdownMenuSubTrigger = forwardRef<
+  HTMLDivElement,
+  DropdownMenuPrimitive.DropdownMenuSubTriggerProps & {
+    cssObj?: CSSObject;
+    showIndicator?: boolean;
+    indicator?: ReactNode;
+  }
+>(({children, cssObj, showIndicator = true, indicator, ...props}, ref) => {
+  return (
+    <DropdownMenuPrimitive.SubTrigger ref={ref} css={{...itemStyle, ...subTriggerStyle, ...cssObj}} {...props}>
+      <span css={textStyles}>{children}</span>
+      {showIndicator ? (
+        <span css={{display: 'inline-flex', flexShrink: 0}}>{indicator ?? defaultSubmenuIndicator}</span>
+      ) : null}
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+});
+
+DropdownMenuSubTrigger.displayName = 'DropdownMenuSubTrigger';
+
+DropdownMenu.SubTrigger = DropdownMenuSubTrigger;
+
+const DropdownMenuSubContent = forwardRef<
+  HTMLDivElement,
+  DropdownMenuPrimitive.DropdownMenuSubContentProps & {cssObj?: CSSObject}
+>(({children, cssObj, ...props}, ref) => {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent ref={ref} css={{...contentStyle, ...subContentStyle, ...cssObj}} {...props}>
+        {children}
+      </DropdownMenuPrimitive.SubContent>
+    </DropdownMenuPrimitive.Portal>
+  );
+});
+
+DropdownMenuSubContent.displayName = 'DropdownMenuSubContent';
+
+DropdownMenu.SubContent = DropdownMenuSubContent;
 DropdownMenu.Sub = DropdownMenuPrimitive.Sub;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-22465" title="WPB-22465" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />WPB-22465</a>  [Web] Add the option to create a new Collabora document from files tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

- add styled DropdownMenu submenu trigger/content with default indicator(

---

## Security Checklist (required)

- [ ] **External inputs are validated & sanitized** on client and/or server where applicable.
- [ ] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [ ] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [ ] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [ ] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [ ] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-web-packages/blob/main/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-web-packages/blob/main/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
