### PR TITLE
feat(commons): add anonhymizer to whitelist props in logs [WPB-24990]

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -12,6 +12,7 @@
     "utils"
   ],
   "dependencies": {
+    "@uphold/anonymizer": "^6.0.2",
     "ansi-regex": "5.0.1",
     "fs-extra": "11.3.3",
     "logdown": "3.3.1",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -12,7 +12,7 @@
     "utils"
   ],
   "dependencies": {
-    "@uphold/anonymizer": "^6.0.2",
+    "@uphold/anonymizer": "6.0.2",
     "ansi-regex": "5.0.1",
     "fs-extra": "11.3.3",
     "logdown": "3.3.1",

--- a/packages/commons/src/anonymizer.ts
+++ b/packages/commons/src/anonymizer.ts
@@ -17,9 +17,21 @@
  *
  */
 
-export * as CommonConfig from './config/CommonConfig';
+import {anonymizer} from '@uphold/anonymizer';
 
-export * from './anonymizer';
-export * from './LogFactory';
-export * from './util/';
-export * from './TypedEventEmitter';
+export const anonymize = anonymizer({
+  whitelist: [
+    '**.id',
+    '**.type',
+    '**.domain',
+    '**.code',
+    '**.error',
+    '**.groupId',
+    '**.conversationId',
+    '**.clientId',
+    '**.userCount',
+    '**.numberOfUpdates',
+    '**.storeName',
+    '**.eventType',
+  ],
+});

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -19,7 +19,6 @@
 
 export * as CommonConfig from './config/CommonConfig';
 
-export * from './anonymizer';
 export * from './LogFactory';
 export * from './util/';
 export * from './TypedEventEmitter';

--- a/packages/commons/src/types/uphold__anonymizer.d.ts
+++ b/packages/commons/src/types/uphold__anonymizer.d.ts
@@ -19,7 +19,7 @@
 
 declare module '@uphold/anonymizer' {
   export interface AnonymizerOptions {
-    whitelist?: string[];
+    whitelist: string[];
   }
 
   export interface AnonymizeFunction {

--- a/packages/commons/src/types/uphold__anonymizer.d.ts
+++ b/packages/commons/src/types/uphold__anonymizer.d.ts
@@ -17,9 +17,14 @@
  *
  */
 
-export * as CommonConfig from './config/CommonConfig';
+declare module '@uphold/anonymizer' {
+  export interface AnonymizerOptions {
+    whitelist?: string[];
+  }
 
-export * from './anonymizer';
-export * from './LogFactory';
-export * from './util/';
-export * from './TypedEventEmitter';
+  export interface AnonymizeFunction {
+    <T>(value: T): T;
+  }
+
+  export function anonymizer(options: AnonymizerOptions): AnonymizeFunction;
+}

--- a/packages/commons/src/util/StringUtil.test.ts
+++ b/packages/commons/src/util/StringUtil.test.ts
@@ -104,8 +104,8 @@ describe('StringUtil', () => {
 
       const result = StringUtil.serializeArgs([circularObj]);
 
-      expect(result[0]).toContain('[Circular]'); // Should replace circular references
       expect(() => JSON.parse(result[0])).not.toThrow(); // Should be valid JSON
+      expect(result[0]).toBeTruthy();
     });
 
     test('should serialize a large object safely', () => {
@@ -121,13 +121,39 @@ describe('StringUtil', () => {
       expect(result[0].length).toBeLessThanOrEqual(1_000_010); // Should be within the truncation limit
     });
 
-    test('should serialize a normal object correctly', () => {
-      const obj = {a: 1, b: 'test', c: [1, 2, 3]};
+    test('should serialize whitelisted properties correctly', () => {
+      const obj = {id: '123', type: 'message', userName: 'alice', code: 'ABC'};
 
       const result = StringUtil.serializeArgs([obj]);
 
       expect(() => JSON.parse(result[0])).not.toThrow(); // Should be valid JSON
-      expect(JSON.parse(result[0])).toEqual(obj); // Should match original object
+      const parsed = JSON.parse(result[0]);
+      // Whitelisted properties should be preserved
+      expect(parsed.id).toBe('123');
+      expect(parsed.type).toBe('message');
+      expect(parsed.code).toBe('ABC');
+      // Non-whitelisted properties should be redacted
+      expect(parsed.userName).toBe('--REDACTED--');
+    });
+
+    test('should anonymize non-whitelisted properties', () => {
+      const obj = {
+        id: 'user-123',
+        email: 'user@example.com',
+        password: 'secret',
+        type: 'user',
+      };
+
+      const result = StringUtil.serializeArgs([obj]);
+
+      expect(() => JSON.parse(result[0])).not.toThrow(); // Should be valid JSON
+      const parsed = JSON.parse(result[0]);
+      // Whitelisted properties preserved
+      expect(parsed.id).toBe('user-123');
+      expect(parsed.type).toBe('user');
+      // Non-whitelisted properties redacted
+      expect(parsed.email).toBe('--REDACTED--');
+      expect(parsed.password).toBe('--REDACTED--');
     });
 
     test('should return "[Unserializable Object]" for unsupported values', () => {
@@ -140,6 +166,93 @@ describe('StringUtil', () => {
       const result = StringUtil.serializeArgs([unserializable]);
 
       expect(result[0]).toBe('[Unserializable Object]'); // Should return error placeholder
+    });
+
+    test('should handle nested objects with whitelisted properties', () => {
+      const obj = {
+        id: 'conv-1',
+        conversationId: 'abc-123',
+        messages: [
+          {id: 'msg-1', type: 'text', content: 'Hello'},
+          {id: 'msg-2', type: 'image', data: 'base64data'},
+        ],
+      };
+
+      const result = StringUtil.serializeArgs([obj]);
+      const parsed = JSON.parse(result[0]);
+
+      // Top-level whitelisted properties
+      expect(parsed.id).toBe('conv-1');
+      expect(parsed.conversationId).toBe('abc-123');
+      // Nested whitelisted properties
+      expect(parsed.messages[0].id).toBe('msg-1');
+      expect(parsed.messages[0].type).toBe('text');
+      expect(parsed.messages[1].id).toBe('msg-2');
+      expect(parsed.messages[1].type).toBe('image');
+      // Non-whitelisted should be redacted
+      expect(parsed.messages[0].content).toBe('--REDACTED--');
+      expect(parsed.messages[1].data).toBe('--REDACTED--');
+    });
+
+    test('should redact Bearer tokens in strings', () => {
+      const authHeader = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+
+      const result = StringUtil.serializeArgs([authHeader]);
+
+      expect(result[0]).toContain('Bearer [REDACTED]');
+      expect(result[0]).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    });
+
+    test('should redact Bearer tokens in objects', () => {
+      const obj = {
+        headers: {
+          Authorization: 'Bearer secret-token-12345',
+          'Content-Type': 'application/json',
+        },
+      };
+
+      const result = StringUtil.serializeArgs([obj]);
+      const parsed = JSON.parse(result[0]);
+
+      // Authorization header should be anonymized (not in whitelist)
+      expect(parsed.headers.Authorization).toBe('--REDACTED--');
+      expect(parsed.headers['Content-Type']).toBe('--REDACTED--');
+      // Secret token should not appear in result
+      const resultStr = result[0];
+      expect(resultStr).not.toContain('secret-token-12345');
+    });
+
+    test('should handle arrays of mixed types', () => {
+      const result = StringUtil.serializeArgs(['string value', 42, true, null, {id: 'obj-1', secret: 'hidden'}]);
+
+      expect(result).toHaveLength(5);
+      expect(result[0]).toBe('string value');
+      expect(result[1]).toBe(42);
+      expect(result[2]).toBe(true);
+      expect(result[3]).toBe(null);
+
+      const parsed = JSON.parse(result[4]);
+      expect(parsed.id).toBe('obj-1');
+      expect(parsed.secret).toBe('--REDACTED--');
+    });
+
+    test('should preserve whitelisted error properties', () => {
+      const errorObj = {
+        code: 'ERR_NETWORK',
+        error: 'Connection failed',
+        message: 'Network timeout occurred',
+        stack: 'Error stack trace...',
+      };
+
+      const result = StringUtil.serializeArgs([errorObj]);
+      const parsed = JSON.parse(result[0]);
+
+      // Whitelisted error properties
+      expect(parsed.code).toBe('ERR_NETWORK');
+      expect(parsed.error).toBe('Connection failed');
+      // Non-whitelisted should be redacted
+      expect(parsed.message).toBe('--REDACTED--');
+      expect(parsed.stack).toBe('--REDACTED--');
     });
   });
 });

--- a/packages/commons/src/util/StringUtil.ts
+++ b/packages/commons/src/util/StringUtil.ts
@@ -17,6 +17,8 @@
  *
  */
 
+import {anonymize} from '../anonymizer';
+
 export function capitalize(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
@@ -44,7 +46,8 @@ export function serializeArgs(args: any[]): any[] {
       result = arg.length > maxSize ? `${arg.slice(0, maxSize - 15)}... [truncated]` : arg;
     } else if (typeof arg === 'object' && arg !== null) {
       try {
-        result = safeJsonStringify(arg);
+        const anonymized = anonymize(arg);
+        result = safeJsonStringify(anonymized);
       } catch (e) {
         result = '[Unserializable Object]';
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9291,6 +9291,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@uphold/anonymizer@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "@uphold/anonymizer@npm:6.0.2"
+  dependencies:
+    json-stringify-safe: ^5.0.1
+    lodash: ^4.17.21
+    serialize-error: ^8.0.0
+    traverse: 0.6.9
+  checksum: d586f6bf0008842b63ee218d9f9f8f9d3c47ae406946a6dac8738235f40245c686a282847471ac3ef4141632578b6d49207281c9fcdbdb6c82e51ea291cf0b6d
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:2.0.5":
   version: 2.0.5
   resolution: "@vitest/expect@npm:2.0.5"
@@ -9672,6 +9684,7 @@ __metadata:
     "@types/fs-extra": 11.0.4
     "@types/jest": ^29.2.0
     "@types/platform": 1.3.6
+    "@uphold/anonymizer": ^6.0.2
     ansi-regex: 5.0.1
     fs-extra: 11.3.3
     jest: ^29.2.1
@@ -22657,6 +22670,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-error@npm:^8.0.0":
+  version: 8.1.0
+  resolution: "serialize-error@npm:8.1.0"
+  dependencies:
+    type-fest: ^0.20.2
+  checksum: 2eef236d50edd2d7926e602c14fb500dc3a125ee52e9f08f67033181b8e0be5d1122498bdf7c23c80683cddcad083a27974e9e7111ce23165f4d3bcdd6d65102
+  languageName: node
+  linkType: hard
+
 "serialize-javascript@npm:^6.0.2":
   version: 6.0.2
   resolution: "serialize-javascript@npm:6.0.2"
@@ -24200,6 +24222,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"traverse@npm:0.6.9":
+  version: 0.6.9
+  resolution: "traverse@npm:0.6.9"
+  dependencies:
+    gopd: ^1.0.1
+    typedarray.prototype.slice: ^1.0.3
+    which-typed-array: ^1.1.15
+  checksum: e2f4b46caf849b6ea9006230995edc7376c1361f33c2110f425339a814b71b968f5c84a130ae21b4300d1849fff42cec6117c2aebde8a68d33c6871e9621a80f
+  languageName: node
+  linkType: hard
+
 "tree-kill@npm:1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
@@ -24569,6 +24602,22 @@ __metadata:
     possible-typed-array-names: ^1.0.0
     reflect.getprototypeof: ^1.0.6
   checksum: deb1a4ffdb27cd930b02c7030cb3e8e0993084c643208e52696e18ea6dd3953dfc37b939df06ff78170423d353dc8b10d5bae5796f3711c1b3abe52872b3774c
+  languageName: node
+  linkType: hard
+
+"typedarray.prototype.slice@npm:^1.0.3":
+  version: 1.0.5
+  resolution: "typedarray.prototype.slice@npm:1.0.5"
+  dependencies:
+    call-bind: ^1.0.8
+    define-properties: ^1.2.1
+    es-abstract: ^1.23.9
+    es-errors: ^1.3.0
+    get-proto: ^1.0.1
+    math-intrinsics: ^1.1.0
+    typed-array-buffer: ^1.0.3
+    typed-array-byte-offset: ^1.0.4
+  checksum: 51e5f1fd49e45cc6006fa3f6ad65cbb11a493529a53e4d82b993c34fe21f40c325cfca127a4cf6b6b36d49425e192cc90a1e306c6ed47649bd4b2870e040146d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9291,7 +9291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@uphold/anonymizer@npm:^6.0.2":
+"@uphold/anonymizer@npm:6.0.2":
   version: 6.0.2
   resolution: "@uphold/anonymizer@npm:6.0.2"
   dependencies:
@@ -9684,7 +9684,7 @@ __metadata:
     "@types/fs-extra": 11.0.4
     "@types/jest": ^29.2.0
     "@types/platform": 1.3.6
-    "@uphold/anonymizer": ^6.0.2
+    "@uphold/anonymizer": 6.0.2
     ansi-regex: 5.0.1
     fs-extra: 11.3.3
     jest: ^29.2.1


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/WPB-24990" title="WPB-24990" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />WPB-24990</a>  [Web] User names are visible in the logs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# Pull Request

## Summary

Added anonymizer for whitelist properties visible in logs

## Security Checklist (required)

- [x] **External inputs are validated & sanitized** on client and/or server where applicable.
- [x] **API responses are validated**; unexpected shapes are handled safely (fallbacks or errors).
- [x] **No unsafe HTML is rendered**; if unavoidable, sanitization is applied **and** documented where it happens.
- [x] **Injection risks (XSS/SQL/command) are prevented** via safe APIs and/or escaping.

## Accessibility (required)

- [x] I have read and this PR **upholds** our [Accessibility Best Practices](https://github.com/wireapp/wire-webapp/blob/dev/docs/accessibility-practices.md).

## Standards Acknowledgement (required)

- [x] I have read and this PR **upholds** our [Coding Standards](https://github.com/wireapp/wire-web-packages/blob/main/docs/coding-standards.md) and [Tech Radar Choices](https://github.com/wireapp/wire-web-packages/blob/main/docs/tech-radar.md).

---

## Screenshots or demo (if the user interface changed)

## Notes for reviewers

- Trade-offs:
- Follow-ups (linked issues):
- Linked PRs (e.g. web-packages):
